### PR TITLE
sh shell does not support arrays.  Use a function instead.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ but also make certain assumptions that you may not want to impose on your module
 
 ## Release Notes
 
+### version TBD
+*Released*: TBD
+(Earliest compatible LabKey version: 20.3)
+* Fix manual-upgrade.sh script since sh shell does not support arrays
+
 ### version 1.10.3
 *Released*: 30 March 2020
 (Earliest compatible LabKey version: 20.3)

--- a/distributionResources/manual-upgrade.sh
+++ b/distributionResources/manual-upgrade.sh
@@ -350,27 +350,34 @@ if [ $? != 0 ]; then print_error; fi # exit if the last command failed
 # Remove all existing LabKey JAR files from TOMCAT_HOME/lib directory, if found
 # Throws warning if the forced delete fails.
 #
-jars=( "javax.activation.jar" "labkeyBootstrap.jar" "mysql.jar" "jtds.jar" "mail.jar" "postgresql.jar"); 
+removeTomcatJar()
+{
+  jar=$1
+  file=$CATALINA_HOME/lib/$jar
+  if [ -f $file ]
+  then
+      echo "Deleting the $file file..."
+      rm -f $file;
+      retValue=$?
+      if [ $retValue -ne 0 ]; then
+          echo "FAILED"
+          deleteFailed=1
+      fi
+  fi
+}
 
 deleteFailed=0
-for jar in "${jars[@]}"
-do
-    file=$CATALINA_HOME/lib/$jar
-    if [ -f $file ]
-    then
-        echo "Deleting the $file file..."
-        rm -f $file;
-        retValue=$?
-        if [ $retValue -ne 0 ]; then
-            echo "FAILED"
-            deleteFailed=1
-        fi
-    fi
-done
+removeTomcatJar 'javax.activation.jar'
+removeTomcatJar 'labkeyBootstrap.jar'
+removeTomcatJar 'mysql.jar'
+removeTomcatJar 'jtds.jar'
+removeTomcatJar 'mail.jar'
+removeTomcatJar 'postgresql.jar'
 
 if [ $deleteFailed -eq 1 ]; then
     echo "Unable to delete one or more legacy jar files from $CATALINA_HOME/lib.  You will need to remove these manually in order for the server to start cleanly."
 fi
+
 #
 # Copy the LabKey jar files (libraries) to the TOMCAT_HOME directory
 #


### PR DESCRIPTION
**Rationale**
Original changes to the manual-upgrade.sh script assumed a shell that supports arrays, but this is not always the case.  The script has been modified to not use arrays and use a function instead for code reuse.  This is a fix we need for 20.3, so we patch from 1.10.3.

**Changes**
* [Issue 40184](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40184): manual-upgrade.sh script revisions for JAR file removal not working on Ubuntu