### PR TITLE
Issue 40472: Revert change in getLabKeyArtifactName for determining group

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <bytecodeTargetLevel target="12" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ but also make certain assumptions that you may not want to impose on your module
 
 ## Release Notes
 
-## version TBD
+### version TBD
 *Released*: TBD
 (Earliest compatible LabKey version: 20.4)
 * [Issue 40472](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40472) Revert change in getLabKeyArtifactName for determining the group.  
 We will always use a LabKey group here.
 
-## version 1.12.0
+### version 1.12.0
 *Released*: 14 May 2020
 (Earliest compatible LabKey version: 20.4)
 * Eliminate duplication of jsp jars in war files
@@ -26,7 +26,7 @@ We will always use a LabKey group here.
 * Use project's group as a prefix to determine the group for api and module artifacts
 * Make xsdDocZip  and jsDocZip tasks for publishing the doc files
 
-## version 1.11.0
+### version 1.11.0
 *Released*: 20 April 2020
 (Earliest compatible LabKey version: 20.4)
 * Removed RPackages plugin in favor of defining relevant tasks in RPackages' own `build.gradle` file
@@ -37,6 +37,19 @@ We will always use a LabKey group here.
 that can be used to override this default (e.g., `PnpmInstallCommand=install`)
 * Add utility methods for getting path to sas and jdbc api projects
 * [Issue 40160](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=40160) Fix war distribution to include missing jar files.
+
+### version 1.10.6
+*Released*: 19 May 2019
+(Earliest compatible LabKey version: 20.3)
+
+* [Issue 40472](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40472) Revert change in getLabKeyArtifactName for determining the group.
+ We will always use a LabKey group here.
+
+### version 1.10.5
+*Released*: 15 May 2020
+(Earliest compatible LabKey version: 20.3)
+
+* Fix Pom file generation to use license info from module.properties and project group as prefix for publish group of api and module artifacts
 
 ### version 1.10.4
 *Released*: 14 April 2020

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ but also make certain assumptions that you may not want to impose on your module
 
 ## Release Notes
 
-### version TBD
-*Released*: TBD
+### version 1.12.1
+*Released*: 20 May 2020
 (Earliest compatible LabKey version: 20.4)
 * [Issue 40472](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40472) Revert change in getLabKeyArtifactName for determining the group.  
 We will always use a LabKey group here.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ but also make certain assumptions that you may not want to impose on your module
 
 ## Release Notes
 
+## version TBD
+*Released*: TBD
+(Earliest compatible LabKey version: 20.4)
+* [Issue 40472](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40472) Revert change in getLabKeyArtifactName for determining the group.  
+We will always use a LabKey group here.
+
 ## version 1.12.0
 *Released*: 14 May 2020
 (Earliest compatible LabKey version: 20.4)

--- a/README.md
+++ b/README.md
@@ -127,6 +127,19 @@ No functional changes; built with JDK 12 instead of 13
 * [Issue 38600](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=38600): Remove stageJars task and relatives
 * Add missing Input and Output annotations for tasks
 
+### version 1.8.4
+*Released*: 19 May 2020
+(Earliest compatible LabKey version: 19.3)
+
+* [Issue 40472](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40472) Revert change in getLabKeyArtifactName for determining the group.
+ We will always use a LabKey group here.
+
+### version 1.8.3
+*Released*: 15 May 2020
+(Earliest compatible LabKey version: 19.3)
+
+* Fix Pom file generation to use license info from module.properties and project group as prefix for publish group of api and module artifacts
+
 ### version 1.8.2
 *Released*: 29 Oct 2019
 (Earliest compatible LabKey version: 19.3)

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
 }
 
 
-project.version = "1.12.0-SNAPSHOT"
+project.version = "1.12.1-SNAPSHOT"
 
 if (project.file("moduleTemplate").exists())
 {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Thu Jan 16 10:40:53 PST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,8 @@
+#### Rationale
+<!-- Rationale describing why this pull request is needed, what behavior it's adding/changing/removing, etc. (replace this comment) -->
+
+#### Related Pull Requests
+* <!-- list of links to related pull requests (replace this comment) -->
+
+#### Changes
+* <!-- list of descriptions of changes that are worth noting (replace this comment) -->

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/LabKeyExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/LabKeyExtension.groovy
@@ -26,6 +26,7 @@ class LabKeyExtension
     public static final String LABKEY_GROUP = "org.labkey"
     public static final String MODULE_GROUP_SUFFIX = ".module"
     public static final String API_GROUP_SUFFIX = ".api"
+    public static final String LABKEY_MODULE_GROUP = LABKEY_GROUP + MODULE_GROUP_SUFFIX
     public static final String LABKEY_API_GROUP = LABKEY_GROUP + API_GROUP_SUFFIX
     private static enum DeployMode {
 

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -635,16 +635,16 @@ class BuildUtils
         }
     }
 
-    static String getLabKeyArtifactName(Project project, String projectPath, String version, String extension)
+    static String getLabKeyArtifactName(Project parentProject, String projectPath, String version, String extension)
     {
         String moduleName
-        String group =  project.group + (extension.equals("module") ? LabKeyExtension.MODULE_GROUP_SUFFIX : LabKeyExtension.API_GROUP_SUFFIX)
-        if (projectPath.endsWith(getRemoteApiProjectPath(project.gradle).substring(1)))
+        String group = extension.equals("module") ? LabKeyExtension.LABKEY_MODULE_GROUP : LabKeyExtension.LABKEY_API_GROUP
+        if (projectPath.endsWith(getRemoteApiProjectPath(parentProject.gradle).substring(1)))
         {
             group = LabKeyExtension.LABKEY_API_GROUP
             moduleName = "labkey-client-api"
         }
-        else if (projectPath.equals(getBootstrapProjectPath(project.gradle)))
+        else if (projectPath.equals(getBootstrapProjectPath(parentProject.gradle)))
         {
             group = LabKeyExtension.LABKEY_GROUP
             moduleName = ServerBootstrap.JAR_BASE_NAME


### PR DESCRIPTION
We will always use the LabKey group here since choosing the parent's group is sort of arbitrary.