### PR TITLE
1.6.3 snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ but also make certain assumptions that you may not want to impose on your module
 * Don't use yarn if there is a package-lock.json file.
 * Add listNodeProjects task for showing which projects are are using node in their build and which package manager
 * Add links for both yarn and npm binaries
+* [Issue 38198](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=38198): Find the nearest vcs root to use for populating vcs properties to accommodate modules nested in git repositories
 
 ### version 1.6.2
 *Release*: 25 Jun 2019

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ but also make certain assumptions that you may not want to impose on your module
 * [Issue 38198](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=38198): Find the nearest vcs root to use for populating vcs properties to accommodate modules nested in git repositories
 * Modify incubating multi-git tasks to account for git modules not in optionalModules and testAutomation repo
 * Add more incubating multi-git tasks: gitPull, gitPush, and gitStatus 
+* Update reallyClean to depend on cleanNodeModules and thus also remove the node_modules directory for a module
 
 ### version 1.6.2
 *Release*: 25 Jun 2019

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ but also make certain assumptions that you may not want to impose on your module
 (Earliest compatible LabKey version: 19.1)
 
 * Modify incubating git tasks to account for git modules not in optionalModules and testAutomation repo
+* Don't use yarn if there is a package-lock.json file.
 
 ### version 1.6.2
 *Release*: 25 Jun 2019

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ but also make certain assumptions that you may not want to impose on your module
 
 * Modify incubating git tasks to account for git modules not in optionalModules and testAutomation repo
 * Don't use yarn if there is a package-lock.json file.
-* Add listNodeProjects task for showing which projects are are using node in their build and which package manager
+* Add listNodeProjects task for showing which projects are using node in their build and which package manager
 * Add links for both yarn and npm binaries
 * [Issue 38198](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=38198): Find the nearest vcs root to use for populating vcs properties to accommodate modules nested in git repositories
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ but also make certain assumptions that you may not want to impose on your module
 
 ## Release Notes
 
-### veresion 1.6.3
-*Release*: ???
+### veresion 1.7.0
+*Release*: 27 Aug 2019
 (Earliest compatible LabKey version: 19.1)
 
 * Don't use yarn if there is a package-lock.json file.

--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@ but also make certain assumptions that you may not want to impose on your module
 *Release*: ???
 (Earliest compatible LabKey version: 19.1)
 
-* Modify incubating git tasks to account for git modules not in optionalModules and testAutomation repo
 * Don't use yarn if there is a package-lock.json file.
 * Add listNodeProjects task for showing which projects are using node in their build and which package manager
 * Add links for both yarn and npm binaries
 * [Issue 38198](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=38198): Find the nearest vcs root to use for populating vcs properties to accommodate modules nested in git repositories
+* Modify incubating multi-git tasks to account for git modules not in optionalModules and testAutomation repo
+* Add more incubating multi-git tasks: gitPull, gitPush, and gitStatus 
 
 ### version 1.6.2
 *Release*: 25 Jun 2019

--- a/README.md
+++ b/README.md
@@ -9,9 +9,15 @@ but also make certain assumptions that you may not want to impose on your module
 
 ## Release Notes
 
+### veresion 1.6.3
+*Release*: ???
+(Earliest compatible LabKey version: 19.1)
+
+* Modify incubating git tasks to account for git modules not in optionalModules and testAutomation repo
+
 ### version 1.6.2
 *Release*: 25 Jun 2019
-(Earliest compatible LabKey version 19.1)
+(Earliest compatible LabKey version: 19.1)
 
 * Fix for symlinkNode task (referencing unknown property)
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ but also make certain assumptions that you may not want to impose on your module
 
 * Modify incubating git tasks to account for git modules not in optionalModules and testAutomation repo
 * Don't use yarn if there is a package-lock.json file.
+* Add listNodeProjects task for showing which projects are are using node in their build and which package manager
+* Add links for both yarn and npm binaries
 
 ### version 1.6.2
 *Release*: 25 Jun 2019

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ buildscript {
 apply plugin: "org.ajoberstar.grgit"
 apply plugin: 'maven-publish'
 
-project.version = "1.6.2-SNAPSHOT"
+project.version = "1.6.3-SNAPSHOT"
 
 if (project.file("moduleTemplate").exists())
 {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
@@ -277,6 +277,8 @@ class FileModule implements Plugin<Project>
                     task.group = GroupNames.BUILD
                     task.description = "Deletes the build, staging, and deployment directories of this module"
                     task.dependsOn(project.tasks.clean, project.tasks.undeployModule)
+                    if (project.tasks.findByName('cleanNodeModules') != null)
+                        task.dependsOn(project.tasks.cleanNodeModules)
             }
         }
 

--- a/src/main/groovy/org/labkey/gradle/plugin/JavaModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/JavaModule.groovy
@@ -247,7 +247,7 @@ class JavaModule extends FileModule
      * @return the collection of files that contain the dependencies
      *
      * FIXME The method of accessing the other projects' external configuration is now deemed unsafe.
-     * Attemps to use the method recommended in the Gradle docs of extending from a configuration of the
+     * Attempts to use the method recommended in the Gradle docs of extending from a configuration of the
      * other project have, thus far, been unsuccessful.  Instead, extending from api's external actually
      * brings in the current project's external dependencies, which means we eliminate just the files we
      * need to keep.  This may have something to do with order of evaluation.

--- a/src/main/groovy/org/labkey/gradle/plugin/MultiGit.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/MultiGit.groovy
@@ -1081,7 +1081,14 @@ class MultiGit implements Plugin<Project>
                     })
                     toUpdate.forEach({
                         Repository repository ->
-                            repository.enlist(branchName)
+                            try
+                            {
+                                repository.enlist(branchName)
+                            }
+                            catch (Exception e)
+                            {
+                                project.logger.error("${repository.projectPath}: problem enlisting in branch '" + branchName + "'. ${e.message}")
+                            }
                     })
                 })
         }

--- a/src/main/groovy/org/labkey/gradle/plugin/MultiGit.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/MultiGit.groovy
@@ -387,7 +387,7 @@ class MultiGit implements Plugin<Project>
             {
                 rootProject.logger.info("${this.getName()}: enlistment already exists in expected location")
                 return Grgit.open {
-                    dir = enlistmentDir
+                    currentDir = enlistmentDir
                 }
             }
             return null;
@@ -1061,7 +1061,7 @@ class MultiGit implements Plugin<Project>
                             if (repository.enlistmentDir.exists())
                             {
                                 Grgit grgit = Grgit.open {
-                                    dir = repository.enlistmentDir
+                                    currentDir = repository.enlistmentDir
                                 }
                                 grgit.fetch(prune: true)
                                 List<Branch> branches = grgit.branch.list(mode: BranchListOp.Mode.REMOTE)
@@ -1109,7 +1109,7 @@ class MultiGit implements Plugin<Project>
                             if (repository.enlistmentDir.exists())
                             {
                                 Grgit grgit = Grgit.open {
-                                    dir = repository.enlistmentDir
+                                    currentDir = repository.enlistmentDir
                                 }
                                 grigit.fetch(prune: project.hasProperty('gitPrune'))
                             }

--- a/src/main/groovy/org/labkey/gradle/plugin/MultiGit.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/MultiGit.groovy
@@ -3,6 +3,7 @@ package org.labkey.gradle.plugin
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.ajoberstar.grgit.Branch
 import org.ajoberstar.grgit.Grgit
+import org.ajoberstar.grgit.Status
 import org.ajoberstar.grgit.operation.BranchListOp
 import org.apache.commons.lang3.StringUtils
 import org.apache.http.client.ResponseHandler
@@ -217,17 +218,17 @@ class MultiGit implements Plugin<Project>
             {
                 this.setIsExternal(true)
             }
-            if (topics.contains('labkey-module-container'))
+            if (topics.contains('labkey-optional-module'))
+            {
+                this.setType(Type.serverOptionalModule)
+            }
+            else if (topics.contains('labkey-module-container'))
             {
                 this.setType(Type.serverModuleContainer)
             }
-            else if (topics.contains('labkey-optional-module'))
-            {
-                this.setType(Type.serverOptionalModule)
-            }
             else if (topics.contains("labkey-module"))
             {
-                this.setType(Type.serverOptionalModule)
+                this.setType(Type.serverModule)
             }
             else if (topics.contains('labkey-test-container'))
             {
@@ -393,6 +394,17 @@ class MultiGit implements Plugin<Project>
             return null;
         }
 
+        boolean hasRemoteBranch(String remoteBranch)
+        {
+            Grgit grgit = getGit()
+            grgit.fetch(prune: true)
+            List<Branch> branches = grgit.branch.list(mode: BranchListOp.Mode.REMOTE)
+
+            return branches.stream().anyMatch({
+                Branch branch ->
+                   return branch.name == remoteBranch
+            })
+        }
 
         void enlist(String branchName)
         {
@@ -412,17 +424,29 @@ class MultiGit implements Plugin<Project>
 
             if (!StringUtils.isEmpty(branchName))
             {
-                rootProject.logger.info("${this.getName()}: Checking out branch '${branchName}'")
-                if (git.branch.list().find( { it.name == branchName }))
-                    git.checkout (branch: branchName)
+                if (hasRemoteBranch("origin/${branchName}"))
+                {
+                    if (git.branch.list().find( { it.name == branchName }))
+                    {
+                        rootProject.logger.quiet("${this.getName()}: Checking out branch '${branchName}'")
+                        git.checkout(branch: branchName)
+                    }
+                    else
+                    {
+                        rootProject.logger.quiet("${this.getName()}: Checkint out branch '${branchName}' (origin/${branchName})")
+                        git.checkout(branch: branchName, startPoint: "origin/${branchName}", createBranch: true)
+                    }
+                }
                 else
-                    git.checkout(branch: branchName, startPoint: "origin/${branchName}", createBranch: true)
+                {
+                    rootProject.logger.quiet("${this.getName()}: No branch '${branchName} found.  Leaving on default branch.")
+                }
             }
         }
 
         private String getCheckoutProject()
         {
-            return getType().enlistmentProject;
+            return isExternal ? ":externalModules" : getType().enlistmentProject;
         }
 
         void setProject(Project rootProject)
@@ -1060,23 +1084,13 @@ class MultiGit implements Plugin<Project>
                         Repository repository ->
                             if (repository.enlistmentDir.exists())
                             {
-                                Grgit grgit = Grgit.open {
-                                    currentDir = repository.enlistmentDir
-                                }
-                                grgit.fetch(prune: true)
-                                List<Branch> branches = grgit.branch.list(mode: BranchListOp.Mode.REMOTE)
-
-                                boolean hasBranch = branches.stream().anyMatch({
-                                    Branch branch ->
-                                        branch.name == remoteBranch
-                                })
-                                if (hasBranch)
-                                    if (grgit.branch.current().name != branchName)
+                                if (repository.hasRemoteBranch(remoteBranch))
+                                    if (repository.git.branch.current().name != branchName)
                                         toUpdate.push(repository)
                                     else
-                                        project.logger.quiet("${repository.projectPath}: already on branch '" + branchName + "'. No checkout required.")
+                                        project.logger.info("${repository.projectPath}: already on branch '" + branchName + "'. No checkout required.")
                                 else
-                                    project.logger.quiet("${repository.projectPath}: no branch '" + branchName + "'. No checkout attempted.")
+                                    project.logger.info("${repository.projectPath}: no branch '" + branchName + "'. No checkout attempted.")
                             }
                     })
                     toUpdate.forEach({
@@ -1093,12 +1107,13 @@ class MultiGit implements Plugin<Project>
                 })
         }
 
-        project.tasks.register("gitFetch") {
+        project.tasks.register("gitStatus") {
             Task task ->
                 task.group = "VCS"
-                task.description = "(incubating) For all repositories with a current enlistement, perform a git fetch. " +
-                                    "Use -PgitPrune to remove any remote-tracking references that no longer exist on the remote." +
-                                   "Use the properties ${RepositoryQuery.TOPICS_PROPERTY}, ${RepositoryQuery.ALL_TOPICS_PROPERTY}, and ${RepositoryQuery.INCLUDE_ARCHIVED_PROPERTY} as for the 'gitRepoList' task for filtering."
+                task.description = "(incubating) Perform a 'git status' for a collection of repositories. " +
+                        "By default, uses the projects specified in the settings.gradle file for which there is a current enlistment. " +
+                        "Use the properties ${RepositoryQuery.TOPICS_PROPERTY}, ${RepositoryQuery.ALL_TOPICS_PROPERTY}, and ${RepositoryQuery.INCLUDE_ARCHIVED_PROPERTY} as for the 'gitRepoList' task for " +
+                        "choosing a set of repositories other than those given in the settings.gradle file."
                 task.doLast({
                     RepositoryQuery query = new RepositoryQuery(project)
                     query.setIncludeTopics(true)
@@ -1106,22 +1121,144 @@ class MultiGit implements Plugin<Project>
                     project.logger.quiet(getEchoHeader(repositories, project))
                     repositories.values().forEach({
                         Repository repository ->
-                            if (repository.enlistmentDir.exists())
+                            if (repository.enlistmentDir.exists() && (project.hasProperty(RepositoryQuery.TOPICS_PROPERTY) || repository.project != null))
                             {
                                 Grgit grgit = Grgit.open {
                                     currentDir = repository.enlistmentDir
                                 }
-                                grigit.fetch(prune: project.hasProperty('gitPrune'))
+                                Status status = grgit.status()
+                                if (status.isClean())
+                                {
+                                    project.logger.quiet("${repository.enlistmentDir}: up to date on branch ${grgit.branch.current().name}")
+                                }
+                                else
+                                {
+                                    List<String> messages = new ArrayList<String>()
+                                    String msg = "Staged changes: "
+                                    if (status.staged.allChanges.size() > 0)
+                                    {
+                                        msg += " ${status.staged.added.size()} additions"
+                                        msg += " ${status.staged.modified.size()} modifications"
+                                        msg += " ${status.staged.removed.size()} removals"
+
+                                    }
+                                    else
+                                    {
+                                        msg += "None"
+                                    }
+                                    messages.add(msg)
+
+                                    msg = "Unstaged changes: "
+                                    if (status.unstaged.allChanges.size() > 0)
+                                    {
+                                        msg += " ${status.unstaged.added.size()} additions"
+                                        msg += " ${status.unstaged.modified.size()} modifications"
+                                        msg += " ${status.unstaged.removed.size()} removals"
+                                    }
+                                    else
+                                    {
+                                        msg += "None"
+                                    }
+                                    messages.add(msg)
+                                    if (status.conflicts.size() > 0)
+                                    {
+                                        messages.add("${status.conflicts.size()} unresolved conflicts")
+                                    }
+                                    project.logger.quiet("${repository.enlistmentDir}:")
+                                    project.logger.quiet("\t${messages.join("\n\t")}")
+                                }
                             }
                     })
                 })
         }
 
-        // TODO support the -Pbranch property.  Almost there, but for the case that the branch does not exist.
+        project.tasks.register("gitPull") {
+            Task task ->
+                task.group = "VCS"
+                task.description = "(incubating) Perform a 'git pull' for a collection of repositories. " +
+                        "Use -PgitRebase to rebase the branches while pulling." +
+                        "By default, uses the projects specified in the settings.gradle file for which there is a current enlistment. " +
+                        "Use the properties ${RepositoryQuery.TOPICS_PROPERTY}, ${RepositoryQuery.ALL_TOPICS_PROPERTY}, and ${RepositoryQuery.INCLUDE_ARCHIVED_PROPERTY} as for the 'gitRepoList' task for " +
+                        "choosing a set of repositories other than those given in the settings.gradle file."
+                task.doLast({
+                    RepositoryQuery query = new RepositoryQuery(project)
+                    query.setIncludeTopics(true)
+                    Map<String, Repository> repositories = query.execute()
+                    project.logger.quiet(getEchoHeader(repositories, project))
+                    repositories.values().forEach({
+                        Repository repository ->
+                            if (repository.enlistmentDir.exists() && (project.hasProperty(RepositoryQuery.TOPICS_PROPERTY) || repository.project != null))
+                            {
+                                project.logger.quiet("Pulling for ${repository.enlistmentDir} ")
+                                Grgit grgit = Grgit.open {
+                                    currentDir = repository.enlistmentDir
+                                }
+                                grgit.pull(rebase: project.hasProperty('gitRebase'))
+                            }
+                    })
+                })
+        }
+
+        project.tasks.register("gitFetch") {
+            Task task ->
+                task.group = "VCS"
+                task.description = "(incubating) Perform a 'git fetch' for a collection of repositories.  " +
+                        "Use -PgitPrune to remove any remote-tracking references that no longer exist on the remote." +
+                        "By default, uses the projects specified in the settings.gradle file for which there is a current enlistment. " +
+                        "Use the properties ${RepositoryQuery.TOPICS_PROPERTY}, ${RepositoryQuery.ALL_TOPICS_PROPERTY}, and ${RepositoryQuery.INCLUDE_ARCHIVED_PROPERTY} as for the 'gitRepoList' task for " +
+                        "choosing a set of repositories other than those given in the settings.gradle file."
+                task.doLast({
+                    RepositoryQuery query = new RepositoryQuery(project)
+                    query.setIncludeTopics(true)
+                    Map<String, Repository> repositories = query.execute()
+                    project.logger.quiet(getEchoHeader(repositories, project))
+                    repositories.values().forEach({
+                        Repository repository ->
+                            if (repository.enlistmentDir.exists() && (project.hasProperty(RepositoryQuery.TOPICS_PROPERTY) || repository.project != null))
+                            {
+                                project.logger.quiet("Fetching for ${repository.enlistmentDir}")
+                                Grgit grgit = Grgit.open {
+                                    currentDir = repository.enlistmentDir
+                                }
+                                grgit.fetch(prune: project.hasProperty('gitPrune'))
+                            }
+                    })
+                })
+        }
+
+
+        project.tasks.register("gitPush") {
+            Task task ->
+                task.group = "VCS"
+                task.description = "(incubating) Perform a `git push` for a collection of repositories. " +
+                        "Use -PgitDryRun to do everything except actually send the updates." +
+                        "By default, uses the projects specified in the settings.gradle file for which there is a current enlistment. " +
+                        "Use the properties ${RepositoryQuery.TOPICS_PROPERTY}, ${RepositoryQuery.ALL_TOPICS_PROPERTY}, and ${RepositoryQuery.INCLUDE_ARCHIVED_PROPERTY} as for the 'gitRepoList' task for " +
+                        "choosing a set of repositories other than those given in the settings.gradle file."
+                task.doLast({
+                    RepositoryQuery query = new RepositoryQuery(project)
+                    query.setIncludeTopics(true)
+                    Map<String, Repository> repositories = query.execute()
+                    project.logger.quiet(getEchoHeader(repositories, project))
+                    repositories.values().forEach({
+                        Repository repository ->
+                            if (repository.enlistmentDir.exists() && (project.hasProperty(RepositoryQuery.TOPICS_PROPERTY) || repository.project != null))
+                            {
+                                project.logger.quiet("Pushing for ${repository.enlistmentDir}")
+                                Grgit grgit = Grgit.open {
+                                    currentDir = repository.enlistmentDir
+                                }
+                                grgit.push(dryRun: project.hasProperty('gitDryRun'))
+                            }
+                    })
+                })
+        }
+
         project.tasks.register("gitEnlist") {
             Task task ->
                 task.group = "VCS"
                 task.description = "(incubating) Enlist in all of the git modules used for a running LabKey server.  " +
+                        "Use -Pbranch=<bname> to enlist in a particular branch (shortcut for using gitEnlist then gitCheckout -Pbranch=<name>)."
                         "Use the properties ${RepositoryQuery.TOPICS_PROPERTY}, ${RepositoryQuery.ALL_TOPICS_PROPERTY}, and ${RepositoryQuery.INCLUDE_ARCHIVED_PROPERTY} as for the 'gitRepoList' task for filtering the repository set. " +
                         "If a moduleSet property is specified, enlist in only the modules included by that module set. Using -PmoduleSet=all is the same as providing no module set property."
                 task.doLast({
@@ -1140,7 +1277,7 @@ class MultiGit implements Plugin<Project>
                     // do recursive enlistment for all the base repositories
                     baseSet.forEach({
                         Repository repository ->
-                            enlist(repositories, repository, enlisted)
+                            enlist(repositories, repository, enlisted,  (String) project.property('branch'))
                     })
                 })
         }
@@ -1195,7 +1332,6 @@ class MultiGit implements Plugin<Project>
             enlisted.add(repository.getName())
             if (!repository.haveEnlistment())
             {
-                project.logger.quiet("Enlisting in ${repository.getName()} in directory ${repository.getEnlistmentDir()}")
                 repository.enlist(branch)
                 if (repository.getProject() == null)
                     repository.setProject(project)

--- a/src/main/groovy/org/labkey/gradle/plugin/MultiGit.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/MultiGit.groovy
@@ -433,7 +433,7 @@ class MultiGit implements Plugin<Project>
                     }
                     else
                     {
-                        rootProject.logger.quiet("${this.getName()}: Checkint out branch '${branchName}' (origin/${branchName})")
+                        rootProject.logger.quiet("${this.getName()}: Checking out branch '${branchName}' (origin/${branchName})")
                         git.checkout(branch: branchName, startPoint: "origin/${branchName}", createBranch: true)
                     }
                 }

--- a/src/main/groovy/org/labkey/gradle/plugin/NpmRun.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/NpmRun.groovy
@@ -210,6 +210,24 @@ class NpmRun implements Plugin<Project>
                 })
         }
 
+        project.tasks.register("listNodeProjects") {
+            Task task ->
+                task.group = GroupNames.NPM_RUN
+                task.description = "List all projects that employ node in their build"
+                task.doLast({
+                    List<String> nodeProjects = []
+                    project.allprojects({Project p ->
+                        if (p.getPlugins().hasPlugin(NpmRun.class))
+                            nodeProjects.add("${p.path} (${useYarn(p) ? 'yarn' : 'npm'})")
+                    })
+                    if (nodeProjects.size == 0)
+                        println("No projects found containing ${NPM_PROJECT_FILE}")
+                    else {
+                        println("The following projects use Node in their builds:\n\t${nodeProjects.join("\n\t")}\n")
+                    }
+                })
+        }
+
     }
 
     private static void addTaskInputOutput(Task task)

--- a/src/main/groovy/org/labkey/gradle/plugin/NpmRun.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/NpmRun.groovy
@@ -95,7 +95,6 @@ class NpmRun implements Plugin<Project>
         }
     }
 
-    // TODO this needs to be tested, but adding the stub now
     private static void addYarnTasks(Project project)
     {
         project.tasks.register("yarnRunClean")
@@ -192,7 +191,7 @@ class NpmRun implements Plugin<Project>
 
     static boolean useYarn(Project project)
     {
-        return project.hasProperty("yarnVersion")
+        return project.hasProperty("yarnVersion") && !project.file(NPM_PROJECT_LOCK_FILE).exists()
     }
 
     private static void addTasks(Project project)

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -451,13 +451,19 @@ class BuildUtils
         Properties ret = new Properties()
         if (project.plugins.hasPlugin("org.labkey.versioning"))
         {
-            ret.setProperty("VcsURL", project.versioning.info.url)
-            if (project.versioning.info.branch != null)
-                ret.setProperty("VcsBranch", project.versioning.info.branch)
-            if (project.versioning.info.tag != null)
-               ret.setProperty("VcsTag", project.versioning.info.tag)
-            ret.setProperty("VcsRevision", project.versioning.info.commit)
-            ret.setProperty("BuildNumber", (String) TeamCityExtension.getTeamCityProperty(project, "build.number", project.versioning.info.build))
+            Project vcsProject = project
+            while (vcsProject.versioning.info.url == "No VCS" && vcsProject != project.rootProject)
+            {
+                vcsProject = vcsProject.parent
+            }
+            vcsProject.println("${project.path} versioning info ${ vcsProject.versioning.info}")
+            ret.setProperty("VcsURL", vcsProject.versioning.info.url)
+            if (vcsProject.versioning.info.branch != null)
+                ret.setProperty("VcsBranch", vcsProject.versioning.info.branch)
+            if (vcsProject.versioning.info.tag != null)
+               ret.setProperty("VcsTag", vcsProject.versioning.info.tag)
+            ret.setProperty("VcsRevision", vcsProject.versioning.info.commit)
+            ret.setProperty("BuildNumber", (String) TeamCityExtension.getTeamCityProperty(project, "build.number", vcsProject.versioning.info.build))
         }
         else
         {


### PR DESCRIPTION
* Don't use yarn if there is a package-lock.json file.
* Add listNodeProjects task for showing which projects are using node in their build and which package manager
* Add links for both yarn and npm binaries
* [Issue 38198](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=38198): Find the nearest vcs root to use for populating vcs properties to accommodate modules nested in git repositories
* Modify incubating multi-git tasks to account for git modules not in optionalModules and testAutomation repo
* Add more incubating multi-git tasks: gitPull, gitPush, and gitStatus 
