### PR TITLE
Add deprecation message about ModuleDependencies moving to build.gradle files

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ on how to do that, including how to develop and test locally and the versioning 
 * Prepare for relocation of webapps directory under server/configs/webapps
 * Make external config extend from runtimeOnly so we pick up those jars in the module's lib directory as well.
 * Add TeamCity property to allow LabKey to load resources from module source
+* Officially Deprecate the use of `ModuleDependencies` in the `module.properties` file
 
 ### version 1.18.0
 *Release*: 17 September 2020

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     api "org.ajoberstar.grgit:grgit-gradle:${grgitGradleVersion}"
 }
 
-project.version = "1.19.0-SNAPSHOT"
+project.version = "1.19.0-propDeprecation-SNAPSHOT"
 
 if (project.file("moduleTemplate").exists())
 {

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     api "org.ajoberstar.grgit:grgit-gradle:${grgitGradleVersion}"
 }
 
-project.version = "1.19.0-propDeprecation-SNAPSHOT"
+project.version = "1.19.0-SNAPSHOT"
 
 if (project.file("moduleTemplate").exists())
 {

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/ModuleExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/ModuleExtension.groovy
@@ -74,8 +74,14 @@ class ModuleExtension
     {
         this.modProperties = new Properties()
         File propertiesFile = project.file(MODULE_PROPERTIES_FILE)
-        if (propertiesFile.exists())
+        if (propertiesFile.exists()) {
             PropertiesUtils.readProperties(propertiesFile, this.modProperties)
+            if (this.modProperties.get(MODULE_DEPENDENCIES_PROPERTY))
+                project.logger.quiet("${propertiesFile.absolutePath}: Use of the '" + MODULE_DEPENDENCIES_PROPERTY + "' property in " + MODULE_PROPERTIES_FILE + " has been deprecated and will be removed with the 21.3.0 release of LabKey Server." +
+                        " Declare the dependency in the module's build.gradle file instead using the 'modules' configuration." +
+                        " See https://www.labkey.org/Documentation/wiki-page.view?name=gradleDepend for more information.")
+
+        }
         else
             project.logger.info("${project.path} - no ${MODULE_PROPERTIES_FILE} found")
 


### PR DESCRIPTION
#### Rationale
We want to remove support for the use of ModuleDependencies from the `module.properties` file as it doesn't allow us to add the module dependencies to the pom files for the `.module` files. 

<img width="1324" alt="Screen Shot 2020-10-14 at 9 19 50 AM" src="https://user-images.githubusercontent.com/11431178/96017273-a8d02680-0dfe-11eb-9447-34a5e13de35d.png">

(I don't know why the log message appears twice, but I'm not going to worry too much about it unless it's really a problem.)
#### Changes
* Add deprecation warning message.
