### PR TITLE
Issue 40472: Revert change in getLabKeyArtifactName for determining group

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ but also make certain assumptions that you may not want to impose on your module
 [LabKey documentation](https://www.labkey.org/Documentation/wiki-page.view?name=gradleModules) for more information.
 
 ## Release Notes
+### version 1.10.6
+*Released*: TBD
+(Earliest compatible LabKey version: 20.3)
+
+* [Issue 40472](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40472) Revert change in getLabKeyArtifactName for determining the group.  
+ We will always use a LabKey group here.
+ 
 ### version 1.10.5
 *Released*: 15 May 2020
 (Earliest compatible LabKey version: 20.3)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ but also make certain assumptions that you may not want to impose on your module
 
 ## Release Notes
 ### version 1.10.6
-*Released*: TBD
+*Released*: 19 May 2019
 (Earliest compatible LabKey version: 20.3)
 
 * [Issue 40472](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40472) Revert change in getLabKeyArtifactName for determining the group.  

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
 }
 
 
-project.version = "1.10.6-SNAPSHOT"
+project.version = "1.10.6"
 
 if (project.file("moduleTemplate").exists())
 {

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
 }
 
 
-project.version = "1.10.5"
+project.version = "1.10.6-SNAPSHOT"
 
 if (project.file("moduleTemplate").exists())
 {

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/LabKeyExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/LabKeyExtension.groovy
@@ -25,6 +25,7 @@ class LabKeyExtension
     private static final String DEPLOY_MODE_PROPERTY = "deployMode"
     public static final String LABKEY_GROUP = "org.labkey"
     public static final String API_GROUP = LABKEY_GROUP + API_GROUP_SUFFIX
+    public static final String MODULE_GROUP = LABKEY_GROUP + MODULE_GROUP_SUFFIX;
     public static final String MODULE_GROUP_SUFFIX = ".module"
     public static final String API_GROUP_SUFFIX = ".api"
     private static enum DeployMode {

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -632,7 +632,8 @@ class BuildUtils
     static String getLabKeyArtifactName(Project project, String projectPath, String version, String extension)
     {
         String moduleName
-        String group = project.group + (extension.equals("module") ? LabKeyExtension.MODULE_GROUP_SUFFIX : LabKeyExtension.API_GROUP_SUFFIX)
+        String group = extension.equals("module") ? LabKeyExtension.MODULE_GROUP : LabKeyExtension.API_GROUP
+
         if (projectPath.endsWith(getRemoteApiProjectPath(project.gradle).substring(1)))
         {
             group = project.hasProperty("labkeyClientApiVersion") ? LabKeyExtension.API_GROUP : LabKeyExtension.LABKEY_GROUP


### PR DESCRIPTION
We will always use a LabKey group here since choosing the parent's group as the dependency's group is sort of arbitrary.