### PR TITLE
Simplify the dependencies and tasks for our test plugins and modify `deployModule` to also deploy dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ on how to do that, including how to develop and test locally and the versioning 
 
 ### version TBD
 *Released*: TBD
-(Earliest compatible LabKey version: 20.7)
+(Earliest compatible LabKey version: 20.9)
 * Wait for Tomcat to shutdown gracefully before killing VM directly
 * Allow test server credentials to be customized on TeamCity
 * Update default project paths for current reality

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ on how to do that, including how to develop and test locally and the versioning 
 * Allow test server credentials to be customized on TeamCity
 * Update default project paths for current reality
 * Update `deployModule` task to also copy in the modules that are required
+* Update logic for getting LabKey artifact name to account for testAutomation group `org.labkey.test`
+* Move dependency declarations out of TestRunner plugin in favor of `testAutomation/build.gradle` declarations 
+* Remove `testJar` task in favor of a default jar task declared in `testAutomatioin/build.gradle`
  
 
 ### version 1.15.0

--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ on how to do that, including how to develop and test locally and the versioning 
 * Allow test server credentials to be customized on TeamCity
 * Update default project paths for current reality
 * Update `deployModule` task to also copy in the modules that are required
+* Fix `undeployModule` so it actually does something
 * Update logic for getting LabKey artifact name to account for testAutomation artifact
 * Move dependency declarations out of TestRunner plugin in favor of `testAutomation/build.gradle` declarations 
 * Remove `testJar` task in favor of a default jar task declared in `testAutomatioin/build.gradle`
+* Fix input and output declarations for `npmInstall`
  
 
 ### version 1.15.0

--- a/README.md
+++ b/README.md
@@ -12,11 +12,14 @@ on how to do that, including how to develop and test locally and the versioning 
 
 ## Release Notes
 
-### version 1.15.1
+### version TBD
 *Released*: TBD
 (Earliest compatible LabKey version: 20.7)
 * Wait for Tomcat to shutdown gracefully before killing VM directly
 * Allow test server credentials to be customized on TeamCity
+* Update default project paths for current reality
+* Update `deployModule` task to also copy in the modules that are required
+ 
 
 ### version 1.15.0
 *Released*: 15 July 2020

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ on how to do that, including how to develop and test locally and the versioning 
 * Allow test server credentials to be customized on TeamCity
 * Update default project paths for current reality
 * Update `deployModule` task to also copy in the modules that are required
-* Update logic for getting LabKey artifact name to account for testAutomation group `org.labkey.test`
+* Update logic for getting LabKey artifact name to account for testAutomation artifact
 * Move dependency declarations out of TestRunner plugin in favor of `testAutomation/build.gradle` declarations 
 * Remove `testJar` task in favor of a default jar task declared in `testAutomatioin/build.gradle`
  

--- a/build.gradle
+++ b/build.gradle
@@ -56,8 +56,7 @@ dependencies {
     api "org.ajoberstar.grgit:grgit-gradle:${grgitGradleVersion}"
 }
 
-
-project.version = "1.15.1-SNAPSHOT"
+project.version = "1.16.0-SNAPSHOT"
 
 if (project.file("moduleTemplate").exists())
 {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Thu Jan 16 10:40:53 PST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
@@ -238,10 +238,12 @@ class FileModule implements Plugin<Project>
                     task.doLast {
                         project.copy { CopySpec copy ->
                             copy.from moduleFile
+                            copy.from project.configurations.modules
                             copy.into project.staging.modulesDir
                         }
                         project.copy { CopySpec copy ->
                             copy.from moduleFile
+                            copy.from project.configurations.modules
                             copy.into ServerDeployExtension.getModulesDeployDirectory(project)
                         }
                     }
@@ -261,12 +263,12 @@ class FileModule implements Plugin<Project>
                                     delete.inputs.file file
                         })
                         delete.outputs.dir "${ServerDeployExtension.getServerDeployDirectory(project)}/modules"
-                        delete.doFirst {
-                            undeployModule(project)
-                            undeployJspJar(project)
-                            Api.deleteModulesApiJar(project)
-                        }
                     })
+                    task.doFirst {
+                        undeployModule(project)
+                        undeployJspJar(project)
+                        Api.deleteModulesApiJar(project)
+                    }
             }
 
 

--- a/src/main/groovy/org/labkey/gradle/plugin/NpmRun.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/NpmRun.groovy
@@ -135,14 +135,6 @@ class NpmRun implements Plugin<Project>
         TaskUtils.configureTaskIfPresent(project, "module", { dependsOn(runCommand) })
         TaskUtils.configureTaskIfPresent(project, "processModuleResources", { mustRunAfter(runCommand) })
 
-        project.tasks.npmInstall
-                {Task task ->
-                    task.inputs.file project.file(NPM_PROJECT_FILE)
-                    if (project.file(NPM_PROJECT_LOCK_FILE).exists())
-                        task.inputs.file project.file(NPM_PROJECT_LOCK_FILE)
-                }
-        project.tasks.npmInstall.outputs.upToDateWhen { project.file(NODE_MODULES_DIR).exists() }
-
         project.tasks.yarn_install {Task task ->
             task.inputs.file project.file(NPM_PROJECT_FILE)
             if (project.file(NPM_PROJECT_LOCK_FILE).exists())
@@ -181,6 +173,14 @@ class NpmRun implements Plugin<Project>
                 }
         addTaskInputOutput(project.tasks.npmRunBuild)
         addTaskInputOutput(project.tasks.getByName("npm_run_${project.npmRun.buildDev}"))
+
+        project.tasks.npmInstall
+                {Task task ->
+                    task.inputs.file project.file(NPM_PROJECT_FILE)
+                    if (project.file(NPM_PROJECT_LOCK_FILE).exists())
+                        task.inputs.file project.file(NPM_PROJECT_LOCK_FILE)
+                }
+        project.tasks.npmInstall.outputs.upToDateWhen { project.file(NODE_MODULES_DIR).exists() }
 
         def runCommand = LabKeyExtension.isDevMode(project) && !project.hasProperty('useNpmProd') ? npmRunBuild : npmRunBuildProd
         TaskUtils.configureTaskIfPresent(project, "module", { dependsOn(runCommand) })

--- a/src/main/groovy/org/labkey/gradle/plugin/TestRunner.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/TestRunner.groovy
@@ -26,9 +26,6 @@ import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.DatabaseProperties
 import org.labkey.gradle.util.GroupNames
 
-/**
- * Created by susanh on 12/7/16.
- */
 class TestRunner extends UiTest
 {
 

--- a/src/main/groovy/org/labkey/gradle/plugin/TestRunner.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/TestRunner.groovy
@@ -34,8 +34,6 @@ class TestRunner extends UiTest
 
     protected void addTasks(Project project)
     {
-        addJarTask(project)
-
         super.addTasks(project)
 
         addPasswordTasks(project)
@@ -84,24 +82,6 @@ class TestRunner extends UiTest
 
     }
 
-    @Override
-    protected void addConfigurations(Project project)
-    {
-        super.addConfigurations(project)
-        project.configurations {
-            aspectj
-        }
-    }
-
-    @Override
-    protected void addDependencies(Project project)
-    {
-        super.addDependencies(project)
-        project.dependencies {
-            aspectj "org.aspectj:aspectjtools:${project.aspectjVersion}"
-        }
-    }
-
 
     private void addPasswordTasks(Project project)
     {
@@ -110,12 +90,12 @@ class TestRunner extends UiTest
             Task task ->
                 task.group = GroupNames.TEST
                 task.description = "Set the password for use in running tests"
-                task.dependsOn(project.tasks.testJar)
+                task.dependsOn(project.tasks.jar)
                 task.doFirst({
                     project.javaexec({
                         main = "org.labkey.test.util.PasswordUtil"
                         classpath {
-                            [project.configurations.uiTestRuntimeClasspath, project.tasks.testJar]
+                            [project.configurations.uiTestRuntimeClasspath, project.tasks.jar]
                         }
                         systemProperties["labkey.server"] = TeamCityExtension.getLabKeyServer(project)
                         args = ["set"]
@@ -129,12 +109,12 @@ class TestRunner extends UiTest
             Task task ->
                 task.group = GroupNames.TEST
                 task.description = "Ensure that the password property used for running tests has been set"
-                task.dependsOn(project.tasks.testJar)
+                task.dependsOn(project.tasks.jar)
                 task.doFirst({
                     project.javaexec({
                         main = "org.labkey.test.util.PasswordUtil"
                         classpath {
-                            [project.configurations.uiTestRuntimeClasspath, project.tasks.testJar]
+                            [project.configurations.uiTestRuntimeClasspath, project.tasks.jar]
                         }
                         systemProperties["labkey.server"] = TeamCityExtension.getLabKeyServer(project)
                         args = ["ensure"]
@@ -228,19 +208,6 @@ class TestRunner extends UiTest
             RunTestSuite task ->
                 task.group = GroupNames.VERIFICATION
                 task.description = "Run a LabKey test suite as defined by ${project.file(testRunnerExt.propertiesFile)} and overridden on the command line by -P<prop>=<value> "
-        }
-    }
-
-    private void addJarTask(Project project)
-    {
-        project.tasks.register("testJar", Jar) {
-            Jar jar ->
-                jar.group = GroupNames.BUILD
-                jar.description = "produce jar file of test classes"
-                jar.from project.sourceSets.uiTest.output
-                jar.archiveBaseName.set("labkeyTest")
-                jar.archiveVersion.set((String) project.version)
-                jar.destinationDirectory = new File("${project.buildDir}/libs")
         }
     }
 

--- a/src/main/groovy/org/labkey/gradle/plugin/UiTest.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/UiTest.groovy
@@ -21,9 +21,7 @@ import org.labkey.gradle.plugin.extension.UiTestExtension
 import org.labkey.gradle.task.RunUiTest
 import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.GroupNames
-/**
- * Created by susanh on 12/21/16.
- */
+
 class UiTest implements Plugin<Project>
 {
     UiTestExtension testRunnerExt
@@ -77,19 +75,10 @@ class UiTest implements Plugin<Project>
     protected void addDependencies(Project project)
     {
         String testProjectPath = BuildUtils.getTestProjectPath(project.gradle)
-        if (project.findProject(testProjectPath) != null)
-        {
-            Project testProject = project.project(testProjectPath)
-            project.dependencies {
-                uiTestImplementation "org.seleniumhq.selenium:selenium-server:${testProject.seleniumVersion}"
-                uiTestRuntimeOnly "org.aspectj:aspectjrt:${testProject.aspectjVersion}"
-                uiTestImplementation "org.aspectj:aspectjtools:${testProject.aspectjVersion}"
-                uiTestImplementation "org.reflections:reflections:${testProject.reflectionsVersion}"
-            }
-        }
 
-        if (project.path != testProjectPath)
+        if (project.path != testProjectPath) {
             BuildUtils.addLabKeyDependency(project: project, config: 'uiTestImplementation', depProjectPath: testProjectPath, depVersion: project.labkeyVersion)
+        }
     }
 
     protected void addTasks(Project project)

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/LabKeyExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/LabKeyExtension.groovy
@@ -28,7 +28,7 @@ class LabKeyExtension
     public static final String API_GROUP_SUFFIX = ".api"
     public static final String LABKEY_MODULE_GROUP = LABKEY_GROUP + MODULE_GROUP_SUFFIX
     public static final String LABKEY_API_GROUP = LABKEY_GROUP + API_GROUP_SUFFIX
-    public static final String LABKEY_TEST_GROUP = LABKEY_GROUP + ".test"
+
     private static enum DeployMode {
 
         dev("Development"),

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/LabKeyExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/LabKeyExtension.groovy
@@ -28,6 +28,7 @@ class LabKeyExtension
     public static final String API_GROUP_SUFFIX = ".api"
     public static final String LABKEY_MODULE_GROUP = LABKEY_GROUP + MODULE_GROUP_SUFFIX
     public static final String LABKEY_API_GROUP = LABKEY_GROUP + API_GROUP_SUFFIX
+    public static final String LABKEY_TEST_GROUP = LABKEY_GROUP + ".test"
     private static enum DeployMode {
 
         dev("Development"),

--- a/src/main/groovy/org/labkey/gradle/task/CheckForVersionConflicts.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/CheckForVersionConflicts.groovy
@@ -19,7 +19,6 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
@@ -89,12 +88,12 @@ class CheckForVersionConflicts  extends DefaultTask
                 }
                 else if (matcher.group(BuildUtils.ARTIFACT_VERSION_INDEX) != null)
                 {
-                    project.logger.debug("adding name (with classifier): ${nameWithClassifier} and version: ${matcher.group(BuildUtils.ARTIFACT_VERSION_INDEX)}")
+                    this.logger.debug("adding name (with classifier): ${nameWithClassifier} and version: ${matcher.group(BuildUtils.ARTIFACT_VERSION_INDEX)}")
                     nameVersionMap.put(nameWithClassifier, new Tuple2(matcher.group(BuildUtils.ARTIFACT_VERSION_INDEX).substring(1), dFile))
                 }
                 else
                 {
-                    project.logger.debug("adding name (with classifier): ${nameWithClassifier} and no version")
+                    this.logger.debug("adding name (with classifier): ${nameWithClassifier} and no version")
                     nameVersionMap.put(nameWithClassifier, new Tuple2(null, dFile))
                 }
             }
@@ -111,7 +110,7 @@ class CheckForVersionConflicts  extends DefaultTask
                     String version = matcher.group(BuildUtils.ARTIFACT_VERSION_INDEX)
                     if (version != null)
                         version = version.substring(1)
-                    project.logger.debug("Checking name (with classifier): ${name} and version ${version}")
+                    this.logger.debug("Checking name (with classifier): ${name} and version ${version}")
                     String existingVersion = nameVersionMap.get(name).first
                     if (existingVersion != version)
                     {
@@ -132,8 +131,8 @@ class CheckForVersionConflicts  extends DefaultTask
             // when there are multiple versions of some artifact, the user needs to decide which to keep and which to delete
             if (action == ConflictAction.delete && !haveMultiples)
             {
-                project.logger.warn("INFO: " + message)
-                project.logger.warn("INFO: Removing existing files that conflict with those from the build.")
+                this.logger.warn("INFO: " + message)
+                this.logger.warn("INFO: Removing existing files that conflict with those from the build.")
                 existingFilesInConflict.forEach({
                     File f ->
                         println("  Deleting ${f}")
@@ -141,7 +140,7 @@ class CheckForVersionConflicts  extends DefaultTask
                 })
             }
             else if (action == ConflictAction.warn)
-                project.logger.warn("WARNING: " + message)
+                this.logger.warn("WARNING: " + message)
             else
                 throw new GradleException(message)
         }

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -646,13 +646,12 @@ class BuildUtils
             group = LabKeyExtension.LABKEY_GROUP
             moduleName = BOOTSTRAP_JAR_BASE_NAME
         }
-        else if (projectPath.equals(getTestProjectPath(parentProject.gradle)))
-        {
-            group = LabKeyExtension.LABKEY_TEST_GROUP
-            moduleName = "testJar"
-        }
         else
         {
+            if (projectPath.equals(getTestProjectPath(parentProject.gradle)))
+            {
+                group = LabKeyExtension.LABKEY_TEST_GROUP
+            }
             int index = projectPath.lastIndexOf(":")
             moduleName = projectPath
             if (index >= 0)

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -274,7 +274,7 @@ class BuildUtils
 
     static String getApiProjectPath(Gradle gradle)
     {
-        return getProjectPath(gradle, "apiProjectPath", ":server:api")
+        return getProjectPath(gradle, "apiProjectPath", ":server:modules:platform:api")
     }
 
     static String getBootstrapProjectPath(Gradle gradle)
@@ -284,7 +284,7 @@ class BuildUtils
 
     static String getInternalProjectPath(Gradle gradle)
     {
-        return getProjectPath(gradle, "internalProjectPath", ":server:internal")
+        return getProjectPath(gradle, "internalProjectPath", ":server:modules:platform:internal")
     }
 
     static String getNodeBinProjectPath(Gradle gradle)
@@ -294,12 +294,12 @@ class BuildUtils
 
     static String getRemoteApiProjectPath(Gradle gradle)
     {
-        return getProjectPath(gradle, "remoteApiProjectPath", ":remoteapi:java")
+        return getProjectPath(gradle, "remoteApiProjectPath", ":remoteapi:labkey-api-java:labkey-client-api")
     }
 
     static String getSasApiProjectPath(Gradle gradle)
     {
-        return getProjectPath(gradle, "sasApiProjectPath", ":remoteapi:sas")
+        return getProjectPath(gradle, "sasApiProjectPath", ":remoteapi:labkey-api-java:labkey-api-sas")
     }
 
     static String getJdbcApiProjectPath(Gradle gradle)
@@ -314,12 +314,12 @@ class BuildUtils
 
     static String getSchemasProjectPath(Gradle gradle)
     {
-        return getProjectPath(gradle, "schemasProjectPath", ":schemas")
+        return getProjectPath(gradle, "schemasProjectPath", ":server:modules:platform:api")
     }
 
     static String getTestProjectPath(Gradle gradle)
     {
-        return getProjectPath(gradle, "testProjectPath", ":server:test")
+        return getProjectPath(gradle, "testProjectPath", ":server:testAutomation")
     }
 
     static boolean isGitModule(Project project)
@@ -645,6 +645,11 @@ class BuildUtils
         {
             group = LabKeyExtension.LABKEY_GROUP
             moduleName = BOOTSTRAP_JAR_BASE_NAME
+        }
+        else if (projectPath.equals(getTestProjectPath(parentProject.gradle)))
+        {
+            group = LabKeyExtension.LABKEY_TEST_GROUP
+            moduleName = "testJar"
         }
         else
         {

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -646,12 +646,14 @@ class BuildUtils
             group = LabKeyExtension.LABKEY_GROUP
             moduleName = BOOTSTRAP_JAR_BASE_NAME
         }
+        else if (projectPath.equals(getTestProjectPath(parentProject.gradle)))
+        {
+            group = LabKeyExtension.LABKEY_API_GROUP
+            moduleName = 'labkey-api-selenium'
+        }
         else
         {
-            if (projectPath.equals(getTestProjectPath(parentProject.gradle)))
-            {
-                group = LabKeyExtension.LABKEY_TEST_GROUP
-            }
+
             int index = projectPath.lastIndexOf(":")
             moduleName = projectPath
             if (index >= 0)

--- a/src/main/groovy/org/labkey/gradle/util/PomFileHelper.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/PomFileHelper.groovy
@@ -38,6 +38,12 @@ class PomFileHelper
         this.isModulePom = isModulePom
     }
 
+    PomFileHelper (Project project)
+    {
+        this.project = project
+        this.isModulePom = false
+    }
+
     static Closure getLabKeyTeamDevelopers() {
         return {
             developer {

--- a/src/main/groovy/org/labkey/gradle/util/PomFileHelper.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/PomFileHelper.groovy
@@ -93,7 +93,7 @@ class PomFileHelper
         return {
             connection = 'scm:git:https://github.com/LabKey/'
             developerConnection = 'scm:git:https://github.com/LabKey/'
-            url = 'scm:git:https://github.com/LabKey/'
+            url = 'https://github.com/LabKey/'
         }
     }
 


### PR DESCRIPTION
#### Rationale
The `deployModule` task is useful as a targeted way to build and deploy a module, but when a module has dependencies on other modules and will not run without those modules present it only makes sense that `deployModule` would also deploy those dependencies.

We modify the dependencies and tasks for the test plugin to make them simpler and to fix a dependency declaration that makes the `moduleUiTests` tasks not work.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/433
* https://github.com/LabKey/platform/pull/1498

#### Changes
* Update default project paths for current reality
* Update `deployModule` task to also copy in the modules that are required
* Fix `undeployModule` so it actually does something
* Update logic for getting LabKey artifact name to account for testAutomation jar file
* Move dependency declarations out of TestRunner plugin in favor of `testAutomation/build.gradle` declarations 
* Remove `testJar` task in favor of a default jar task declared in `testAutomatioin/build.gradle`
