### PR TITLE
Issue 40472: Revert change in getLabKeyArtifactName for determining group

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ but also make certain assumptions that you may not want to impose on your module
 ## Release Notes
 
 ### version 1.8.4
-*Released*: TBD
+*Released*: 19 May 2020
 (Earliest compatible LabKey version: 19.3)
 
 * [Issue 40472](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40472) Revert change in getLabKeyArtifactName for determining the group.  

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ but also make certain assumptions that you may not want to impose on your module
 [LabKey documentation](https://www.labkey.org/Documentation/wiki-page.view?name=gradleModules) for more information.
 
 ## Release Notes
+
+### version 1.8.4
+*Released*: TBD
+(Earliest compatible LabKey version: 19.3)
+
+* [Issue 40472](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40472) Revert change in getLabKeyArtifactName for determining the group.  
+ We will always use a LabKey group here.
+  
 ### version 1.8.3
 *Released*: 15 May 2020
 (Earliest compatible LabKey version: 19.3)

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ buildscript {
 apply plugin: "org.ajoberstar.grgit"
 apply plugin: 'maven-publish'
 
-project.version = "1.8.3"
+project.version = "1.8.4-SNAPSHOT"
 
 if (project.file("moduleTemplate").exists())
 {

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ buildscript {
 apply plugin: "org.ajoberstar.grgit"
 apply plugin: 'maven-publish'
 
-project.version = "1.8.4-SNAPSHOT"
+project.version = "1.8.4"
 
 if (project.file("moduleTemplate").exists())
 {

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/LabKeyExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/LabKeyExtension.groovy
@@ -25,6 +25,7 @@ class LabKeyExtension
     private static final String DEPLOY_MODE_PROPERTY = "deployMode"
     public static final String LABKEY_GROUP = "org.labkey"
     public static final String API_GROUP = LABKEY_GROUP + API_GROUP_SUFFIX
+    public static final String MODULE_GROUP = LABKEY_GROUP + MODULE_GROUP_SUFFIX;
     public static final String MODULE_GROUP_SUFFIX = ".module"
     public static final String API_GROUP_SUFFIX = ".api"
     private static enum DeployMode {

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -605,7 +605,8 @@ class BuildUtils
     static String getLabKeyArtifactName(Project project, String projectPath, String version, String extension)
     {
         String moduleName
-        String group = project.group + (extension.equals("module") ? LabKeyExtension.MODULE_GROUP_SUFFIX : LabKeyExtension.API_GROUP_SUFFIX)
+        String group = extension.equals("module") ? LabKeyExtension.MODULE_GROUP : LabKeyExtension.API_GROUP
+
         if (projectPath.endsWith(getRemoteApiProjectPath(project.gradle).substring(1)))
         {
             group = LabKeyExtension.LABKEY_GROUP


### PR DESCRIPTION
We will always use a LabKey group here since choosing the parent's group as the dependency's group is sort of arbitrary.