### PR TITLE
Remove now-defunct references to GXT and GWT-DND

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ but also make certain assumptions that you may not want to impose on your module
 
 ## Release Notes
 
-### version X
-*Released*: The wonderful future
-* Remove references to GXT and GWT-DND, no longer used in product code
+### version 1.12.2
+*Released*: 25 May 2020
+* Remove assumption that GXT and GWT-DND are part of the build
 
 ### version 1.12.1
 *Released*: 20 May 2020

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ but also make certain assumptions that you may not want to impose on your module
 
 ## Release Notes
 
+### version X
+*Released*: The wonderful future
+* Remove references to GXT and GWT-DND, no longer used in product code
+
 ### version 1.12.1
 *Released*: 20 May 2020
 (Earliest compatible LabKey version: 20.4)

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
 }
 
 
-project.version = "1.12.1-SNAPSHOT"
+project.version = "1.12.1-gxtRemoval-SNAPSHOT"
 
 if (project.file("moduleTemplate").exists())
 {

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
 }
 
 
-project.version = "1.12.1-gxtRemoval-SNAPSHOT"
+project.version = "1.12.2"
 
 if (project.file("moduleTemplate").exists())
 {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-// Empty settings file to allow wrapper to be used within this psuedo sub-prject
+// Empty settings file to allow wrapper to be used within this pseudo sub-project

--- a/src/main/groovy/org/labkey/gradle/plugin/Gwt.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Gwt.groovy
@@ -70,13 +70,9 @@ class Gwt implements Plugin<Project>
 
     private void addDependencies(Project project)
     {
-        String gxtGroup = (BuildUtils.compareVersions(project.gxtVersion, "2.2.5") > 0) ? "com.sencha.gxt" : "com.extjs"
-
         project.dependencies {
             gwtCompile "com.google.gwt:gwt-user:${project.gwtVersion}",
                     "com.google.gwt:gwt-dev:${project.gwtVersion}",
-                    "${gxtGroup}:gxt:${project.gxtVersion}",
-                    "com.allen-sauer.gwt.dnd:gwt-dnd:${project.gwtDndVersion}",
                     "javax.validation:validation-api:${project.validationApiVersion}"
         }
 

--- a/src/main/groovy/org/labkey/gradle/plugin/Gwt.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Gwt.groovy
@@ -70,12 +70,27 @@ class Gwt implements Plugin<Project>
 
     private void addDependencies(Project project)
     {
-        project.dependencies {
-            gwtCompile "com.google.gwt:gwt-user:${project.gwtVersion}",
-                    "com.google.gwt:gwt-dev:${project.gwtVersion}",
-                    "javax.validation:validation-api:${project.validationApiVersion}"
-        }
+        // Be backwards-compatible for builds that still reference GXT and GWT-DND
+        if (project.hasProperty("gxtVersion") && project.hasProperty("gwtDndVersion"))
+        {
+            String gxtGroup = (BuildUtils.compareVersions(project.gxtVersion, "2.2.5") > 0) ? "com.sencha.gxt" : "com.extjs"
 
+            project.dependencies {
+                gwtCompile "com.google.gwt:gwt-user:${project.gwtVersion}",
+                        "com.google.gwt:gwt-dev:${project.gwtVersion}",
+                        "${gxtGroup}:gxt:${project.gxtVersion}",
+                        "com.allen-sauer.gwt.dnd:gwt-dnd:${project.gwtDndVersion}",
+                        "javax.validation:validation-api:${project.validationApiVersion}"
+            }
+        }
+        else
+        {
+            project.dependencies {
+                gwtCompile "com.google.gwt:gwt-user:${project.gwtVersion}",
+                        "com.google.gwt:gwt-dev:${project.gwtVersion}",
+                        "javax.validation:validation-api:${project.validationApiVersion}"
+            }
+        }
     }
 
     private void addSourceSet(Project project)


### PR DESCRIPTION
#### Rationale
We don't use GXT and GWT-DND in the product anymore, so the Gradle build shouldn't require they have properties set

