### PR TITLE
Publish v1.17.1 and move to next snapshot version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,16 @@ on how to do that, including how to develop and test locally and the versioning 
 
 ## Release Notes
 
+### version 1.17.1
+*Released*: 13 September 2020
+(Earliest compatible LabKey version: 20.9)
+* Add explicit dependency between the process*Resources tasks and the npmRun task since we may produce *.lib.xml files
+from npmRun now
+* When finding lib.xml files to compress, don't use a cached map of these files since they may now be being created by npm
+
 ### version 1.17.0
 *Released*: 10 September 2020
-(Earliest compatible LabKey verson: 20.9)
+(Earliest compatible LabKey version: 20.9)
 * Remove gradlePlugin type (no longer included under regular enlistment) and update module paths in comments
 * Adjust moduleTemplate for removal of appendNavTrail in favor of addNavTrail
 * Add missing dependency version numbers for some base module dependencies

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     api "org.ajoberstar.grgit:grgit-gradle:${grgitGradleVersion}"
 }
 
-project.version = "1.17.1"
+project.version = "1.18.0-SNAPSHOT"
 
 if (project.file("moduleTemplate").exists())
 {

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     api "org.ajoberstar.grgit:grgit-gradle:${grgitGradleVersion}"
 }
 
-project.version = "1.17.1-SNAPSHOT"
+project.version = "1.17.1"
 
 if (project.file("moduleTemplate").exists())
 {


### PR DESCRIPTION
#### Changes
* Update for release 1.17.1 and move back to 1.18.0-SNAPSHOT version
