### PR TITLE
Support usage of plugins for standalone modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ on how to do that, including how to develop and test locally and the versioning 
 * Add missing dependency version numbers for some base module dependencies
 * Parameterize path for server module project and config project (allowing for them to be separate)
 * Remove additional assumptions on presence of server modules project when not needed
+* Update configurations in JavaModule plugin to no longer reference the compile configuration (being deprecated for dependency resolution)
 
 ### version 1.16.0
 *Released*: 26 August 2020

--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ on how to do that, including how to develop and test locally and the versioning 
 
 ## Release Notes
 
+### version TBD
+*Released*: TBD
+(Earliest compatible LabKey verson: 20.9)
+* Remove gradlePlugin type (no longer included under regular enlistment) and update module paths in comments
+* Adjust moduleTemplate for removal of appendNavTrail in favor of addNavTrail
+* Add missing dependency version numbers for some base module dependencies
+* Parameterize path for server module project and config project (allowing for them to be separate)
+* Remove additional assumptions on presence of server modules project when not needed
+
 ### version 1.16.0
 *Released*: 26 August 2020
 (Earliest compatible LabKey version: 20.9)

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     api "org.ajoberstar.grgit:grgit-gradle:${grgitGradleVersion}"
 }
 
-project.version = "1.17.0-standalone-SNAPSHOT"
+project.version = "1.17.0-SNAPSHOT"
 
 if (project.file("moduleTemplate").exists())
 {

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     api "org.ajoberstar.grgit:grgit-gradle:${grgitGradleVersion}"
 }
 
-project.version = "1.17.0-SNAPSHOT"
+project.version = "1.17.0-standalone-SNAPSHOT"
 
 if (project.file("moduleTemplate").exists())
 {

--- a/moduleTemplate/src/org/labkey/MODULE_DIR_NAME/MODULE_NAMEController.java
+++ b/moduleTemplate/src/org/labkey/MODULE_DIR_NAME/MODULE_NAMEController.java
@@ -43,9 +43,6 @@ public class @@MODULE_NAME@@Controller extends SpringActionController
             return new JspView("/org/labkey/@@MODULE_LOWERCASE_NAME@@/view/hello.jsp");
         }
 
-        public NavTree appendNavTrail(NavTree root)
-        {
-            return root;
-        }
+        public void addNavTrail(NavTrail root) { }
     }
 }

--- a/src/main/groovy/org/labkey/gradle/plugin/AntBuild.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/AntBuild.groovy
@@ -19,6 +19,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.plugins.PluginInstantiationException
+import org.labkey.gradle.util.BuildUtils
 
 /**
  * Plugin that will import the tasks from an ant build.xml file and add a dependency between the
@@ -58,7 +59,7 @@ class AntBuild implements Plugin<Project>
 
     private static void setAntProperties(Project project)
     {
-        project.ant.setProperty('basedir', project.project(":server").projectDir)
+        project.ant.setProperty('basedir', BuildUtils.getServerProject(project).projectDir)
         project.ant.setProperty('modules.dir', project.projectDir.parent)
         project.ant.setProperty('build.modules.dir', project.buildDir.parent)
         project.ant.setProperty('build.dir', project.rootProject.buildDir)

--- a/src/main/groovy/org/labkey/gradle/plugin/Api.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Api.groovy
@@ -73,8 +73,8 @@ class Api implements Plugin<Project>
     {
         project.dependencies
                 {
-                    BuildUtils.addLabKeyDependency(project: project, config: 'apiImplementation', depProjectPath: BuildUtils.getApiProjectPath(project.gradle))
-                    BuildUtils.addLabKeyDependency(project: project, config: 'apiImplementation', depProjectPath: BuildUtils.getInternalProjectPath(project.gradle))
+                    BuildUtils.addLabKeyDependency(project: project, config: 'apiImplementation', depProjectPath: BuildUtils.getApiProjectPath(project.gradle), depVersion: project.labkeyVersion)
+                    BuildUtils.addLabKeyDependency(project: project, config: 'apiImplementation', depProjectPath: BuildUtils.getInternalProjectPath(project.gradle), depVersion: project.labkeyVersion)
                     BuildUtils.addLabKeyDependency(project: project, config: "apiImplementation", depProjectPath: BuildUtils.getRemoteApiProjectPath(project.gradle), depVersion: BuildUtils.getLabKeyClientApiVersion(project))
                 }
     }

--- a/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
@@ -31,6 +31,7 @@ import org.labkey.gradle.plugin.extension.TeamCityExtension
 import org.labkey.gradle.task.ModuleDistribution
 import org.labkey.gradle.util.PomFileHelper
 import org.labkey.gradle.util.GroupNames
+import org.labkey.gradle.util.BuildUtils
 
 class Distribution implements Plugin<Project>
 {

--- a/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
@@ -48,7 +48,7 @@ class Distribution implements Plugin<Project>
             project.extensions.create("teamCity", TeamCityExtension, project)
 
         // we depend on tasks from the server project, so it needs to have been evaluated first
-        project.evaluationDependsOn(":server")
+        project.evaluationDependsOn(BuildUtils.getServerProjectPath(project.gradle))
         addDependencies(project)
         addConfigurations(project)
         addTasks(project)

--- a/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
@@ -494,7 +494,7 @@ class FileModule implements Plugin<Project>
 
     private static void addDependencies(Project project)
     {
-        Project serverProject = project.findProject(":server")
+        Project serverProject = BuildUtils.getServerProject(project)
         if (serverProject != null)
         {
             BuildUtils.addLabKeyDependency(project: serverProject, config: 'modules', depProjectPath: project.path, depProjectConfig: 'published', depExtension: 'module')

--- a/src/main/groovy/org/labkey/gradle/plugin/JavaModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/JavaModule.groovy
@@ -212,7 +212,9 @@ class JavaModule extends FileModule
                     }
 
             project.tasks.copyExternalLibs.dependsOn(project.tasks.checkModuleJarVersions)
-            project.project(":server").tasks.checkVersionConflicts.dependsOn(project.tasks.checkModuleJarVersions)
+            Project serverProject = BuildUtils.getServerProject(project)
+            if (serverProject != null)
+                serverProject.tasks.checkVersionConflicts.dependsOn(project.tasks.checkModuleJarVersions)
         })
     }
 

--- a/src/main/groovy/org/labkey/gradle/plugin/JavaModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/JavaModule.groovy
@@ -100,10 +100,8 @@ class JavaModule extends FileModule
                     labkey // use this configuration for dependencies to labkey API jars that are needed for a module
                            // but don't need to show up in the dependencies.txt and jars.txt
                     api.extendsFrom(external)
-                    compile.extendsFrom(external)
                     implementation.extendsFrom(external)
                     implementation.extendsFrom(labkey)
-                    compile.extendsFrom(labkey)
                     dedupe {
                         canBeConsumed = false
                         canBeResolved = true

--- a/src/main/groovy/org/labkey/gradle/plugin/Jsp.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Jsp.groovy
@@ -167,7 +167,7 @@ class Jsp implements Plugin<Project>
                         })
                 }
 
-        if (project.findProject(":server") != null)
+        if (BuildUtils.getServerProject(project) != null)
             project.tasks.copyTagLibs.dependsOn(project.rootProject.tasks.copyTagLibsBase)
 
         project.tasks.register('jsp2Java', JspCompile2Java) {

--- a/src/main/groovy/org/labkey/gradle/plugin/Module.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Module.groovy
@@ -43,7 +43,7 @@ class Module extends JavaModule
                 {
                     BuildUtils.addTomcatBuildDependencies(project, 'implementation')
 
-                    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: BuildUtils.getInternalProjectPath(project.gradle))
+                    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: BuildUtils.getInternalProjectPath(project.gradle), depVersion: project.labkeyVersion)
                     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: BuildUtils.getRemoteApiProjectPath(project.gradle), depVersion: BuildUtils.getLabKeyClientApiVersion(project))
                     if (BuildUtils.isBaseModule(project) && !BuildUtils.isApi(project) && project.findProject(BuildUtils.getApiProjectPath(project.gradle)))
                     {

--- a/src/main/groovy/org/labkey/gradle/plugin/MultiGit.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/MultiGit.groovy
@@ -161,7 +161,6 @@ class MultiGit implements Plugin<Project>
         enum Type
         {
             clientLibrary('labkey-client-api', ":remoteapi"),
-            gradlePlugin('gradle-plugin', ":buildSrc"),
             serverModule("labkey-module", ":server:modules"),
             serverModuleContainer("labkey-module-container", ":server:modules"),
             testContainer("labkey-test-container", ":server"),
@@ -228,10 +227,6 @@ class MultiGit implements Plugin<Project>
             else if (topics.contains("labkey-client-api"))
             {
                 this.setType(Type.clientLibrary)
-            }
-            else if (topics.contains("gradle-plugin"))
-            {
-                this.setType(Type.gradlePlugin)
             }
             else
             {
@@ -549,24 +544,24 @@ class MultiGit implements Plugin<Project>
         }
 
         /**
-         * :server:optionalModules:biologics
+         * :server:modules:biologics
          *         Type: private active serverModule
          *         License: LabKey Software License (https://www.labkey.com/license)
          *         Repo: https://github.com/LabKey/biologics
-         * :server:optionalModules:tnprc_ehr
+         * :server:modules:tnprc_ehr
          *         Type: private active serverModule
          *         Description: LabKey Server module for Tulane National Primate Research Center's EHR implementation
          *         License: Apache License 2.0
          *         Repo: https://github.com/LabKey/tnprc_ehr
-         * :server:optionalModules:workflow
+         * :server:modules:workflow
          *         Description: Workflow processing engine and services
          *         License: Apache License 2.0
          *         Repo: https://github.com/LabKey/workflow
          *         Type: public active serverModule
          *
-         * :server:optionalModules:biologics (https://github.com/LabKey/biologics) - [serverModule] Description here
-         * :server:optionalModules:tnprc_ehr (https://github.com/LabKey/tnprc_ehr) - [serverModule] LabKey Server module for Tulane National Primate Research Center's EHR implementation
-         * :server:optionalModules:workflow (https://github.com/LabKey/workflow) - [serverModule] Workflow processing engine and services
+         * :server:modules:biologics (https://github.com/LabKey/biologics) - [serverModule] Description here
+         * :server:modules:tnprc_ehr (https://github.com/LabKey/tnprc_ehr) - [serverModule] LabKey Server module for Tulane National Primate Research Center's EHR implementation
+         * :server:modules:workflow (https://github.com/LabKey/workflow) - [serverModule] Workflow processing engine and services
          * @param verbose
          * @return
          */

--- a/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
@@ -135,7 +135,7 @@ class TeamCity extends Tomcat
             Copy task ->
                 task.group = GroupNames.TEST_SERVER
                 task.description = "Create NLP engine configs for the test server"
-                task.from project.project(":server").file(TEST_CONFIGS_DIR)
+                task.from BuildUtils.getServerProject(project).file(TEST_CONFIGS_DIR)
                 task.include NLP_CONFIG_FILE
                 task.filter({ String line ->
                     Matcher matcher = PropertiesUtils.PROPERTY_PATTERN.matcher(line)
@@ -209,8 +209,8 @@ class TeamCity extends Tomcat
                         task.group = GroupNames.DEPLOY
                         task.description = "Undeploy modules that are either not supposed to be built or are not supported by database ${properties.dbTypeAndVersion}"
                         task.dbType = properties.shortType
-                        task.mustRunAfter(project.project(":server").tasks.pickMSSQL)
-                        task.mustRunAfter(project.project(":server").tasks.pickPg)
+                        task.mustRunAfter(BuildUtils.getServerProject(project).tasks.pickMSSQL)
+                        task.mustRunAfter(BuildUtils.getServerProject(project).tasks.pickPg)
                 }
             }
             TaskProvider undeployTaskProvider = project.tasks.named(undeployTaskName)

--- a/src/main/groovy/org/labkey/gradle/plugin/UiTest.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/UiTest.groovy
@@ -88,8 +88,11 @@ class UiTest implements Plugin<Project>
             RunUiTest task ->
                 task.group = GroupNames.VERIFICATION
                 task.description = "Run UI (Selenium) tests for this module"
-                task.mustRunAfter(project.project(":server").tasks.pickPg)
-                task.mustRunAfter(project.project(":server").tasks.pickMSSQL)
+                Project serverProject = BuildUtils.getServerProject(project)
+                if (serverProject != null) {
+                    task.mustRunAfter(serverProject.tasks.pickPg)
+                    task.mustRunAfter(serverProject.tasks.pickMSSQL)
+                }
         }
     }
 

--- a/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
@@ -25,6 +25,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import org.labkey.gradle.plugin.ServerDeploy
+import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.DatabaseProperties
 import org.labkey.gradle.util.PropertiesUtils
 
@@ -37,8 +38,9 @@ class DoThenSetup extends DefaultTask
 
     DoThenSetup()
     {
-        if (project.findProject(":server") != null)
-            this.dependsOn project.project(":server").configurations.tomcatJars
+        Project serverProject = BuildUtils.getServerProject(project)
+        if (serverProject != null)
+            this.dependsOn serverProject.configurations.tomcatJars
     }
 
     // Currently this type of task will always run because there are no declared inputs and outputs
@@ -143,7 +145,7 @@ class DoThenSetup extends DefaultTask
             })
         }
 
-        if (project.findProject(":server") != null)
+        if (BuildUtils.getServerProject(project) != null)
             copyTomcatJars()
 
 
@@ -175,7 +177,7 @@ class DoThenSetup extends DefaultTask
 
     private void copyTomcatJars()
     {
-        Project serverProject = project.project(":server")
+        Project serverProject = BuildUtils.getServerProject(project)
         // Remove the staging tomcatLib directory before copying into it to avoid duplicates.
         project.delete project.staging.tomcatLibDir
         // for consistency with a distribution deployment and the treatment of all other deployment artifacts,

--- a/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
@@ -17,6 +17,7 @@ package org.labkey.gradle.task
 
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.Project
 import org.gradle.api.file.CopySpec
 import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.file.FileTree
@@ -65,8 +66,9 @@ class ModuleDistribution extends DefaultTask
         description = "Make a LabKey modules distribution"
         distExtension = project.extensions.findByType(DistributionExtension.class)
 
-        this.dependsOn(project.project(":server").tasks.setup)
-        this.dependsOn(project.project(":server").tasks.stageApp)
+        Project serverProject = BuildUtils.getServerProject(project)
+        this.dependsOn(serverProject.tasks.setup)
+        this.dependsOn(serverProject.tasks.stageApp)
     }
 
     @OutputDirectory

--- a/src/main/groovy/org/labkey/gradle/task/PickDb.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/PickDb.groovy
@@ -28,7 +28,7 @@ class PickDb extends DoThenSetup
     String dbType
 
     @InputDirectory
-    File configsDir = new File(project.project(":server").projectDir, "configs")
+    File configsDir = new File(BuildUtils.getConfigsProject(project).projectDir, "configs")
 
     @Override
     protected void doDatabaseTask()

--- a/src/main/groovy/org/labkey/gradle/task/PickDb.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/PickDb.groovy
@@ -18,6 +18,7 @@ package org.labkey.gradle.task
 import org.gradle.api.file.CopySpec
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
+import org.labkey.gradle.util.BuildUtils
 
 /**
  * Created by susanh on 8/11/16.

--- a/src/main/groovy/org/labkey/gradle/task/StageDistribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/StageDistribution.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.file.RelativePath
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
+import org.labkey.gradle.util.BuildUtils
 
 import java.nio.file.Paths
 

--- a/src/main/groovy/org/labkey/gradle/task/StageDistribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/StageDistribution.groovy
@@ -127,7 +127,7 @@ class StageDistribution extends DefaultTask
         project.copy({ CopySpec spec ->
             spec.from isTar ? project.tarTree(distributionFile).files : project.zipTree(distributionFile).files
             spec.into tomcatJarStagingDir
-            project.project(":server").configurations.tomcatJars.files.each {
+            BuildUtils.getServerProject(project).configurations.tomcatJars.files.each {
                 File file ->
                     spec.include file.getName()
             }

--- a/src/main/groovy/org/labkey/gradle/task/StartTomcat.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/StartTomcat.groovy
@@ -47,7 +47,7 @@ class StartTomcat extends DefaultTask
         {
             env(
                 key: "PATH",
-                path: "${project.project(":server").serverDeploy.binDir}${File.pathSeparator}${System.getenv("PATH")}"
+                path: "${BuildUtils.getServerProject(project).serverDeploy.binDir}${File.pathSeparator}${System.getenv("PATH")}"
             )
 
             List<String> optsList = new ArrayList<>()

--- a/src/main/groovy/org/labkey/gradle/task/StartTomcat.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/StartTomcat.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 import org.labkey.gradle.plugin.extension.LabKeyExtension
 import org.labkey.gradle.plugin.extension.TeamCityExtension
+import org.labkey.gradle.util.BuildUtils
 
 /**
  * Created by susanh on 11/15/16.

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -241,6 +241,26 @@ class BuildUtils
         return whyNotBuildFromSource(project, BUILD_CLIENT_LIBS_FROM_SOURCE_PROP).isEmpty()
     }
 
+    static Project getConfigsProject(Project project)
+    {
+        return project.project(getConfigsProjectPath(project.gradle))
+    }
+
+    static String getConfigsProjectPath(Gradle gradle)
+    {
+        return getProjectPath(gradle, "configsProjectPath", getServerProjectPath(gradle))
+    }
+
+    static Project getServerProject(Project project)
+    {
+        return project.findProject(getServerProjectPath(project.gradle))
+    }
+
+    static String getServerProjectPath(Gradle gradle)
+    {
+        return getProjectPath(gradle, "serverProjectPath", ":server")
+    }
+
     static String getPlatformModuleProjectPath(Gradle gradle, String name)
     {
         // without the toString call below, you get the following error:

--- a/src/main/groovy/org/labkey/gradle/util/DatabaseProperties.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/DatabaseProperties.groovy
@@ -76,7 +76,7 @@ class DatabaseProperties
 
     private static File getConfigFile(Project project, String dbConfigFile)
     {
-        return BuildUtils.getServerProject(project).file(dbConfigFile)
+        return BuildUtils.getConfigsProject(project).file(dbConfigFile)
     }
 
     void setProject(Project project)

--- a/src/main/groovy/org/labkey/gradle/util/DatabaseProperties.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/DatabaseProperties.groovy
@@ -76,7 +76,7 @@ class DatabaseProperties
 
     private static File getConfigFile(Project project, String dbConfigFile)
     {
-        return project.project(":server").file(dbConfigFile)
+        return BuildUtils.getServerProject(project).file(dbConfigFile)
     }
 
     void setProject(Project project)
@@ -216,7 +216,7 @@ class DatabaseProperties
     {
         if (getConfigFile(project, configFile).exists())
         {
-            Properties props = PropertiesUtils.readFileProperties(project.project(":server"), configFile)
+            Properties props = PropertiesUtils.readFileProperties(BuildUtils.getConfigsProject(project), configFile)
             return props
         }
         else


### PR DESCRIPTION
#### Rationale
As more developers are taking advantage of the artifacts published to Artifactory, they may want to build modules outside of the LabKey enlistment.  This is possible to do by writing custom Gradle tasks, but in order to use these plugins outside of the enlistment, we need to remove a couple of assumptions about the presence of the `server` project and add some missing version numbers on dependency declarations

This PR also includes a few updates to the moduleTemplate and to move things forward for Gradle 7


#### Changes
* Remove gradlePlugin type (no longer included under regular enlistment) and update module paths in comments
* Adjust moduleTemplate for removal of appendNavTrail in favor of addNavTrail
* Add missing dependency version numbers for some base module dependencies
* Parameterize path for server module project and config project (allowing for them to be separate)
* Remove additional assumptions on presence of server modules project when not needed
* Update configurations in JavaModule plugin to no longer reference the compile configuration (being deprecated for dependency resolution)