### PR TITLE
Remove additional reference to testJar task that no longer is being built

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     api "org.ajoberstar.grgit:grgit-gradle:${grgitGradleVersion}"
 }
 
-project.version = "1.16.0-SNAPSHOT"
+project.version = "1.16.0-removeTestJar-SNAPSHOT"
 
 if (project.file("moduleTemplate").exists())
 {

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     api "org.ajoberstar.grgit:grgit-gradle:${grgitGradleVersion}"
 }
 
-project.version = "1.16.0-removeTestJar-SNAPSHOT"
+project.version = "1.16.0-SNAPSHOT"
 
 if (project.file("moduleTemplate").exists())
 {

--- a/src/main/groovy/org/labkey/gradle/plugin/JavaModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/JavaModule.groovy
@@ -100,8 +100,10 @@ class JavaModule extends FileModule
                     labkey // use this configuration for dependencies to labkey API jars that are needed for a module
                            // but don't need to show up in the dependencies.txt and jars.txt
                     api.extendsFrom(external)
+                    compile.extendsFrom(external)
                     implementation.extendsFrom(external)
                     implementation.extendsFrom(labkey)
+                    compile.extendsFrom(labkey)
                     dedupe {
                         canBeConsumed = false
                         canBeResolved = true

--- a/src/main/groovy/org/labkey/gradle/plugin/JavaModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/JavaModule.groovy
@@ -99,10 +99,8 @@ class JavaModule extends FileModule
                 {
                     labkey // use this configuration for dependencies to labkey API jars that are needed for a module
                            // but don't need to show up in the dependencies.txt and jars.txt
-                    api.extendsFrom(external) // TODO this is probably not necessary
-                    compile.extendsFrom(external)
+                    api.extendsFrom(external)
                     implementation.extendsFrom(external)
-                    compile.extendsFrom(labkey)
                     implementation.extendsFrom(labkey)
                     dedupe {
                         canBeConsumed = false

--- a/src/main/groovy/org/labkey/gradle/plugin/Jsp.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Jsp.groovy
@@ -109,7 +109,7 @@ class Jsp implements Plugin<Project>
         // they don't belong ("CLASSPATH element .../labkey.tld is not a JAR.").  These warnings may appear if
         // building within IntelliJ but perhaps we can live with that (for now).
         if (BuildUtils.isIntellij())
-            project.dependencies.add("compile", project.rootProject.tasks.copyTagLibsBase.inputs.files)
+            project.dependencies.add("implementation", project.rootProject.tasks.copyTagLibsBase.inputs.files)
     }
 
     private void addJspTasks(Project project)

--- a/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
@@ -83,12 +83,12 @@ class TeamCity extends Tomcat
             Task task ->
                 task.group = GroupNames.TEST_SERVER
                 task.description = "Set the password for use in running tests"
-                task.dependsOn(project.tasks.testJar)
+                task.dependsOn(project.tasks.jar)
                 task.doLast {
                     project.javaexec({ JavaExecSpec spec ->
                         spec.main = "org.labkey.test.util.PasswordUtil"
                         spec.classpath {
-                            [project.configurations.uiTestRuntimeClasspath, project.tasks.testJar]
+                            [project.configurations.uiTestRuntimeClasspath, project.tasks.jar]
                         }
                         spec.systemProperties["labkey.server"] = TeamCityExtension.getLabKeyServer(project)
                         spec.args = ["set", TeamCityExtension.getLabKeyUsername(project), TeamCityExtension.getLabKeyPassword(project)]


### PR DESCRIPTION
#### Rationale
Need to remove all the references to the testJar task, even the ones only used by TeamCIty

#### Related Pull Requests
* #81 

#### Changes
* Replace `testJar` with just plain `jar`
