### PR TITLE
Allow test server credentials to be customized on TeamCity

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ on how to do that, including how to develop and test locally and the versioning 
 ### version 1.15.1
 *Released*: TBD
 (Earliest compatible LabKey version: 20.7)
-* Wait for Tomcat to shutdown gracefully before killing VM directly 
+* Wait for Tomcat to shutdown gracefully before killing VM directly
+* Allow test server credentials to be customized on TeamCity
 
 ### version 1.15.0
 *Released*: 15 July 2020

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
 }
 
 
-project.version = "1.15.1-SNAPSHOT"
+project.version = "1.15.1-setPassword-SNAPSHOT"
 
 if (project.file("moduleTemplate").exists())
 {

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
 }
 
 
-project.version = "1.15.1-setPassword-SNAPSHOT"
+project.version = "1.15.1-SNAPSHOT"
 
 if (project.file("moduleTemplate").exists())
 {

--- a/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
@@ -91,7 +91,7 @@ class TeamCity extends Tomcat
                             [project.configurations.uiTestRuntimeClasspath, project.tasks.testJar]
                         }
                         spec.systemProperties["labkey.server"] = TeamCityExtension.getLabKeyServer(project)
-                        spec.args = ["set", "teamcity@labkey.test", "yekbal1!"]
+                        spec.args = ["set", TeamCityExtension.getLabKeyUsername(), TeamCityExtension.getLabKeyPassword()]
                     })
                 }
         }

--- a/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
@@ -91,7 +91,7 @@ class TeamCity extends Tomcat
                             [project.configurations.uiTestRuntimeClasspath, project.tasks.testJar]
                         }
                         spec.systemProperties["labkey.server"] = TeamCityExtension.getLabKeyServer(project)
-                        spec.args = ["set", TeamCityExtension.getLabKeyUsername(), TeamCityExtension.getLabKeyPassword()]
+                        spec.args = ["set", TeamCityExtension.getLabKeyUsername(project), TeamCityExtension.getLabKeyPassword(project)]
                     })
                 }
         }

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/TeamCityExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/TeamCityExtension.groovy
@@ -133,4 +133,14 @@ class TeamCityExtension
     {
         return getTeamCityProperty(project, "labkey.server", "http://localhost")
     }
+
+    static String getLabKeyUsername(Project project)
+    {
+        return getTeamCityProperty(project, "labkey.server.email", "teamcity@labkey.test")
+    }
+
+    static String getLabKeyPassword(Project project)
+    {
+        return getTeamCityProperty(project, "labkey.server.password", "yekbal1!")
+    }
 }

--- a/src/main/groovy/org/labkey/gradle/task/RunTestSuite.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/RunTestSuite.groovy
@@ -17,8 +17,6 @@ package org.labkey.gradle.task
 
 import org.apache.commons.lang3.StringUtils
 import org.gradle.api.file.CopySpec
-import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.Optional
 import org.labkey.gradle.plugin.TeamCity
 import org.labkey.gradle.plugin.extension.TeamCityExtension
 import org.labkey.gradle.util.DatabaseProperties
@@ -59,7 +57,7 @@ class RunTestSuite extends RunUiTest
                 doLast( {
                     project.copy({ CopySpec copy ->
                         copy.from "${project.tomcat.catalinaHome}/logs"
-                        copy.into "${project.buildDir}/logs/${dbProperties.dbTypeAndVersion}"
+                        copy.into "${project.buildDir}/logs/test/tomcat"
                     })
                 })
             }


### PR DESCRIPTION
#### Rationale
The test server's username/password are hard-coded when running on TeamCity. We need to be able to specify alternate credentials to run tests on remote servers.

#### Changes
* Add `labkey.server.email` and `labkey.server.password` for `setTeamCityAgentPassword` task
