### PR TITLE
Add support for relocation of webapps directory under server/configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ on how to do that, including how to develop and test locally and the versioning 
 (Earliest compatible LabKey version: 20.9)
 * Make sure we don't duplicate the .module suffix in the groupId for modules dependencies
 * Prepare for relocation of webapps directory under server/configs/webapps
+* Make external config extend from runtimeOnly so we pick up those jars in the module's lib directory as well.
 
 ### version 1.18.0
 *Release*: 17 September 2020

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ on how to do that, including how to develop and test locally and the versioning 
 
 ## Release Notes
 
+### version TBD
+*Released*: TBD
+(Earliest compatible LabKey version: 20.9)
+* Make sure we don't duplicate the .module suffix in the groupId for modules dependencies
+* Prepare for relocation of webapps directory under server/configs/webapps
+
 ### version 1.18.0
 *Release*: 17 September 2020
 (Earliest compatible LabKey version: 20.9)

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     api "org.ajoberstar.grgit:grgit-gradle:${grgitGradleVersion}"
 }
 
-project.version = "1.19.0-configReorg-SNAPSHOT"
+project.version = "1.19.0-SNAPSHOT"
 
 if (project.file("moduleTemplate").exists())
 {

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     api "org.ajoberstar.grgit:grgit-gradle:${grgitGradleVersion}"
 }
 
-project.version = "1.19.0-SNAPSHOT"
+project.version = "1.19.0-configReorg-SNAPSHOT"
 
 if (project.file("moduleTemplate").exists())
 {

--- a/src/main/groovy/org/labkey/gradle/plugin/JavaModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/JavaModule.groovy
@@ -99,9 +99,10 @@ class JavaModule extends FileModule
                     // TODO I think what's really wanted here is external.extendsFrom(api) and external.extendsFrom(implementation)
                     // Then we change the gradle files to use api and implementation as per usual.  Perhaps we can then do away with
                     // external altogether if we also get rid of jars.txt and we'll just copy from the api and implementation configurations
-                    // into explodedModule/lib. (Will also want to accommodate runtimeOnly)
+                    // into explodedModule/lib.
                     api.extendsFrom(external)
                     implementation.extendsFrom(external)
+                    external.extendsFrom(runtimeOnly)
                     implementation.extendsFrom(labkey)
                     dedupe {
                         canBeConsumed = false
@@ -235,6 +236,7 @@ class JavaModule extends FileModule
             return null
 
         config = labkeyConfig == null ? config : (config == null ? labkeyConfig : config + labkeyConfig)
+
 
         // trim nothing from api
         if (BuildUtils.isApi(project))

--- a/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
@@ -55,7 +55,7 @@ class ServerDeploy implements Plugin<Project>
         serverDeploy.modulesDir = "${serverDeploy.dir}/modules"
         serverDeploy.webappDir = "${serverDeploy.dir}/labkeyWebapp"
         serverDeploy.binDir = "${serverDeploy.dir}/bin"
-        serverDeploy.rootWebappsDir = "${project.rootDir}/webapps"
+        serverDeploy.rootWebappsDir = BuildUtils.getWebappConfigPath(project)
         serverDeploy.pipelineLibDir = "${serverDeploy.dir}/pipelineLib"
         addTasks(project)
     }

--- a/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
@@ -106,9 +106,9 @@ class DoThenSetup extends DefaultTask
             Properties configProperties = databaseProperties.getConfigProperties()
             configProperties.setProperty("appDocBase", appDocBase)
             boolean isNextLineComment = false
-
+            String webappsDir = BuildUtils.getWebappConfigPath(project)
             project.copy({ CopySpec copy ->
-                copy.from "${project.rootProject.projectDir}/webapps"
+                copy.from webappsDir
                 copy.into "${project.rootProject.buildDir}"
                 copy.include "labkey.xml"
                 copy.filter({ String line ->

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -16,6 +16,7 @@
 package org.labkey.gradle.util
 
 import org.apache.commons.lang3.StringUtils
+import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.initialization.Settings
 import org.gradle.api.invocation.Gradle
@@ -66,8 +67,6 @@ class BuildUtils
             "externalModules/snprcEHRModules",
             "externalModules/DISCVR"
     ]
-
-    public static final List<String> EXTERNAL_MODULE_DIRS = ["externalModules/scharp"] + EHR_EXTERNAL_MODULE_DIRS
 
     // matches on: name-X.Y.Z-SNAPSHOT.jar, name-X.Y.Z.word[-SNAPSHOT][-classifier].jar, name-X.Y.Z-SNAPSHOT-classifier.jar, name-X.Y.Z_branch-SNAPSHOT.jar, name-X.Y.Z_branch-SNAPSHOT-classifier.extension name-X.Y.Z.extension
     // Groups are:
@@ -748,5 +747,15 @@ class BuildUtils
     static String getProjectPath(Gradle gradle, String propertyName, String defaultValue)
     {
         return gradle.hasProperty(propertyName) ? gradle.getProperty(propertyName) : defaultValue
+    }
+
+    static String getWebappConfigPath(Project project)
+    {
+        if (project.rootProject.file("webapps").exists())
+            return "${project.rootProject.projectDir}/webapps/"
+        else if (project.rootProject.file("server/configs/webapps").exists())
+            return "${project.rootProject.projectDir}/server/configs/webapps/"
+        else
+            throw new GradleException("Unable to find webapps config directory")
     }
 }

--- a/src/main/groovy/org/labkey/gradle/util/PomFileHelper.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/PomFileHelper.groovy
@@ -125,7 +125,7 @@ class PomFileHelper
                 depNode.appendNode("scope", pomProperties.getProperty("scope"))
                 if (isModulePom) {
                     depNode.appendNode("type", pomProperties.getProperty("type"))
-                    depNode.appendNode("groupId", (it.group.endsWith(".module") ? it.group : it.group + ".module")
+                    depNode.appendNode("groupId", (it.group.endsWith(".module") ? it.group : it.group + ".module"))
                 } else {
                     depNode.appendNode("groupId", it.group)
                 }

--- a/src/main/groovy/org/labkey/gradle/util/PomFileHelper.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/PomFileHelper.groovy
@@ -125,7 +125,7 @@ class PomFileHelper
                 depNode.appendNode("scope", pomProperties.getProperty("scope"))
                 if (isModulePom) {
                     depNode.appendNode("type", pomProperties.getProperty("type"))
-                    depNode.appendNode("groupId", it.group + ".module")
+                    depNode.appendNode("groupId", (it.group.endsWith(".module") ? it.group : it.group + ".module")
                 } else {
                     depNode.appendNode("groupId", it.group)
                 }


### PR DESCRIPTION
#### Rationale
We plan to move the `webapps` directory from its current location as a sibling of the `server` directory under the `server/configs` directory.  We introduce changes here to support either location and throw an exception if the directory cannot be found in either place.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Make sure we don't duplicate the .module suffix in the groupId for modules dependencies
* Add utility method for getting the location of the webapps directory so we can easily look for it in its current location and the planned new location
* Make `external` config extend from `runtimeOnly` so we can property declare such dependencies and have them show up in the module
