### PR TITLE
Allow resource reloading on TeamCity

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 ## Release Notes
 
+### version 1.18.1
+*Release*: ??
+(Earliest compatible LabKey version: 20.9)
+* Add TeamCity property to allow LabKey to load resources from module source
+
 ### version 1.18.0
 *Release*: 17 September 2020
 (Earliest compatible LabKey version: 20.9)

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     api "org.ajoberstar.grgit:grgit-gradle:${grgitGradleVersion}"
 }
 
-project.version = "1.19.0-SNAPSHOT"
+project.version = "1.19.0-teamcityResourceReloading-SNAPSHOT"
 
 if (project.file("moduleTemplate").exists())
 {

--- a/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
@@ -70,10 +70,7 @@ class TeamCity extends Tomcat
             project.tomcat.trustStorePassword = "-Djavax.net.ssl.trustStorePassword=changeit"
         }
         project.tomcat.disableRecompileJsp = true
-        if (extension.getTeamCityProperty("allowResourceReloading", null) == null)
-        {
-            project.tomcat.ignoreModuleSource = true
-        }
+        project.tomcat.ignoreModuleSource = !(Boolean) extension.getTeamCityProperty("allowResourceReloading", false)
         project.tomcat.debugPort = extension.getTeamCityProperty("tomcat.debug") // Tomcat intermittently hangs on shutdown if we don't specify a debug port
         project.tomcat.catalinaOpts = "-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=${project.tomcat.debugPort} -Dproject.root=${project.rootProject.projectDir.absolutePath} -Xnoagent -Djava.compiler=NONE"
 

--- a/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
@@ -69,9 +69,9 @@ class TeamCity extends Tomcat
             project.tomcat.trustStore = "-Djavax.net.ssl.trustStore=${project.tomcat.catalinaHome}/localhost.truststore"
             project.tomcat.trustStorePassword = "-Djavax.net.ssl.trustStorePassword=changeit"
         }
+        project.tomcat.disableRecompileJsp = true
         if (extension.getTeamCityProperty("allowResourceReloading", null) == null)
         {
-            project.tomcat.disableRecompileJsp = true
             project.tomcat.ignoreModuleSource = true
         }
         project.tomcat.debugPort = extension.getTeamCityProperty("tomcat.debug") // Tomcat intermittently hangs on shutdown if we don't specify a debug port

--- a/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
@@ -69,8 +69,11 @@ class TeamCity extends Tomcat
             project.tomcat.trustStore = "-Djavax.net.ssl.trustStore=${project.tomcat.catalinaHome}/localhost.truststore"
             project.tomcat.trustStorePassword = "-Djavax.net.ssl.trustStorePassword=changeit"
         }
-        project.tomcat.disableRecompileJsp = true
-        project.tomcat.ignoreModuleSource = true
+        if (extension.getTeamCityProperty("allowResourceReloading", null) == null)
+        {
+            project.tomcat.disableRecompileJsp = true
+            project.tomcat.ignoreModuleSource = true
+        }
         project.tomcat.debugPort = extension.getTeamCityProperty("tomcat.debug") // Tomcat intermittently hangs on shutdown if we don't specify a debug port
         project.tomcat.catalinaOpts = "-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=${project.tomcat.debugPort} -Dproject.root=${project.rootProject.projectDir.absolutePath} -Xnoagent -Djava.compiler=NONE"
 


### PR DESCRIPTION
#### Rationale
The module editor needs access to the modules source location. 

#### Changes
* Add TeamCity property to allow LabKey to load resources from module source
