### PR TITLE
Wait for Tomcat to shutdown gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 ## Release Notes
 
+### version 1.15.1
+*Released*: TBD
+(Earliest compatible LabKey version: 20.7)
+* Wait for Tomcat to shutdown gracefully before killing VM directly 
+
 ### version 1.15.0
 *Released*: 15 July 2020
 (Earliest compatible LabKey version: 20.7)

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
 }
 
 
-project.version = "1.15.1-tomcatShutdown-SNAPSHOT"
+project.version = "1.15.1-SNAPSHOT"
 
 if (project.file("moduleTemplate").exists())
 {

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
 }
 
 
-project.version = "1.16.0-SNAPSHOT"
+project.version = "1.15.1-tomcatShutdown-SNAPSHOT"
 
 if (project.file("moduleTemplate").exists())
 {

--- a/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
@@ -37,6 +37,7 @@ import org.labkey.gradle.util.DatabaseProperties
 import org.labkey.gradle.util.GroupNames
 import org.labkey.gradle.util.PropertiesUtils
 
+import java.time.Duration
 import java.util.regex.Matcher
 
 /**
@@ -49,6 +50,7 @@ class TeamCity extends Tomcat
     private static final String TEST_CONFIGS_DIR = "configs/config-test"
     private static final String NLP_CONFIG_FILE = "nlpConfig.xml"
     private static final String PIPELINE_CONFIG_FILE =  "pipelineConfig.xml"
+    private static final Duration TOMCAT_SHUTDOWN_TIMEOUT = Duration.ofSeconds(15);
 
     private TeamCityExtension extension
 
@@ -320,7 +322,7 @@ class TeamCity extends Tomcat
         }
 
         println("Waiting for graceful Tomcat shutdown.")
-        while (System.currentTimeMillis() - startTime < 15_000)
+        while (System.currentTimeMillis() - startTime < TOMCAT_SHUTDOWN_TIMEOUT.toMillis())
         {
             try
             {

--- a/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
@@ -308,7 +308,7 @@ class TeamCity extends Tomcat
         arguments.get("port").setValue(Integer.toString(port));
         long startTime = System.currentTimeMillis()
         println("Waiting for graceful Tomcat shutdown.")
-        while (System.currentTimeMillis() - startTime > 15_000)
+        while (System.currentTimeMillis() - startTime < 15_000)
         {
             try
             {

--- a/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
@@ -307,8 +307,9 @@ class TeamCity extends Tomcat
         arguments.get("hostname").setValue("localhost");
         arguments.get("port").setValue(Integer.toString(port));
         long startTime = System.currentTimeMillis()
-        println("Waiting for graceful Tomcat shutdown.");
-        do {
+        println("Waiting for graceful Tomcat shutdown.")
+        while (System.currentTimeMillis() - startTime > 15_000)
+        {
             try
             {
                 VirtualMachine vm = connector.attach(arguments)
@@ -319,7 +320,7 @@ class TeamCity extends Tomcat
             {
                 return
             }
-        } while (System.currentTimeMillis() - startTime > 15_000);
+        }
         println("Attempting to shutdown Tomcat on debug port: " + port);
         try
         {


### PR DESCRIPTION
#### Rationale
`TeamCity.ensureShutdown` sometimes kills Tomcat before it is able to finish shutting down gracefully from the normal `stopTomcat` task. This is preventing shutdown listeners from logging JSP error counts, action stats, and query stats after some suites on TeamCity.

#### Changes
* Wait for Tomcat to shutdown gracefully before killing VM directly
