### PR TITLE
Epic 4977: Remove Server Build's dependency on local Tomcat install

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ but also make certain assumptions that you may not want to impose on your module
 (Earliest compatible LabKey version: 19.1)
 
 * Update tasks for yarn support
+* [Issue 36138](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=36138) - Remove compile-time dependency on local tomcat installation
+  * Only require `tomcat.home`/`CATALINA_HOME` for tasks that use them
 
 ### version 1.5
 *Release*: 22 May 2019

--- a/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
@@ -47,7 +47,7 @@ class Distribution implements Plugin<Project>
         // We add the TeamCity extension here if it doesn't exist because we will use the build
         // number property from TeamCity in the distribution artifact names, if present.
         TeamCityExtension teamCityExt  = project.getExtensions().findByType(TeamCityExtension.class)
-        if (teamCityExt == null)
+        if (TeamCityExtension.isOnTeamCity(project) && teamCityExt == null)
             project.extensions.create("teamCity", TeamCityExtension, project)
 
         // we depend on tasks from the server project, so it needs to have been evaluated first

--- a/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
@@ -342,19 +342,19 @@ class ServerDeploy implements Plugin<Project>
 
     private static void deleteTomcatLibs(Project project)
     {
-        Files.newDirectoryStream(Paths.get(project.tomcatDir, "lib"), "${ServerBootstrap.JAR_BASE_NAME}*.jar").each { Path path ->
+        Files.newDirectoryStream(Paths.get(project.tomcat.catalinaHome, "lib"), "${ServerBootstrap.JAR_BASE_NAME}*.jar").each { Path path ->
             project.delete path.toString()
         }
 
         project.configurations.tomcatJars.files.each {File jarFile ->
-            File libFile = new File("${project.tomcatDir}/lib/${jarFile.getName()}")
+            File libFile = new File("${project.tomcat.catalinaHome}/lib/${jarFile.getName()}")
             if (libFile.exists())
                 project.delete libFile.getAbsolutePath()
         }
 
         // Get rid of (un-versioned) jars that were deployed
         TOMCAT_LIB_UNVERSIONED_JARS.each{String name ->
-            File libFile = new File("${project.tomcatDir}/lib/${name}")
+            File libFile = new File("${project.tomcat.catalinaHome}/lib/${name}")
             if (libFile.exists())
                 project.delete libFile.getAbsolutePath()
         }

--- a/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
@@ -342,6 +342,8 @@ class ServerDeploy implements Plugin<Project>
 
     private static void deleteTomcatLibs(Project project)
     {
+        project.tomcat.validateCatalinaHome()
+
         Files.newDirectoryStream(Paths.get(project.tomcat.catalinaHome, "lib"), "${ServerBootstrap.JAR_BASE_NAME}*.jar").each { Path path ->
             project.delete path.toString()
         }

--- a/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
@@ -68,9 +68,9 @@ class TeamCity extends Tomcat
         // from TeamCity's configuration when creating the UITestExtension on TeamCity
         super.apply(project)
         project.tomcat.assertionFlag = "-ea"
-        if (project.file("${project.tomcatDir}/localhost.truststore").exists())
+        if (project.file("${project.tomcat.catalinaHome}/localhost.truststore").exists())
         {
-            project.tomcat.trustStore = "-Djavax.net.ssl.trustStore=${project.tomcatDir}/localhost.truststore"
+            project.tomcat.trustStore = "-Djavax.net.ssl.trustStore=${project.tomcat.catalinaHome}/localhost.truststore"
             project.tomcat.trustStorePassword = "-Djavax.net.ssl.trustStorePassword=changeit"
         }
         project.tomcat.recompileJsp = false

--- a/src/main/groovy/org/labkey/gradle/plugin/Tomcat.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Tomcat.groovy
@@ -34,7 +34,7 @@ class Tomcat implements Plugin<Project>
     @Override
     void apply(Project project)
     {
-        project.extensions.create("tomcat", TomcatExtension)
+        project.extensions.create("tomcat", TomcatExtension, project)
         if (project.plugins.hasPlugin(TestRunner.class))
         {
             UiTestExtension testEx = (UiTestExtension) project.getExtensions().getByType(UiTestExtension.class)
@@ -64,10 +64,10 @@ class Tomcat implements Plugin<Project>
         project.tasks.register("cleanLogs", Delete) {
             Delete task ->
                 task.group = GroupNames.WEB_APPLICATION
-                task.description = "Delete logs from ${project.tomcatDir}"
+                task.description = "Delete logs from ${project.tomcat.catalinaHome}"
                 task.configure(
                 {
-                    DeleteSpec spec -> spec.delete project.fileTree("${project.tomcatDir}/logs")
+                    DeleteSpec spec -> spec.delete project.fileTree("${project.tomcat.catalinaHome}/logs")
                     }
                 )
         }
@@ -75,19 +75,19 @@ class Tomcat implements Plugin<Project>
         project.tasks.register("cleanTemp", DefaultTask) {
             DefaultTask task ->
                 task.group = GroupNames.WEB_APPLICATION
-                task.description = "Delete temp files from ${project.tomcatDir}"
+                task.description = "Delete temp files from ${project.tomcat.catalinaHome}"
                 task.doLast(  {
                     // Note that we use the AntBuilder here because a fileTree in Gradle is a set of FILES only.
                     // Deleting a file tree will delete all the leaves of the directory structure, but none of the
                     // directories.
                     project.ant.delete(includeEmptyDirs: true, quiet: true)
                     {
-                        fileset(dir: "${project.tomcatDir}/temp")
+                        fileset(dir: "${project.tomcat.catalinaHome}/temp")
                                 {
                                     include(name: "**/*")
                                 }
                     }
-                    new File("${project.tomcatDir}", "temp").mkdirs()
+                    new File("${project.tomcat.catalinaHome}", "temp").mkdirs()
                 })
         }
 

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/TeamCityExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/TeamCityExtension.groovy
@@ -42,8 +42,9 @@ class TeamCityExtension
     {
         if (getTeamCityProperty("suite").isEmpty())
             validationMessages.add("'suite' property not specified")
-        if (getTeamCityProperty("tomcat.home").isEmpty())
-            validationMessages.add("'tomcat.home' property not specified")
+        // TODO: Remove references to 'tomcat.home' once plugin doesn't support 19.1
+        if (project.tomcat.catalinaHome == null || project.tomcat.catalinaHome.isEmpty())
+            validationMessages.add("'tomcat.home' and 'CATALINA_HOME' are not specified")
         if (getTeamCityProperty("tomcat.port").isEmpty())
             validationMessages.add("'tomcat.port' property not specified")
         if (this.databaseTypes.isEmpty())

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/TeamCityExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/TeamCityExtension.groovy
@@ -42,9 +42,6 @@ class TeamCityExtension
     {
         if (getTeamCityProperty("suite").isEmpty())
             validationMessages.add("'suite' property not specified")
-        // TODO: Remove references to 'tomcat.home' once plugin doesn't support 19.1
-        if (project.tomcat.catalinaHome == null || project.tomcat.catalinaHome.isEmpty())
-            validationMessages.add("'tomcat.home' and 'CATALINA_HOME' are not specified")
         if (getTeamCityProperty("tomcat.port").isEmpty())
             validationMessages.add("'tomcat.port' property not specified")
         if (this.databaseTypes.isEmpty())

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/TomcatExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/TomcatExtension.groovy
@@ -15,11 +15,15 @@
  */
 package org.labkey.gradle.plugin.extension
 
+import org.gradle.api.Project
+
 /**
  * Created by susanh on 4/23/17.
  */
 class TomcatExtension
 {
+    String catalinaHome
+    String tomcatConfDir
     String assertionFlag = "-ea" // set to -da to disable assertions and -ea to enable assertions
     String maxMemory = "1G"
     boolean recompileJsp = true
@@ -27,4 +31,42 @@ class TomcatExtension
     String trustStorePassword = ""
     String catalinaOpts = ""
     String debugPort = null // this is used for TeamCity catalina options
+
+    TomcatExtension(Project project)
+    {
+        setCatalinaDirs(project)
+    }
+
+    private void setCatalinaDirs(Project project)
+    {
+        if (System.getenv("CATALINA_HOME") != null)
+        {
+            this.catalinaHome = System.getenv("CATALINA_HOME")
+        }
+        else if (project.hasProperty("tomcatDir"))
+        {
+            this.catalinaHome = project.tomcatDir
+        }
+        else if (project.ext.hasProperty("tomcatDir"))
+        {
+            this.catalinaHome = project.ext.tomcatDir
+        }
+        else
+        {
+            this.catalinaHome = TeamCityExtension.getTeamCityProperty(project, "tomcat.home", null)
+        }
+
+        if (project.ext.hasProperty("tomcatConfDir"))
+        {
+            this.tomcatConfDir = project.ext.tomcatConfDir
+        }
+        else if (this.catalinaHome != null)
+        {
+            this.tomcatConfDir = "${this.catalinaHome}/conf/Catalina/localhost"
+        }
+        else
+        {
+            this.tomcatConfDir = null
+        }
+    }
 }

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/TomcatExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/TomcatExtension.groovy
@@ -43,17 +43,15 @@ class TomcatExtension
 
     String getCatalinaHome()
     {
-        validateCatalinaHome()
         return catalinaHome
     }
 
     String getTomcatConfDir()
     {
-        validateCatalinaHome()
         return tomcatConfDir
     }
 
-    private void validateCatalinaHome()
+    void validateCatalinaHome()
     {
         String errorMsg = ""
         if (catalinaHome == null || catalinaHome.isEmpty())

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/TomcatExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/TomcatExtension.groovy
@@ -15,6 +15,7 @@
  */
 package org.labkey.gradle.plugin.extension
 
+import org.gradle.api.GradleException
 import org.gradle.api.Project
 
 /**
@@ -22,6 +23,8 @@ import org.gradle.api.Project
  */
 class TomcatExtension
 {
+    private final Project project
+
     String catalinaHome
     String tomcatConfDir
     String assertionFlag = "-ea" // set to -da to disable assertions and -ea to enable assertions
@@ -34,7 +37,45 @@ class TomcatExtension
 
     TomcatExtension(Project project)
     {
+        this.project = project
         setCatalinaDirs(project)
+    }
+
+    String getCatalinaHome()
+    {
+        validateCatalinaHome()
+        return catalinaHome
+    }
+
+    String getTomcatConfDir()
+    {
+        validateCatalinaHome()
+        return tomcatConfDir
+    }
+
+    private void validateCatalinaHome()
+    {
+        String errorMsg = ""
+        if (catalinaHome == null || catalinaHome.isEmpty())
+        {
+            errorMsg = "Tomcat home directory not set"
+        }
+        else if (!project.file(catalinaHome).exists())
+        {
+            errorMsg = "Specified Tomcat home directory [${project.file(catalinaHome).getAbsolutePath()}] does not exist"
+        }
+        else if (!new File(project.file(catalinaHome), "conf/server.xml").exists())
+        {
+            errorMsg = "Specified Tomcat home directory [${project.file(catalinaHome).getAbsolutePath()}] does not appear to be a tomcat installation"
+        }
+        if (!errorMsg.isEmpty())
+        {
+            throw new GradleException("${errorMsg}. Please specify using the environment variable CATALINA_HOME. " +
+                    "You may also set the value of the 'tomcat.home' system property using either " +
+                    "systemProp.tomcat.home=<tomcat home directory> in a gradle.properties file or " +
+                    "-Dtomcat.home=<tomcat home directory> on command line. Note that CATALINA_HOME is not, generally, " +
+                    "visible from within IntelliJ IDEA")
+        }
     }
 
     private void setCatalinaDirs(Project project)

--- a/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
@@ -77,6 +77,7 @@ class DoThenSetup extends DefaultTask
 
     @TaskAction
     void setup() {
+        project.tomcat.validateCatalinaHome()
         File tomcatConfDir = project.file(project.tomcat.tomcatConfDir)
         if (tomcatConfDir.exists())
         {

--- a/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
@@ -53,10 +53,10 @@ class DoThenSetup extends DefaultTask
 //        List<File> files = new ArrayList<>();
 //        for (String jar : ServerDeploy.TOMCAT_LIB_UNVERSIONED_JARS) {
 //            files.add(new File(project.staging.tomcatLibDir, jar))
-//            files.add(new File("${project.tomcatDir}/lib/${jar}"))
+//            files.add(new File("${project.tomcat.catalinaHome}/lib/${jar}"))
 //        }
 //        files.add(new File("${project.rootProject.buildDir}/labkey.xml"))
-//        files.add(new File("${project.ext.tomcatConfDir}/labkey.xml"))
+//        files.add(new File("${project.tomcat.tomcatConfDir}/labkey.xml"))
 //        return files
 //    }
 
@@ -77,7 +77,7 @@ class DoThenSetup extends DefaultTask
 
     @TaskAction
     void setup() {
-        File tomcatConfDir = project.file(project.ext.tomcatConfDir)
+        File tomcatConfDir = project.file(project.tomcat.tomcatConfDir)
         if (tomcatConfDir.exists())
         {
             if (!tomcatConfDir.isDirectory())
@@ -131,7 +131,7 @@ class DoThenSetup extends DefaultTask
 
             project.copy({ CopySpec copy ->
                 copy.from "${project.rootProject.buildDir}"
-                copy.into "${project.ext.tomcatConfDir}"
+                copy.into "${project.tomcat.tomcatConfDir}"
                 copy.include "labkey.xml"
             })
         }
@@ -151,7 +151,7 @@ class DoThenSetup extends DefaultTask
             return false;
 
         File dbPropFile = DatabaseProperties.getPickedConfigFile(project)
-        File tomcatLabkeyXml = new File("${project.ext.tomcatConfDir}", "labkey.xml")
+        File tomcatLabkeyXml = new File("${project.tomcat.tomcatConfDir}", "labkey.xml")
         if (!dbPropFile.exists() || !tomcatLabkeyXml.exists())
             return false
         if (dbPropFile.lastModified() < tomcatLabkeyXml.lastModified())
@@ -213,7 +213,7 @@ class DoThenSetup extends DefaultTask
 
         // Then copy them into the tomcat/lib directory
         project.ant.copy(
-                todir: "${project.tomcatDir}/lib",
+                todir: "${project.tomcat.catalinaHome}/lib",
                 preserveLastModified: true,
                 overwrite: true
         )

--- a/src/main/groovy/org/labkey/gradle/task/RunTestSuite.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/RunTestSuite.groovy
@@ -49,12 +49,15 @@ class RunTestSuite extends RunUiTest
             dependsOn(project.tasks.killChrome)
             dependsOn(project.tasks.ensurePassword)
 
-            doLast( {
-                project.copy({ CopySpec copy ->
-                    copy.from "${project.tomcat.catalinaHome}/logs"
-                    copy.into "${project.buildDir}/logs/${dbProperties.dbTypeAndVersion}"
+            if (project.tomcat.catalinaHome != null)
+            {
+                doLast( {
+                    project.copy({ CopySpec copy ->
+                        copy.from "${project.tomcat.catalinaHome}/logs"
+                        copy.into "${project.buildDir}/logs/${dbProperties.dbTypeAndVersion}"
+                    })
                 })
-            })
+            }
         }
     }
 

--- a/src/main/groovy/org/labkey/gradle/task/RunTestSuite.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/RunTestSuite.groovy
@@ -51,7 +51,7 @@ class RunTestSuite extends RunUiTest
 
             doLast( {
                 project.copy({ CopySpec copy ->
-                    copy.from "${project.tomcatDir}/logs"
+                    copy.from "${project.tomcat.catalinaHome}/logs"
                     copy.into "${project.buildDir}/logs/${dbProperties.dbTypeAndVersion}"
                 })
             })
@@ -72,6 +72,7 @@ class RunTestSuite extends RunUiTest
                 systemProperty "testRecentlyFailed", "${runRiskGroupTestsFirst.contains("recentlyFailed")}"
             }
             systemProperty "teamcity.buildType.id", project.teamcity['teamcity.buildType.id']
+            // TODO: Remove references to 'tomcat.home' once plugin doesn't support 19.1, should use CATALINA_HOME
             systemProperty "tomcat.home", project.teamcity["tomcat.home"]
             systemProperty "tomcat.port", project.teamcity["tomcat.port"]
             systemProperty "tomcat.debug", project.teamcity["tomcat.debug"]

--- a/src/main/groovy/org/labkey/gradle/task/RunUiTest.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/RunUiTest.groovy
@@ -90,7 +90,8 @@ class RunUiTest extends Test
         systemProperty "labkey.root", project.rootProject.projectDir
         systemProperty "project.root", project.rootProject.projectDir
         systemProperty "user.home", System.getProperty('user.home')
-        systemProperty "tomcat.home", project.ext.tomcatDir
+        // A handfull of tests require tomcat.home to be defined when running within IntelliJ
+        systemProperty "tomcat.home", project.tomcat.catalinaHome
         systemProperty "test.credentials.file", "${project.projectDir}/test.credentials.json"
         if (project.findProject(BuildUtils.getTestProjectPath(project.gradle)) != null)
         {

--- a/src/main/groovy/org/labkey/gradle/task/StartTomcat.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/StartTomcat.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 import org.labkey.gradle.plugin.extension.LabKeyExtension
 import org.labkey.gradle.plugin.extension.TeamCityExtension
+import org.labkey.gradle.plugin.extension.TomcatExtension
 
 /**
  * Created by susanh on 11/15/16.
@@ -29,6 +30,8 @@ class StartTomcat extends DefaultTask
     @TaskAction
     void action()
     {
+        project.tomcat.validateCatalinaHome()
+
         // we need to create the logs directory if it doesn't exist because Tomcat won't start without it,
         // and, annoyingly, this is not seen as an error for this action.
         if (!project.file("${project.tomcat.catalinaHome}/logs").exists())

--- a/src/main/groovy/org/labkey/gradle/task/StartTomcat.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/StartTomcat.groovy
@@ -31,15 +31,15 @@ class StartTomcat extends DefaultTask
     {
         // we need to create the logs directory if it doesn't exist because Tomcat won't start without it,
         // and, annoyingly, this is not seen as an error for this action.
-        if (!project.file("${project.tomcatDir}/logs").exists())
-            project.mkdir("${project.tomcatDir}/logs")
+        if (!project.file("${project.tomcat.catalinaHome}/logs").exists())
+            project.mkdir("${project.tomcat.catalinaHome}/logs")
         if (SystemUtils.IS_OS_UNIX)
         {
-            project.ant.chmod(dir: "${project.tomcatDir}/bin", includes: "**/*.sh", perm: "ug+rx")
+            project.ant.chmod(dir: "${project.tomcat.catalinaHome}/bin", includes: "**/*.sh", perm: "ug+rx")
         }
         project.ant.exec(
                 spawn: true,
-                dir: SystemUtils.IS_OS_WINDOWS ? "${project.tomcatDir}/bin" : project.tomcatDir,
+                dir: SystemUtils.IS_OS_WINDOWS ? "${project.tomcat.catalinaHome}/bin" : project.tomcat.catalinaHome,
                 executable: SystemUtils.IS_OS_WINDOWS ? "cmd" : "bin/catalina.sh"
         )
         {
@@ -111,7 +111,7 @@ class StartTomcat extends DefaultTask
                 arg(line: "/c start ")
                 arg(value: "'Tomcat Server'")
                 arg(value: "/B")
-                arg(value: "${project.tomcatDir}/bin/catalina.bat")
+                arg(value: "${project.tomcat.catalinaHome}/bin/catalina.bat")
             }
             arg(value: "start")
         }

--- a/src/main/groovy/org/labkey/gradle/task/StopTomcat.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/StopTomcat.groovy
@@ -27,6 +27,7 @@ class StopTomcat extends DefaultTask
     @TaskAction
     void exec()
     {
+        project.tomcat.validateCatalinaHome()
         project.javaexec( {
             JavaExecSpec java ->
                 java.main = "org.apache.catalina.startup.Bootstrap"

--- a/src/main/groovy/org/labkey/gradle/task/StopTomcat.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/StopTomcat.groovy
@@ -30,8 +30,8 @@ class StopTomcat extends DefaultTask
         project.javaexec( {
             JavaExecSpec java ->
                 java.main = "org.apache.catalina.startup.Bootstrap"
-                java.classpath  { ["${project.tomcatDir}/bin/bootstrap.jar", "${project.tomcatDir}/bin/tomcat-juli.jar"] }
-                java.systemProperties["user.dir"] = project.tomcatDir
+                java.classpath  { ["${project.tomcat.catalinaHome}/bin/bootstrap.jar", "${project.tomcat.catalinaHome}/bin/tomcat-juli.jar"] }
+                java.systemProperties["user.dir"] = project.tomcat.catalinaHome
                 java.args = ["stop"]
                 java.ignoreExitValue = true
         })


### PR DESCRIPTION
Related to "Epic 4977: Remove Server Build's dependency on local Tomcat install"

@labkey-susanh Please take a look at your convenience. I'm not sure whether this is the proper way to centralize the various properties that represent catalina_home. I've verified that `deployApp`, `pickPg`, and `stopTomcat` work locally but wanted some extra eyes on this before updating `1.6-snapshot`.
On a related note, should these changes go into a `1.5.1` release? I'm not sure whether this would be considered _new_ functionality or just a tweak of existing functionality that could be considered a bug fix.