### PR TITLE
Fix distribution filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 ## Release Notes
 
+### version 1.21.2
+*Released*: TBD
+(Earliest compatible LabKey version: 20.9)
+* Fix distribution filenames; use '-' to separate version from build number.
+
 ### version 1.21.1
 *Released*: 5 November 2020
 (Earliest compatible LabKey version: 20.9)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ on how to do that, including how to develop and test locally and the versioning 
 ### version 1.21.2
 *Released*: TBD
 (Earliest compatible LabKey version: 20.9)
-* Fix distribution filenames; use '-' to separate version from build number.
+* Fix distribution filenames; use '-' to separate version from build number
+* Include unique TeamCity build ID in module.xml properties
 
 ### version 1.21.1
 *Released*: 5 November 2020

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     api "org.ajoberstar.grgit:grgit-gradle:${grgitGradleVersion}"
 }
 
-project.version = "1.22.0-SNAPSHOT"
+project.version = "1.21.2-distName-SNAPSHOT"
 
 if (project.file("moduleTemplate").exists())
 {

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     api "org.ajoberstar.grgit:grgit-gradle:${grgitGradleVersion}"
 }
 
-project.version = "1.21.2-distName-SNAPSHOT"
+project.version = "1.21.2-SNAPSHOT"
 
 if (project.file("moduleTemplate").exists())
 {


### PR DESCRIPTION
#### Rationale
Previous distribution name change didn't result in the agreed filename pattern. Should be `LabKey20.11.0-1-test.tar.gz` instead of `LabKey20.11.0.1-test.tar.gz`.

#### Related Pull Requests
* #95 

#### Changes
* Use '-' to separate version from build number
* Include unique TeamCity build ID in `module.xml` properties
