### PR TITLE
Fix distribution names for full Git enlistment

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 ## Release Notes
 
+### version ???
+*Released*: TBD
+(Earliest compatible LabKey version: 20.9)
+* Fix distribution and module versioning to work with Git server respository
+
 ### version 1.19.0
 *Released*: 14 October 2020
 (Earliest compatible LabKey version: 20.9)

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     api "org.ajoberstar.grgit:grgit-gradle:${grgitGradleVersion}"
 }
 
-project.version = "1.20.0-SNAPSHOT"
+project.version = "1.20.0_distributionNames-SNAPSHOT"
 
 if (project.file("moduleTemplate").exists())
 {

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     api "org.ajoberstar.grgit:grgit-gradle:${grgitGradleVersion}"
 }
 
-project.version = "1.20.0_distributionNames-SNAPSHOT"
+project.version = "1.20.0-SNAPSHOT"
 
 if (project.file("moduleTemplate").exists())
 {

--- a/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
@@ -213,7 +213,6 @@ class FileModule implements Plugin<Project>
                     jar.exclude "META-INF/${project.name}/**"
                     jar.exclude 'gwt-unitCache/**'
                     jar.archiveBaseName.set(project.name)
-                    jar.archiveVersion.set(BuildUtils.getModuleFileVersion(project))
                     jar.archiveExtension.set('module')
                     jar.destinationDirectory = project.buildDir
             }

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/TeamCityExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/TeamCityExtension.groovy
@@ -64,8 +64,8 @@ class TeamCityExtension
         else
         {
             String name = getTeamCityProperty("teamcity.buildType.id")
-            if (!(Boolean) getTeamCityProperty("teamcity.build.branch.is_default", true))
-                name = "${getTeamCityProperty('teamcity.build.branch')}_${name}"
+            if (!isBuildBranchDefault())
+                name = "${getBuildBranch()}_${name}"
             this.databaseName = name.replaceAll("[/\\.\\s-]", "_")
             String dropProperty = getTeamCityProperty('drop.database')
             this.dropDatabase = dropProperty.equals("1") || dropProperty.equalsIgnoreCase("true")
@@ -102,6 +102,16 @@ class TeamCityExtension
             props.setJdbcPassword(getTeamCityProperty("database.${typeAndVersion}.password"))
 
         this.databaseTypes.add(props)
+    }
+
+    String getBuildBranch()
+    {
+        getTeamCityProperty('teamcity.build.branch')
+    }
+
+    boolean isBuildBranchDefault()
+    {
+        (Boolean) getTeamCityProperty("teamcity.build.branch.is_default", true)
     }
 
     static boolean isOnTeamCity(Project project)

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -358,7 +358,8 @@ class BuildUtils
         if (project.hasProperty("versioning"))
         {
             String branch = project.versioning.info.branchId
-            if (!["trunk", "develop", ""].contains(branch) && !branch.toLowerCase().matches("release.*-snapshot"))
+            if (!["trunk", "develop", "master", "main", "none", ""].contains(branch) &&
+                    !branch.toLowerCase().matches("release.*-snapshot"))
             {
                 Matcher matcher = Pattern.compile(".*fb_(.+)").matcher(branch)
                 if (matcher.matches()) {
@@ -379,7 +380,7 @@ class BuildUtils
      *     (Beta means we are in a release branch, but have not yet released and updated from the snapshot version)
      *     Release - 20.11.0-1 (<Current labkeyVersion>-[<VCSRevision>.]<BuildNumber>)
      * See Issue 31165.
-     * @param project the distribution project. e.g. ':distributions:community'
+     * @param project the distribution project. e.g. project(':distributions:community')
      * @return the version string for this distribution project
      */
     static String getDistributionVersion(Project project)


### PR DESCRIPTION
#### Rationale
Now that we are all in Git, the distribution archives include the entire commit hash, which is too long and not very useful. Additionally, we don't quite handle the case where there is no vcs information available (branchId comes back as blank, not "none"). While I was in here, I removed some old code for handling alpha release branches, which we haven't used since 19.1.
I also changed this to reference TeamCity's branch information, since we rarely create feature branches in the 'distributions' or 'server' repositories. This will allow distributions built on feature branches to be named accordingly on TeamCity.

#### Changes
* Don't include the vcs revision in distribution file names
* Use TeamCity branch information in module versions
* Remove `-bin` from distribution archive names
* Clean up now redundant methods in `ModuleDistribution.groovy`
