### PR TITLE
Task to install R package from an archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 ## Release Notes
 
+### version 1.14.1
+*Released*: TBD
+(Earliest compatible LabKey version: 20.7)
+* Add `CopyAndInstallRPackage` task for installing pre-downloaded R packages
+
 ### version 1.14.0
 *Released*: 8 July 2020
 (Earliest compatible LabKey version: 20.7)

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
 }
 
 
-project.version = "1.14.1-rPackages-SNAPSHOT"
+project.version = "1.15.0-SNAPSHOT"
 
 if (project.file("moduleTemplate").exists())
 {

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
 }
 
 
-project.version = "1.15.0-SNAPSHOT"
+project.version = "1.14.1-rPackages-SNAPSHOT"
 
 if (project.file("moduleTemplate").exists())
 {

--- a/src/main/groovy/org/labkey/gradle/task/CopyAndInstallRPackage.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/CopyAndInstallRPackage.groovy
@@ -1,0 +1,29 @@
+package org.labkey.gradle.task
+
+import org.gradle.api.file.CopySpec
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+
+class CopyAndInstallRPackage extends InstallRPackage
+{
+    @Input
+    String packageName
+    @Input
+    File sourceDir
+
+    @TaskAction
+    void doInstall()
+    {
+        super.doInstall() // Install dependencies
+        File rLibsUserDir = getInstallDir()
+        project.copy {
+            CopySpec copy ->
+                copy.from sourceDir
+                copy.into(rLibsUserDir)
+                copy.include(packageName + "*.tar.gz")
+                copy.rename(packageName + ".*.tar.gz", packageName + ".tar.gz")
+        }
+        installFromArchive(packageName + ".tar.gz")
+    }
+
+}

--- a/src/main/groovy/org/labkey/gradle/task/CopyAndInstallRPackage.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/CopyAndInstallRPackage.groovy
@@ -3,21 +3,22 @@ package org.labkey.gradle.task
 import org.gradle.api.file.CopySpec
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.TaskInstantiationException
 
 class CopyAndInstallRPackage extends InstallRPackage
 {
     @InputDirectory
     File packageLocation
 
-    private final String packageName
+    private String packageName
 
     CopyAndInstallRPackage()
     {
-        if (packageNames == null || packageNames.isEmpty())
+        if (getPackageNames() == null || getPackageNames().isEmpty())
         {
-            logger.error("No package name specified.")
+            throw new TaskInstantiationException("Task did not specify a package to install.")
         }
-        packageName = packageNames.get(0)
+        packageName = getPackageNames().get(0)
     }
 
     @TaskAction

--- a/src/main/groovy/org/labkey/gradle/task/CopyAndInstallRPackage.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/CopyAndInstallRPackage.groovy
@@ -1,15 +1,24 @@
 package org.labkey.gradle.task
 
 import org.gradle.api.file.CopySpec
-import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.TaskAction
 
 class CopyAndInstallRPackage extends InstallRPackage
 {
-    @Input
-    String packageName
-    @Input
-    File sourceDir
+    @InputDirectory
+    File packageLocation
+
+    private final String packageName
+
+    CopyAndInstallRPackage()
+    {
+        if (packageNames == null || packageNames.isEmpty())
+        {
+            logger.error("No package name specified.")
+        }
+        packageName = packageNames.get(0)
+    }
 
     @TaskAction
     void doInstall()
@@ -18,7 +27,7 @@ class CopyAndInstallRPackage extends InstallRPackage
         File rLibsUserDir = getInstallDir()
         project.copy {
             CopySpec copy ->
-                copy.from sourceDir
+                copy.from packageLocation
                 copy.into(rLibsUserDir)
                 copy.include(packageName + "*.tar.gz")
                 copy.rename(packageName + ".*.tar.gz", packageName + ".tar.gz")

--- a/src/main/groovy/org/labkey/gradle/task/CopyAndInstallRPackage.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/CopyAndInstallRPackage.groovy
@@ -3,27 +3,22 @@ package org.labkey.gradle.task
 import org.gradle.api.file.CopySpec
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.TaskAction
-import org.gradle.api.tasks.TaskInstantiationException
+import org.gradle.api.tasks.TaskExecutionException
 
 class CopyAndInstallRPackage extends InstallRPackage
 {
     @InputDirectory
     File packageLocation
 
-    private String packageName
-
-    CopyAndInstallRPackage()
-    {
-        if (getPackageNames() == null || getPackageNames().isEmpty())
-        {
-            throw new TaskInstantiationException("Task did not specify a package to install.")
-        }
-        packageName = getPackageNames().get(0)
-    }
-
     @TaskAction
     void doInstall()
     {
+        if (getPackageNames() == null || getPackageNames().isEmpty())
+        {
+            throw new TaskExecutionException(this, new RuntimeException("Task did not specify a package to install."))
+        }
+        String packageName = getPackageNames().get(0)
+
         super.doInstall() // Install dependencies
         File rLibsUserDir = getInstallDir()
         project.copy {

--- a/src/main/groovy/org/labkey/gradle/task/InstallRLabKey.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/InstallRLabKey.groovy
@@ -19,6 +19,7 @@ import org.apache.commons.lang3.SystemUtils
 import org.gradle.api.file.CopySpec
 /**
  * Created by susanh on 3/16/17.
+ * TODO: Remove when 20.7 is no longer supported
  */
 class InstallRLabKey extends InstallRPackage
 {

--- a/src/main/groovy/org/labkey/gradle/task/InstallRPackage.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/InstallRPackage.groovy
@@ -164,7 +164,14 @@ class InstallRPackage extends DefaultTask
     void installFromArchive(String archiveFileName)
     {
 
-        project.ant.exec(dir: getRLibsUserPath(project), executable: rPath, failifexecutionfails: "false", searchpath: true)
+        ant.exec(
+                executable: rPath,
+                dir: getRLibsUserPath(project),
+                failifexecutionfails: true,
+                searchpath: true,
+                output: "${getRLibsUserPath(project)}/logs/${archiveFileName}.log",
+                logError: true
+        )
                 {
                     arg(line: "CMD INSTALL -l ${rLibsUserDir} ${rLibsUserDir}/${archiveFileName}")
                 }

--- a/src/main/groovy/org/labkey/gradle/task/InstallRPackage.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/InstallRPackage.groovy
@@ -45,7 +45,6 @@ class InstallRPackage extends DefaultTask
             logger.error("Unable to locate R executable. Make sure R_HOME is defined and points at your R install directory")
         if (rLibsUserDir == null)
             logger.error("Unable to install R dependencies. Make sure R_LIBS_USER is defined and points at sampledata/rlabkey")
-
         onlyIf {
             if (rPath == null)
                 return false

--- a/src/main/groovy/org/labkey/gradle/task/InstallRPackage.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/InstallRPackage.groovy
@@ -33,8 +33,6 @@ class InstallRPackage extends DefaultTask
     List<String> packageNames
     @Optional @Input
     String installScript
-    @Optional @Input
-    File scriptDir
 
     protected String rPath
     protected File rLibsUserDir
@@ -47,9 +45,6 @@ class InstallRPackage extends DefaultTask
             logger.error("Unable to locate R executable. Make sure R_HOME is defined and points at your R install directory")
         if (rLibsUserDir == null)
             logger.error("Unable to install R dependencies. Make sure R_LIBS_USER is defined and points at sampledata/rlabkey")
-        if (scriptDir == null) {
-            scriptDir = project.projectDir
-        }
 
         onlyIf {
             if (rPath == null)
@@ -84,8 +79,8 @@ class InstallRPackage extends DefaultTask
     {
         String exitCode = ""
         ant.exec(executable: rPath,
-                dir: scriptDir,
-                input: new File(scriptDir, "check-installed.R"),
+                dir: project.projectDir,
+                input:project.file("check-installed.R"),
                 failifexecutionfails: true,
                 searchpath: true,
                 resultproperty: exitCode )
@@ -154,10 +149,10 @@ class InstallRPackage extends DefaultTask
     {
         ant.exec(
                 executable: rPath,
-                dir: scriptDir,
+                dir: project.projectDir,
                 failifexecutionfails: false,
                 searchpath: true,
-                input: new File(scriptDir, scriptName),
+                input: "${project.projectDir}/${scriptName}",
                 output: "${getRLibsUserPath(project)}/logs/${scriptName}.log",
                 logError: true
         )

--- a/src/main/groovy/org/labkey/gradle/task/InstallRPackage.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/InstallRPackage.groovy
@@ -33,6 +33,8 @@ class InstallRPackage extends DefaultTask
     List<String> packageNames
     @Optional @Input
     String installScript
+    @Optional @Input
+    File scriptDir
 
     protected String rPath
     protected File rLibsUserDir
@@ -45,6 +47,10 @@ class InstallRPackage extends DefaultTask
             logger.error("Unable to locate R executable. Make sure R_HOME is defined and points at your R install directory")
         if (rLibsUserDir == null)
             logger.error("Unable to install R dependencies. Make sure R_LIBS_USER is defined and points at sampledata/rlabkey")
+        if (scriptDir == null) {
+            scriptDir = project.projectDir
+        }
+
         onlyIf {
             if (rPath == null)
                 return false
@@ -78,8 +84,8 @@ class InstallRPackage extends DefaultTask
     {
         String exitCode = ""
         ant.exec(executable: rPath,
-                dir: project.projectDir,
-                input:project.file("check-installed.R"),
+                dir: scriptDir,
+                input: new File(scriptDir, "check-installed.R"),
                 failifexecutionfails: true,
                 searchpath: true,
                 resultproperty: exitCode )
@@ -148,10 +154,10 @@ class InstallRPackage extends DefaultTask
     {
         ant.exec(
                 executable: rPath,
-                dir: project.projectDir,
+                dir: scriptDir,
                 failifexecutionfails: false,
                 searchpath: true,
-                input: "${project.projectDir}/${scriptName}",
+                input: new File(scriptDir, scriptName),
                 output: "${getRLibsUserPath(project)}/logs/${scriptName}.log",
                 logError: true
         )

--- a/src/main/groovy/org/labkey/gradle/task/InstallRuminex.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/InstallRuminex.groovy
@@ -19,6 +19,7 @@ import org.gradle.api.file.CopySpec
 import org.gradle.api.tasks.TaskAction
 /**
  * Created by susanh on 3/16/17.
+ * TODO: Remove when 20.7 is no longer supported
  */
 class InstallRuminex extends InstallRPackage
 {


### PR DESCRIPTION
#### Rationale
We want to remove the prebuilt [Rlabkey binaries](https://svn.mgt.labkey.host/stedi/branches/release20.7-SNAPSHOT/remoteapi/r/) from Subversion. The `InstallRLabKey` task has that location baked in. Rather than conditionalize its behavior, I added a generic task for installing from a local tar.gz.

#### Related Pull Requests
* LabKey/labkey-api-r#56

#### Changes
* Add a generalized task for installing Rlabkey and Ruminex
