### PR TITLE
Remove apiCompile, update distributions to get binaries from artifactory, check for projects before adding dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ on how to do that, including how to develop and test locally and the versioning 
 * Remove ClientApiDistribution task no longer used in client-api distribution
 * Increase default Tomcat heap to 2GB
 * Check if api project exists before depending on it
+* Remove deprecated apiCompile configuration from Api plugin
 
 ### version 1.12.2
 *Released*: 25 May 2020

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ on how to do that, including how to develop and test locally and the versioning 
 * Remove deprecated apiCompile configuration from Api plugin
 * [Issue 40668](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40668) Add property to use build-prod even if in dev mode
 * Adjust deployApp and distribution tasks to pull utility and proteomics binaries from Artifactory
+* Remove `includeMassSpecBinaries` property from Distribution configuration (available for download From Artifactory)
 
 ### version 1.12.2
 *Released*: 25 May 2020

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ If you are making changes to the plugins, please see the [internal docs](https:/
 on how to do that, including how to develop and test locally and the versioning information.
 
 ## Release Notes
+
 ### version TBD
 *Released*: TBD
 (Earliest compatible LabKey version: 20.7)
@@ -18,7 +19,7 @@ on how to do that, including how to develop and test locally and the versioning 
 * Increase default Tomcat heap to 2GB
 * Check if api project exists before depending on it
 * Remove deprecated apiCompile configuration from Api plugin
-* [Issue 40668](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40668) Add property to use build-prod even if in dev mode]
+* [Issue 40668](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40668) Add property to use build-prod even if in dev mode
 * Adjust deployApp and distribution tasks to pull utility and proteomics binaries from Artifactory
 
 ### version 1.12.2
@@ -54,6 +55,12 @@ We will always use a LabKey group here.
 that can be used to override this default (e.g., `PnpmInstallCommand=install`)
 * Add utility methods for getting path to sas and jdbc api projects
 * [Issue 40160](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=40160) Fix war distribution to include missing jar files.
+
+### version 1.10.7
+*Released*: 11 June 2020 
+(Earliest compatible LabKey version: 20.3)
+            
+* Do not add projects to dedupe configuration dependency if they have buildFromSource=false
 
 ### version 1.10.6
 *Released*: 19 May 2019

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ on how to do that, including how to develop and test locally and the versioning 
 * Increase default Tomcat heap to 2GB
 * Check if api project exists before depending on it
 * Remove deprecated apiCompile configuration from Api plugin
+* [Issue 40668](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40668) Add property to use build-prod even if in dev mode]
+* Adjust deployApp and distribution tasks to pull utility and proteomics binaries from Artifactory
 
 ### version 1.12.2
 *Released*: 25 May 2020

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ on how to do that, including how to develop and test locally and the versioning 
 (Earliest compatible LabKey version: 20.7)
 * Remove ClientApiDistribution task no longer used in client-api distribution
 * Increase default Tomcat heap to 2GB
+* Check if api project exists before depending on it
 
 ### version 1.12.2
 *Released*: 25 May 2020

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
 }
 
 
-project.version = "1.13.0-checkForProjects-SNAPSHOT"
+project.version = "1.13.0-SNAPSHOT"
 
 if (project.file("moduleTemplate").exists())
 {

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
 }
 
 
-project.version = "1.13.0-SNAPSHOT"
+project.version = "1.13.0-checkForProjects-SNAPSHOT"
 
 if (project.file("moduleTemplate").exists())
 {

--- a/src/main/groovy/org/labkey/gradle/plugin/Api.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Api.groovy
@@ -123,7 +123,6 @@ class Api implements Plugin<Project>
     {
         project.artifacts
                 {
-                    apiCompile project.tasks.apiJar // deprecated.  Remove this artifact declaration once build files have been updated to use apiJarFile instead
                     apiJarFile project.tasks.apiJar
                 }
     }

--- a/src/main/groovy/org/labkey/gradle/plugin/CoreScripts.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/CoreScripts.groovy
@@ -17,7 +17,6 @@ package org.labkey.gradle.plugin
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.labkey.gradle.task.ServerSideJS
 import org.labkey.gradle.util.GroupNames
 

--- a/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
@@ -78,9 +78,10 @@ class Distribution implements Plugin<Project>
     private void addDependencies(Project project)
     {
         // we package these Windows utilities with each distribution so any distribution can be used on any platform
-        project.dependencies {
-            utilities "org.labkey.tools.windows:utils:${project.windowsUtilsVersion}@zip"
-        }
+        if (project.hasProperty('windowsUtilsVersion'))
+            project.dependencies {
+                utilities "org.labkey.tools.windows:utils:${project.windowsUtilsVersion}@zip"
+            }
     }
 
     private static void addTasks(Project project)

--- a/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
@@ -49,6 +49,7 @@ class Distribution implements Plugin<Project>
 
         // we depend on tasks from the server project, so it needs to have been evaluated first
         project.evaluationDependsOn(":server")
+        addDependencies(project)
         addConfigurations(project)
         addTasks(project)
         addTaskDependencies(project)
@@ -63,6 +64,23 @@ class Distribution implements Plugin<Project>
                 {
                     distribution
                 }
+        project.configurations.distribution.setDescription("Artifacts of creating a LabKey distribution (aka installer)")
+        if (project.configurations.findByName("utilities") == null)
+        {
+            project.configurations
+                    {
+                        utilities
+                    }
+            project.configurations.utilities.setDescription("Utility binaries for use on Windows platform")
+        }
+    }
+
+    private void addDependencies(Project project)
+    {
+        // we package these Windows utilities with each distribution so any distribution can be used on any platform
+        project.dependencies {
+            utilities "org.labkey.tools.windows:utils:${project.windowsUtilsVersion}@zip"
+        }
     }
 
     private static void addTasks(Project project)

--- a/src/main/groovy/org/labkey/gradle/plugin/Gwt.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Gwt.groovy
@@ -158,11 +158,9 @@ class Gwt implements Plugin<Project>
                                 project.sourceSets.gwt.compileClasspath,       // Dep
                                 project.sourceSets.gwt.java.srcDirs           // Java source
                         ]
-                        String internalProjectPath = BuildUtils.getInternalProjectPath(project.gradle)
-                        if (project.findProject(internalProjectPath) != null && project.project(internalProjectPath).file(project.gwt.srcDir).exists())
-                            paths += [project.project(internalProjectPath).file(project.gwt.srcDir)]
-                        else
-                            paths += [project.project(BuildUtils.getApiProjectPath(project.gradle)).file(project.gwt.srcDir)]
+                        String apiProjectPath = BuildUtils.getApiProjectPath(project.gradle)
+                        if (project.findProject(apiProjectPath) != null && project.project(apiProjectPath).file(project.gwt.srcDir).exists())
+                            paths += [project.project(apiProjectPath).file(project.gwt.srcDir)]
                         java.classpath paths
 
                         java.args =

--- a/src/main/groovy/org/labkey/gradle/plugin/Module.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Module.groovy
@@ -54,7 +54,7 @@ class Module extends JavaModule
                     {
                         for (String path : BuildUtils.getBaseModules(project.gradle))
                         {
-                            if (project.findProject(path)) // exclude dependencies only if building that module (otherwise we don't have the external configuration
+                            if (project.findProject(path) && BuildUtils.shouldBuildFromSource(project.project(path))) // exclude dependencies only if building that module (otherwise we don't have the external configuration)
                             {
                                 BuildUtils.addLabKeyDependency(project: project, config: "dedupe", depProjectPath: path, depProjectConfig: "external")
                             }

--- a/src/main/groovy/org/labkey/gradle/plugin/NpmRun.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/NpmRun.groovy
@@ -182,7 +182,7 @@ class NpmRun implements Plugin<Project>
         addTaskInputOutput(project.tasks.npmRunBuild)
         addTaskInputOutput(project.tasks.getByName("npm_run_${project.npmRun.buildDev}"))
 
-        def runCommand = LabKeyExtension.isDevMode(project) ? npmRunBuild : npmRunBuildProd
+        def runCommand = LabKeyExtension.isDevMode(project) && !project.hasProperty('useNpmProd') ? npmRunBuild : npmRunBuildProd
         TaskUtils.configureTaskIfPresent(project, "module", { dependsOn(runCommand) })
         TaskUtils.configureTaskIfPresent(project, "processModuleResources", { mustRunAfter(runCommand) })
     }

--- a/src/main/groovy/org/labkey/gradle/plugin/SpringConfig.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/SpringConfig.groovy
@@ -37,7 +37,8 @@ class SpringConfig implements Plugin<Project>
     {
         _dirName = "${DIR_PREFIX}/${project.name}"
         project.apply plugin: 'java-base'
-        project.evaluationDependsOn(BuildUtils.getApiProjectPath(project.gradle))
+        if (project.findProject(BuildUtils.getApiProjectPath(project.gradle)))
+            project.evaluationDependsOn(BuildUtils.getApiProjectPath(project.gradle))
         addSourceSet(project)
         addDependencies(project)
     }

--- a/src/main/groovy/org/labkey/gradle/plugin/SpringConfig.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/SpringConfig.groovy
@@ -62,7 +62,13 @@ class SpringConfig implements Plugin<Project>
         // Issue 30155: without this, the spring xml files will not find the classes in the api jar
         if (BuildUtils.isIntellij())
         {
-            project.dependencies.add("springImplementation", project.project(BuildUtils.getApiProjectPath(project.gradle)).tasks.jar.outputs.files)
+            BuildUtils.addLabKeyDependency(
+                    project: project,
+                    config: "springImplementation",
+                    depProjectPath: BuildUtils.getApiProjectPath(project.gradle),
+                    depProjectConfig: 'apiJarFile',
+                    transitive: false
+            )
             if (project.tasks.findByName("jar") != null)
                 project.dependencies.add("springImplementation", project.tasks.jar.outputs.files)
             if (project.tasks.findByName("apiJar") != null)

--- a/src/main/groovy/org/labkey/gradle/plugin/XmlBeans.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/XmlBeans.groovy
@@ -61,9 +61,10 @@ class XmlBeans implements Plugin<Project>
         {
             BuildUtils.addLabKeyDependency(project: project, config: 'xmlbeans', depProjectPath: schemasProjectPath)
         }
-        if (!project.path.equals(BuildUtils.getApiProjectPath(project.gradle)))
+        String apiProjectPath = BuildUtils.getApiProjectPath(project.gradle)
+        if (!project.path.equals(apiProjectPath) && project.findProject(apiProjectPath))
         {
-            project.evaluationDependsOn(BuildUtils.getApiProjectPath(project.gradle))
+            project.evaluationDependsOn(apiProjectPath)
         }
     }
 
@@ -82,9 +83,10 @@ class XmlBeans implements Plugin<Project>
                     project.delete(task.getClassesDir())
                 })
                 // make sure we compile any API schemas first as other schemas can depend on that
-                if (!project.path.equals(BuildUtils.getApiProjectPath(project.gradle)))
+                String apiProjectPath = BuildUtils.getApiProjectPath(project.gradle)
+                if (!project.path.equals(apiProjectPath) && project.findProject(apiProjectPath))
                 {
-                    task.dependsOn(project.project(BuildUtils.getApiProjectPath(project.gradle)).tasks.jar)
+                    task.dependsOn(project.project(apiProjectPath).tasks.jar)
                 }
         }
 

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/LabKeyExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/LabKeyExtension.groovy
@@ -55,7 +55,6 @@ class LabKeyExtension
 
     String srcGenDir
     String externalDir
-    String externalLibDir
     String ext3Dir = "ext-3.4.1"
     String ext4Dir = "ext-4.2.1"
 
@@ -82,7 +81,6 @@ class LabKeyExtension
         srcGenDir = "${project.buildDir}/gensrc"
 
         externalDir = "${project.rootDir}/external"
-        externalLibDir = "${externalDir}/lib"
     }
 
     private static Properties getBasePomProperties(String artifactPrefix, String description, Project project)

--- a/src/main/groovy/org/labkey/gradle/task/DeployApp.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DeployApp.groovy
@@ -96,19 +96,19 @@ class DeployApp extends DefaultTask
 
         if (project.configurations.findByName("binaries") != null)
         {
-            project.logger.quiet("Copying from binaries configuration to ${deployBinDir}")
+            project.logger.info("Copying from binaries configuration to ${deployBinDir}")
             project.copy({
                 CopySpec copy ->
                     copy.from(project.configurations.binaries.collect { project.zipTree(it) })
                     copy.into deployBinDir.path
             })
-            project.logger.quiet("Contents of ${deployBinDir}\n" + deployBinDir.listFiles());
+            project.logger.info("Contents of ${deployBinDir}\n" + deployBinDir.listFiles());
         }
         // For TC builds, we deposit the artifacts of the Linux TPP Tools and Windows Proteomics Tools into
         // the external directory, so we want to copy those over as well.
         // TODO: package the output of these builds into the Artfactory artifact to simplify
         if (project.file(externalDir).exists()) {
-            project.logger.quiet("Copying from ${externalDir} to ${project.serverDeploy.binDir}")
+            project.logger.info("Copying from ${externalDir} to ${project.serverDeploy.binDir}")
             if (SystemUtils.IS_OS_MAC)
                 deployBinariesViaProjectCopy("osx")
             else if (SystemUtils.IS_OS_LINUX)

--- a/src/main/groovy/org/labkey/gradle/task/DeployApp.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DeployApp.groovy
@@ -104,7 +104,7 @@ class DeployApp extends DefaultTask
             })
         }
         else if (project.file(externalDir).exists()) {
-            project.logger.query("Copying from ${externalDir} to ${project.serverDeploy.binDir}")
+            project.logger.quiet("Copying from ${externalDir} to ${project.serverDeploy.binDir}")
             ant.copy(
                     todir: project.serverDeploy.binDir,
                     preserveLastModified: true

--- a/src/main/groovy/org/labkey/gradle/task/DeployApp.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DeployApp.groovy
@@ -104,21 +104,11 @@ class DeployApp extends DefaultTask
             })
             project.logger.quiet("Contents of ${deployBinDir}\n" + deployBinDir.listFiles());
         }
-        else if (project.file(externalDir).exists()) {
+        // For TC builds, we deposit the artifacts of the Linux TPP Tools and Windows Proteomics Tools into
+        // the external directory, so we want to copy those over as well.
+        // TODO: package the output of these builds into the Artfactory artifact to simplify
+        if (project.file(externalDir).exists()) {
             project.logger.quiet("Copying from ${externalDir} to ${project.serverDeploy.binDir}")
-            ant.copy(
-                    todir: project.serverDeploy.binDir,
-                    preserveLastModified: true
-            )
-                    {
-                        // Use cutdirsmapper to strip off the parent directory name to merge each subdirectory into a single parent
-                        ant.cutdirsmapper(dirs: 1)
-                        // first grab all the JAR files, which are the same for all platforms
-                        fileset(dir: "${externalDir}/windows")
-                                {
-                                    include ( name: "**/*.jar")
-                                }
-                    }
             if (SystemUtils.IS_OS_MAC)
                 deployBinariesViaProjectCopy("osx")
             else if (SystemUtils.IS_OS_LINUX)

--- a/src/main/groovy/org/labkey/gradle/task/DeployApp.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DeployApp.groovy
@@ -96,6 +96,7 @@ class DeployApp extends DefaultTask
 
         if (project.configurations.findByName("binaries") != null)
         {
+            project.logger.quiet("Copying from binaries configuration to ${deployBinDir}")
             project.copy({
                 CopySpec copy ->
                     copy.from(project.configurations.binaries.collect { project.zipTree(it) })
@@ -103,6 +104,7 @@ class DeployApp extends DefaultTask
             })
         }
         else if (project.file(externalDir).exists()) {
+            project.logger.query("Copying from ${externalDir} to ${project.serverDeployBinDir}")
             ant.copy(
                     todir: project.serverDeploy.binDir,
                     preserveLastModified: true

--- a/src/main/groovy/org/labkey/gradle/task/DeployApp.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DeployApp.groovy
@@ -104,7 +104,7 @@ class DeployApp extends DefaultTask
             })
         }
         else if (project.file(externalDir).exists()) {
-            project.logger.query("Copying from ${externalDir} to ${project.serverDeployBinDir}")
+            project.logger.query("Copying from ${externalDir} to ${project.serverDeploy.binDir}")
             ant.copy(
                     todir: project.serverDeploy.binDir,
                     preserveLastModified: true

--- a/src/main/groovy/org/labkey/gradle/task/DeployApp.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DeployApp.groovy
@@ -100,8 +100,9 @@ class DeployApp extends DefaultTask
             project.copy({
                 CopySpec copy ->
                     copy.from(project.configurations.binaries.collect { project.zipTree(it) })
-                    copy.into deployBinDir
+                    copy.into deployBinDir.path
             })
+            project.logger.quiet("Contents of ${deployBinDir}\n" + deployBinDir.listFiles());
         }
         else if (project.file(externalDir).exists()) {
             project.logger.quiet("Copying from ${externalDir} to ${project.serverDeploy.binDir}")

--- a/src/main/groovy/org/labkey/gradle/task/PomFile.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/PomFile.groovy
@@ -56,7 +56,7 @@ class PomFile extends DefaultTask
                 if (!asNode().dependencies.isEmpty())
                 {
                     def dependenciesNode = asNode().dependencies.first()
-                    DependencySet dependencySet = isModulePom ? project.configurations.modules.allDependencies : project.configurations.api.allDependencies
+                    DependencySet dependencySet = isModulePom ? project.configurations.modules.allDependencies : project.configurations.external.allDependencies
 
                     // FIXME it's possible to have external dependencies but no dependencies.
                     // add in the dependencies from the external configuration as well

--- a/src/main/groovy/org/labkey/gradle/task/ServerSideJS.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ServerSideJS.groovy
@@ -23,7 +23,7 @@ import org.gradle.api.tasks.TaskAction
 import org.labkey.gradle.util.BuildUtils
 
 /**
- * Created by susanh on 8/8/16.
+ * N.B.  This task requires that you have the platform/api project source as it needs access to directories in that project
  */
 class ServerSideJS extends DefaultTask
 {


### PR DESCRIPTION
#### Rationale
The changes in this PR provide better support for not building from source by removing some assumptions about the presence of the all-important api module.  We also provide support for pulling binary artifacts from Artifactory instead of from their SVN directory and make one update to edge us closer to Gradle 7 compatibility.

#### Related Pull Requests
* https://github.com/LabKey/distributions/pull/92

#### Changes
* Check if api project exists before depending on it
* Remove deprecated apiCompile configuration from Api plugin
* [Issue 40668](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40668) Add property to use build-prod even if in dev mode
* Adjust deployApp and distribution tasks to pull utility and proteomics binaries from Artifactory
* Remove `includeMassSpecBinaries` property from Distribution configuration (available for download From Artifactory)
