### PR TITLE
Allow for use of `logj2.xml` file based on presence of the property log4j2Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 ## Release Notes
 
+### version TBD
+*Released*: TBD
+(Earliest compatible LabKey version: 20.7)
+* Allow for use of `logj2.xml` file based on presence of the property `log4j2Version`.
+
 ### version 1.14.0
 *Released*: 8 July 2020
 (Earliest compatible LabKey version: 20.7)

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
 }
 
 
-project.version = "1.15.0-SNAPSHOT"
+project.version = "1.15.0-log4j2-SNAPSHOT"
 
 if (project.file("moduleTemplate").exists())
 {

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
 }
 
 
-project.version = "1.15.0-log4j2-SNAPSHOT"
+project.version = "1.15.0-SNAPSHOT"
 
 if (project.file("moduleTemplate").exists())
 {

--- a/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
@@ -221,11 +221,12 @@ class ServerDeploy implements Plugin<Project>
 
         project.tasks.deployApp.dependsOn(project.tasks.setup)
 
-
+        String log4jFile = project.hasProperty('log4j2Version') ? 'log4j2.xml' : 'log4j.xml'
         project.tasks.register('configureLog4j', ConfigureLog4J) {
             ConfigureLog4J task ->
+                task.fileName = log4jFile
                 task.group = GroupNames.DEPLOY
-                task.description = "Edit and copy log4j.xml file"
+                task.description = "Edit and copy ${log4jFile} file"
         }
         project.tasks.stageApp.dependsOn(project.tasks.configureLog4j)
 

--- a/src/main/groovy/org/labkey/gradle/task/ConfigureLog4J.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ConfigureLog4J.groovy
@@ -16,6 +16,7 @@
 package org.labkey.gradle.task
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
@@ -27,19 +28,29 @@ import org.labkey.gradle.plugin.extension.LabKeyExtension
  */
 class ConfigureLog4J extends DefaultTask
 {
-    private static final String FILE_NAME = "log4j.xml";
-
-    @InputFile
-    File log4jXML = new File((String) project.serverDeploy.rootWebappsDir, FILE_NAME)
+    @Input
+    String fileName
 
     private File stagingDir = new File((String) project.staging.webappClassesDir)
     private File deployDir = new File("${project.serverDeploy.webappDir}/WEB-INF/classes");
 
-    @OutputFile
-    File stagingFile = new File(stagingDir, FILE_NAME)
+    @InputFile
+    File getLog4jXml()
+    {
+        return new File((String) project.serverDeploy.rootWebappsDir, fileName)
+    }
 
     @OutputFile
-    File deployFile = new File(deployDir, FILE_NAME)
+    File getStagingFile()
+    {
+        return new File(stagingDir, fileName)
+    }
+
+    @OutputFile
+    File getDeployFile()
+    {
+        return new File(deployDir, fileName)
+    }
 
     @TaskAction
     void copyFile()
@@ -54,7 +65,7 @@ class ConfigureLog4J extends DefaultTask
                 overwrite: true,
         )
         {
-            fileset(file: log4jXML)
+            fileset(file: getLog4jXml())
             filterset(beginToken: "@@", endToken: "@@")
                     {
                         filter (token: "consoleAppender",
@@ -67,7 +78,7 @@ class ConfigureLog4J extends DefaultTask
                 overwrite: true,
         )
         {
-            fileset(file: stagingFile)
+            fileset(file: getStagingFile())
         }
     }
 }


### PR DESCRIPTION

#### Rationale
We are updating to log4j2 and need to copy its XML configuration file instead of `log4j.xml` when we have the appropriate properties.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1378

#### Changes
* Allow for use of `logj2.xml` file based on presence of the property `log4j2Version`.
