### PR TITLE
1.10.7 fb dedupe not buidling from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ but also make certain assumptions that you may not want to impose on your module
 
 ## Release Notes
 ### version 1.10.7
-*Released*: TBD
+*Released*: 11 June 2020
 (Earliest compatible LabKey version: 20.3)
 * Do not add projects to dedupe configuration dependency if they have buildFromSource=false
 
 ### version 1.10.6
-*Released*: 19 May 2019
+*Released*: 19 May 2020
 (Earliest compatible LabKey version: 20.3)
 
 * [Issue 40472](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40472) Revert change in getLabKeyArtifactName for determining the group.  

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ but also make certain assumptions that you may not want to impose on your module
 [LabKey documentation](https://www.labkey.org/Documentation/wiki-page.view?name=gradleModules) for more information.
 
 ## Release Notes
+### version 1.10.7
+*Released*: TBD
+(Earliest compatible LabKey version: 20.3)
+* Do not add projects to dedupe configuration dependency if they have buildFromSource=false
+
 ### version 1.10.6
 *Released*: 19 May 2019
 (Earliest compatible LabKey version: 20.3)

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
 }
 
 
-project.version = "1.10.6"
+project.version = "1.10.7-SNAPSHOT"
 
 if (project.file("moduleTemplate").exists())
 {

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
 }
 
 
-project.version = "1.10.7-SNAPSHOT"
+project.version = "1.10.7"
 
 if (project.file("moduleTemplate").exists())
 {

--- a/src/main/groovy/org/labkey/gradle/plugin/Module.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Module.groovy
@@ -54,7 +54,7 @@ class Module extends JavaModule
                     {
                         for (String path : BuildUtils.getBaseModules(project.gradle))
                         {
-                            if (project.findProject(path)) // exclude dependencies only if building that module (otherwise we don't have the external configuration
+                            if (project.findProject(path) && BuildUtils.shouldBuildFromSource(project.project(path))) // exclude dependencies only if building that module (otherwise we don't have the external configuration)
                             {
                                 BuildUtils.addLabKeyDependency(project: project, config: "dedupe", depProjectPath: path, depProjectConfig: "external")
                             }


### PR DESCRIPTION
#### Rationale
Previous PR was merged before local commits updating to release version were pushed

#### Related Pull Requests
* #70 

#### Changes
* update to release version and date
