### PR TITLE
Modify installer to support mode without tomcat

### DIFF
--- a/distributionResources/manual-upgrade.sh
+++ b/distributionResources/manual-upgrade.sh
@@ -70,7 +70,7 @@ print_usage()
     echo ""
     echo "        --tomcat_lk: for LabKey Internal Hosted Server Installed Only"
     echo ""
-    echo "        --skip_tomcat: the script will not attempt to start/stop tomcat.  you must do this manually before/after running the script. This might be suitable for remote pipeline servers as well.
+    echo "        --skip_tomcat: the script will not attempt to start/stop tomcat.  You must do this manually before/after running the script.
     echo ""
 }
 
@@ -414,4 +414,3 @@ echo "  - LabKey specific log: $tomcat_home/logs/labkey.log "
 echo ""
 echo " ------------- The upgrade has completed at "  `date`
 echo ""
-

--- a/distributionResources/manual-upgrade.sh
+++ b/distributionResources/manual-upgrade.sh
@@ -44,7 +44,7 @@
 print_usage()
 {
     echo "Usage:"
-    echo "    manual-upgrade.sh -l dir [-d dir] [-c dir] [-u tomcatuser] [--noPrompt] [--service|--systemctl|--catalina|--tomcat_lk]"
+    echo "    manual-upgrade.sh -l dir [-d dir] [-c dir] [-u tomcatuser] [--noPrompt] [--service|--systemctl|--catalina|--tomcat_lk|--skip_tomcat]"
     echo ""
     echo "    -l dir: LABKEY_HOME directory to be upgraded. This directory contains the "
     echo "            the labkeywebapp, modules, pipeline-lib, etc directories for the existing "
@@ -70,6 +70,8 @@ print_usage()
     echo ""
     echo "        --tomcat_lk: for LabKey Internal Hosted Server Installed Only"
     echo ""
+    echo "        --skip_tomcat: the script will not attempt to start/stop tomcat.  you must do this manually before/after running the script. This might be suitable for remote pipeline servers as well.
+    echo ""
 }
 
 print_error()
@@ -89,6 +91,7 @@ service="true"
 systemctl="false"
 catalina="false"
 tomcat_lk="false"
+skip_tomcat="false"
 noPrompt="false"
 labkey_home=""
 tomcat_home=$CATALINA_HOME
@@ -160,9 +163,13 @@ do
     --catalina)
     catalina="true";
     service="false"
-    shift;;
+    shift;;    
     --tomcat_lk)
     tomcat_lk="true";
+    service="false"
+    shift;;
+    --skip_tomcat)
+    skip_tomcat="true";
     service="false"
     shift;;
     --noPrompt)
@@ -267,6 +274,9 @@ then
 elif [ "$catalina" = "true" ]
 then
     $tomcat_home/bin/shutdown.sh
+elif [ "$skip_tomcat" = "true" ]
+then
+    echo "skip_tomcat=true, so tomcat will not be shutdown"
 fi
 
 #
@@ -371,6 +381,9 @@ then
 elif [ $catalina = "true" ]
 then
     $tomcat_home/bin/startup.sh
+elif [ "$skip_tomcat" = "true" ]
+then
+    echo "skip_tomcat=true, so tomcat will not be restarted"    
 fi
 
 #


### PR DESCRIPTION
Hello,

We deploy LabKey to our cluster, where it runs in a mode without tomcat.  Years ago I wrote our deploy code to copy/paste a bunch of this script, since I was unable to use this script verbatim because we are not attempting to start/stop the tomcat service.  However, it is pretty easy to just add an argument to the official script to avoid start/stopping the tomcat server.  This PR adds that.

While extracting the LK tar and copying modules+ pipline_libs isnt hard, it would be slightly better to use the official LK script for this, if something ever changes in the future in that process.

Thank you for considering this.
