### PR TITLE
Avoid problem from AntBuilder trying to resolve the tomcatJars configuration during pickMssql

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 ## Release Notes
 
+### version 1.21.1
+*Released*: TBD
+(Earliest compatible LabKey version: 20.9)
+* Resolve the tomcatJars configuration before adding files to the ant task that copies them
+
 ### version 1.21.0
 *Released*: 4 November 2020
 (Earliest compatible LabKey version: 20.9)

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     api "org.ajoberstar.grgit:grgit-gradle:${grgitGradleVersion}"
 }
 
-project.version = "1.22.0-SNAPSHOT"
+project.version = "1.22.0-pickDbForTC-SNAPSHOT"
 
 if (project.file("moduleTemplate").exists())
 {

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     api "org.ajoberstar.grgit:grgit-gradle:${grgitGradleVersion}"
 }
 
-project.version = "1.22.0-pickDbForTC-SNAPSHOT"
+project.version = "1.21.1-SNAPSHOT"
 
 if (project.file("moduleTemplate").exists())
 {

--- a/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
@@ -166,6 +166,12 @@ class DoThenSetup extends DefaultTask
         // for consistency with a distribution deployment and the treatment of all other deployment artifacts,
         // first copy the tomcat jars into the staging directory
 
+        // We resolve the tomcatJars files outside of the ant copy because this seems to avoid
+        // an error we saw on TeamCity when running the pickMssql task on Windows when updating to Gradle 6.7
+        // The error in the gradle log was:
+        //       org.apache.tools.ant.BuildException: copy doesn't support the nested "exec" element.
+        // Theory is that when the files in the configuration have not been resolved, they get resolved
+        // inside the node being added to the ant task below and that is not supported.
         Set<File> tomcatFiles = serverProject.configurations.tomcatJars.files
         this.logger.info("Copying to ${project.staging.tomcatLibDir}")
         this.logger.info("tomcatFiles are ${tomcatFiles}")

--- a/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
@@ -18,6 +18,7 @@ package org.labkey.gradle.task
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.CopySpec
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.Input
@@ -27,6 +28,7 @@ import org.labkey.gradle.plugin.ServerDeploy
 import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.DatabaseProperties
 import org.labkey.gradle.util.PropertiesUtils
+
 
 class DoThenSetup extends DefaultTask
 {
@@ -164,7 +166,7 @@ class DoThenSetup extends DefaultTask
         // for consistency with a distribution deployment and the treatment of all other deployment artifacts,
         // first copy the tomcat jars into the staging directory
 
-        FileCollection tomcatFiles = serverProject.configurations.tomcatJars.fileCollection
+        Set<File> tomcatFiles = serverProject.configurations.tomcatJars.files
         this.logger.info("Copying to ${project.staging.tomcatLibDir}")
         this.logger.info("tomcatFiles are ${tomcatFiles}")
         project.ant.copy(
@@ -173,7 +175,9 @@ class DoThenSetup extends DefaultTask
                 overwrite: true // Issue 33473: overwrite the existing jars to facilitate switching to older versions of labkey with older dependencies
         )
             {
-                tomcatFiles.addToAntBuilder(project.ant, 'fileset', FileCollection.AntType.FileSet)
+                serverProject.configurations.tomcatJars { Configuration collection ->
+                    collection.addToAntBuilder(project.ant, "fileset", FileCollection.AntType.FileSet)
+                }
 
                 // Put unversioned files into the tomcatLibDir.  These files are meant to be copied into
                 // the tomcat/lib directory when deploying a build or a distribution.  When version numbers change,

--- a/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
@@ -18,7 +18,6 @@ package org.labkey.gradle.task
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.Project
-import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.CopySpec
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.Input
@@ -92,29 +91,29 @@ class DoThenSetup extends DefaultTask
                 copy.into "${project.rootProject.buildDir}"
                 copy.include "labkey.xml"
                 copy.filter({ String line ->
-                    String newLine = line;
+                    String newLine = line
 
                     if (project.ext.has('enableJms') && project.ext.enableJms)
                     {
-                        newLine = newLine.replace("<!--@@jmsConfig@@", "");
-                        newLine = newLine.replace("@@jmsConfig@@-->", "");
-                        return newLine;
+                        newLine = newLine.replace("<!--@@jmsConfig@@", "")
+                        newLine = newLine.replace("@@jmsConfig@@-->", "")
+                        return newLine
                     }
                     // If we want to automatically enable an LDAP Sync that is hardcoded in the labkey.xml
                     // for testing purposes, this will uncomment that stanza if the enableLdapSync
                     // property is defined.
                     if (project.hasProperty('enableLdapSync'))
                     {
-                        newLine = newLine.replace("<!--@@ldapSyncConfig@@", "");
-                        newLine = newLine.replace("@@ldapSyncConfig@@-->", "");
-                        return newLine;
+                        newLine = newLine.replace("<!--@@ldapSyncConfig@@", "")
+                        newLine = newLine.replace("@@ldapSyncConfig@@-->", "")
+                        return newLine
                     }
                     if (isNextLineComment || newLine.contains("<!--"))
                     {
-                        isNextLineComment = !newLine.contains("-->");
-                        return newLine;
+                        isNextLineComment = !newLine.contains("-->")
+                        return newLine
                     }
-                    return PropertiesUtils.replaceProps(line, configProperties, true);
+                    return PropertiesUtils.replaceProps(line, configProperties, true)
                 })
             })
 
@@ -137,7 +136,7 @@ class DoThenSetup extends DefaultTask
     boolean labkeyXmlUpToDate(String appDocBase)
     {
         if (this.dbPropertiesChanged)
-            return false;
+            return false
 
         File dbPropFile = DatabaseProperties.getPickedConfigFile(project)
         File tomcatLabkeyXml = new File("${project.tomcat.tomcatConfDir}", "labkey.xml")
@@ -165,17 +164,17 @@ class DoThenSetup extends DefaultTask
         // for consistency with a distribution deployment and the treatment of all other deployment artifacts,
         // first copy the tomcat jars into the staging directory
 
+        FileCollection tomcatFiles = serverProject.configurations.tomcatJars.fileCollection
         this.logger.info("Copying to ${project.staging.tomcatLibDir}")
+        this.logger.info("tomcatFiles are ${tomcatFiles}")
         project.ant.copy(
-
                 todir: project.staging.tomcatLibDir,
                 preserveLastModified: true,
                 overwrite: true // Issue 33473: overwrite the existing jars to facilitate switching to older versions of labkey with older dependencies
         )
             {
-                serverProject.configurations.tomcatJars { Configuration collection ->
-                    collection.addToAntBuilder(project.ant, "fileset", FileCollection.AntType.FileSet)
-                }
+                tomcatFiles.addToAntBuilder(project.ant, 'fileset', FileCollection.AntType.FileSet)
+
                 // Put unversioned files into the tomcatLibDir.  These files are meant to be copied into
                 // the tomcat/lib directory when deploying a build or a distribution.  When version numbers change,
                 // you will end up with multiple versions of these jar files on the classpath, which will often


### PR DESCRIPTION
#### Rationale
We resolve the tomcatJars files outside of the ant copy because this seems to avoid an error we saw on TeamCity when running the pickMssql task on Windows when updating to Gradle 6.7.  The error in the build log was:
```
     org.apache.tools.ant.BuildException: copy doesn't support the nested "exec" element.
```
The theory is that when the files in the configuration have not been resolved, they get resolved inside the node being added to the ant task below and that is not supported.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/3

#### Changes
* Resolve the tomcatJars configuration before adding files to the ant task that copies them