### PR TITLE
Fix schemas compile classpath and remove java files from jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ but also make certain assumptions that you may not want to impose on your module
 ## Release Notes
 
 ### version 1.8.1
-*Release*: ???
+*Released*: 21 Oct 2019
 (Earliest compatible LabKey version: 19.3)
 
 * Fix classpath for XSD schema compilation to prevent duplicate classes
-* Remove .java files generated from XSD files
+* Remove .java files generated from XSD files from jar file
 * Move to new node plugin that works with Gradle 6
 
 ### version 1.8
-*Release*: 17 Oct 2019
+*Released*: 17 Oct 2019
 (Earliest compatible LabKey version: 19.3)
 
 * Update reallyClean to depend on cleanSchemasCompile and thus remove the classes generated from xsd files
@@ -32,7 +32,7 @@ but also make certain assumptions that you may not want to impose on your module
 * Add property to allow TeamCity to run Tomcat under a different JDK `teamcity["tomcatJavaHome"]`
 
 ### version 1.7.0
-*Release*: 27 Aug 2019
+*Released*: 27 Aug 2019
 (Earliest compatible LabKey version: 19.1)
 
 * Don't use yarn if there is a package-lock.json file.
@@ -44,20 +44,20 @@ but also make certain assumptions that you may not want to impose on your module
 * Update reallyClean to depend on cleanNodeModules and thus also remove the node_modules directory for a module
 
 ### version 1.6.2
-*Release*: 25 Jun 2019
+*Released*: 25 Jun 2019
 (Earliest compatible LabKey version: 19.1)
 
 * Fix for symlinkNode task (referencing unknown property)
 
 ### version 1.6.1
-*Release*: 18 Jun 2019
+*Released*: 18 Jun 2019
 (Earliest compatible LabKey version: 19.1)
 
 * [Issue 37754](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=37754) - fix line endings for `manual-upgrade.sh`
 
 
 ### version 1.6
-*Release*: 14 Jun 2019
+*Released*: 14 Jun 2019
 (Earliest compatible LabKey version: 19.1)
 
 * Update tasks for yarn support
@@ -65,7 +65,7 @@ but also make certain assumptions that you may not want to impose on your module
   * Only require `tomcat.home`/`CATALINA_HOME` for tasks that use them
 
 ### version 1.5
-*Release*: 23 May 2019
+*Released*: 23 May 2019
 (Earliest compatible LabKey version: 19.1)
 
 * [Issue 36138](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=36138) - Remove compile-time dependency on local tomcat installation 
@@ -78,19 +78,19 @@ but also make certain assumptions that you may not want to impose on your module
 * (Incubating) Enable yarn for NPM plugin configuration if yarnVersion and yarnWorkDirectory properties are defined 
 
 ### version 1.4.4
-*Release*: 27 Mar 2019
+*Released*: 27 Mar 2019
 (Earliest compatible LabKey version: 19.1)
 
 * Build with Java 11 istead of 12
 
 ### version 1.4.3
-*Release*: 25 Mar 2019
+*Released*: 25 Mar 2019
 (Earliest compatible LabKey version: 19.1)
 
 * Fix evaluation ordering for SpringConfig plugin when doing IntelliJ gradle syncing.
 
 ### version 1.4.2
-*Release*: 20 Mar 2019
+*Released*: 20 Mar 2019
 (Earliest compatible LabKey version: 19.1)
 
 * Add ability to get base modules from a different location using the `platformProjectPath` property to
@@ -98,7 +98,7 @@ support some reorganization of the modules into git repositories.
 
 
 ### version 1.4.1
-*Release*: 20 Feb 2019
+*Released*: 20 Feb 2019
 (Earliest compatible LabKey version: 19.1)
 
 * Remove Windows installer
@@ -107,7 +107,7 @@ support some reorganization of the modules into git repositories.
 * (incubating) Add task for listing pull request info on a set of git repositories
 
 ### version 1.4
-*Release*: 17 Jan 2019
+*Released*: 17 Jan 2019
 (Earliest compatible LabKey version: 19.1)
 
 * [Issue 36261](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=36261) - always include source path as module property
@@ -122,7 +122,7 @@ deprecated functionality.
 * No longer throw exception if a `modules` configuration dependency is declared for a project in the settings file but there is no enlistment for that project
 
 ### version 1.3.8
-*Release*: 14 Jan 2019
+*Released*: 14 Jan 2019
 (Earliest compatible LabKey version: 18.3)
 
 * [Issue 36527](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=36527) - Don't add branch name to artifact version if on release snapshot branch
@@ -131,7 +131,7 @@ deprecated functionality.
 (skipped)
 
 ### version 1.3.6
-*Release*: 28 Nov 2018
+*Released*: 28 Nov 2018
 (Earliest compatible LabKey version: 18.3)
 
 * Move ThreadDumpAndKill functionality into TeamCity plugin, where it is used
@@ -142,7 +142,7 @@ deprecated functionality.
 * [Issue 36171](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=36171) - make the contents of the .tar.gz and .zip distributions identical
 
 ### version 1.3.5
-*Release*: 29 Oct 2018
+*Released*: 29 Oct 2018
 (Earliest compatible LabKey version: 18.3)
 
 * When copying the labkey.xml file to the tomcat conf directory, don't throw an exception if the directory does not exist but the user can create it (via the copy)
@@ -152,13 +152,13 @@ deprecated functionality.
 * Removed TestRunner dependency on sardine.
 
 ### version 1.3.4
-*Release*: 29 Oct 2018
+*Released*: 29 Oct 2018
 (Earliest compatible LabKey version: 18.2)
 
 (Accidental no-change release)
 
 ### version 1.3.3
-*Release*: 18 Oct 2018
+*Released*: 18 Oct 2018
 (Earliest compatible LabKey version: 18.2)
 
 * add ability to enable ldap sync configuration in labkey.xml with -PenableLdapSync.  This will uncomment a stanza in the labkey.xml
@@ -169,7 +169,7 @@ that is surrounded by &lt;`--@@ldapSyncConfig@@` and `@@ldapSyncConfig@@`--&gt;
 * update pattern for jar checking to account for words in the release version (e.g., Spring's 4.3.0.RELEASE)
 
 ### version 1.3.2
-*Release*: 29 Aug 2019
+*Released*: 29 Aug 2019
 (Earliest compatible LabKey version: 18.2)
 
 * [Issue 34390](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=34523) - make createModule use lower case name
@@ -181,7 +181,7 @@ linking to npm executables work when not building from source
 * Update template for createModule task to parameterize version number and copyright year
 
 ### version 1.3.1
-*Released*: 19 June 2018
+*Releasedd*: 19 June 2018
 (Earliest compatible LabKey version: 18.2)
 
 * Remove code that attempted (but failed) to create symbolic links to node and npm directories on Windows. 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ but also make certain assumptions that you may not want to impose on your module
 
 ## Release Notes
 
+### version 1.8.1
+*Release*: ???
+(Earliest compatible LabKey version: 19.3)
+
+* Fix classpath for XSD schema compilation to prevent duplicate classes
+* Remove .java files generated from XSD files
+* Move to new node plugin that works with Gradle 6
+
 ### version 1.8
 *Release*: 17 Oct 2019
 (Earliest compatible LabKey version: 19.3)

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ buildscript {
 apply plugin: "org.ajoberstar.grgit"
 apply plugin: 'maven-publish'
 
-project.version = "1.8.1_schemasJarFix-SNAPSHOT"
+project.version = "1.8.1-SNAPSHOT"
 
 if (project.file("moduleTemplate").exists())
 {

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ buildscript {
 apply plugin: "org.ajoberstar.grgit"
 apply plugin: 'maven-publish'
 
-project.version = "1.8.1-SNAPSHOT"
+project.version = "1.8.1_schemasJarFix-SNAPSHOT"
 
 if (project.file("moduleTemplate").exists())
 {

--- a/src/main/groovy/org/labkey/gradle/plugin/NpmRun.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/NpmRun.groovy
@@ -49,7 +49,7 @@ class NpmRun implements Plugin<Project>
     void apply(Project project)
     {
         // This brings in nodeSetup and npmInstall tasks.  See https://github.com/srs/gradle-node-plugin
-        project.apply plugin: 'com.moowork.node'
+        project.apply plugin: 'com.github.node-gradle.node'
         project.extensions.create(EXTENSION_NAME, NpmRunExtension)
 
         configurePlugin(project)

--- a/src/main/groovy/org/labkey/gradle/plugin/XmlBeans.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/XmlBeans.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.Project
 import org.gradle.api.file.DeleteSpec
 import org.gradle.api.tasks.Delete
 import org.labkey.gradle.task.SchemaCompile
+import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.GroupNames
 
 /**
@@ -54,6 +55,12 @@ class XmlBeans implements Plugin<Project>
                 {
                     xmlbeans "org.apache.xmlbeans:xmlbeans:${project.xmlbeansVersion}"
                 }
+
+        String schemasProjectPath = BuildUtils.getSchemasProjectPath(project.gradle)
+        if (!project.path.equals(schemasProjectPath))
+        {
+            BuildUtils.addLabKeyDependency(project: project, config: 'xmlbeans', depProjectPath: schemasProjectPath)
+        }
     }
 
     private static void addTasks(Project project)

--- a/src/main/groovy/org/labkey/gradle/plugin/XmlBeans.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/XmlBeans.groovy
@@ -85,8 +85,8 @@ class XmlBeans implements Plugin<Project>
                     task.description = "remove source and class files generated from xsd files"
                     task.configure (
                 {DeleteSpec del ->
-                            del.delete "$project.buildDir/$XmlBeans.CLASS_DIR",
-                                         "$project.labkey.srcGenDir/$XmlBeans.CLASS_DIR"
+                            del.delete "$project.buildDir/$CLASS_DIR",
+                                         "$project.labkey.srcGenDir/$CLASS_DIR"
                         }
                     )
         }

--- a/src/main/groovy/org/labkey/gradle/task/SchemaCompile.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/SchemaCompile.groovy
@@ -33,7 +33,10 @@ class SchemaCompile extends DefaultTask {
     return project.file(XmlBeans.SCHEMAS_DIR)
   }
 
-  @OutputDirectory
+  // Not marked as an OutputDirectory to prevent inclusion of .java files in the jar file.
+  // Alternatively, the jar task could be configured to exclude .java files, but these
+  // intermediate files should never be modified on their own and are cleand up directly
+  // so there seems no reason to declare this as an output directory
   File getSrcGenDir()
   {
     return new File("$project.labkey.srcGenDir/$XmlBeans.CLASS_DIR")


### PR DESCRIPTION
Pulling into develop where version number is 1.8.1-SNAPSHOT, in a slight departure from previous process.

[BVT Postgres](https://teamcity.labkey.org/viewLog.html?buildId=837918&buildTypeId=bt7)
[BVT SQLServer](https://teamcity.labkey.org/viewLog.html?buildId=837920&buildTypeId=bt8)
[Premium build](https://teamcity.labkey.org/viewLog.html?buildId=837916&buildTypeId=LabKey_Trunk_LabkeyPremiumTrunk_Build)