### PR TITLE
Update createModule so it adds a build.gradle file

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ on how to do that, including how to develop and test locally and the versioning 
 *Released*: TBD
 (Earliest compatible LabKey version: 21.1)
 * Add build.gradle file to module created with `createModule` task.
+* Fix relative path input for `createModule` so it is relative to the current directory not the gradle Daemon
 
 ### version 1.22.0
 *Released*: 7 December 2020

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ If you are making changes to the plugins, please see the [internal docs](https:/
 on how to do that, including how to develop and test locally and the versioning information.
 
 ## Release Notes
+### version TBD
+*Released*: TBD
+(Earliest compatible LabKey version: 21.1)
+* Add build.gradle file to module created with `createModule` task.
+
 ### version 1.22.0
 *Released*: 7 December 2020
 (Earliest compatible LabKey version: 21.1)

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.23.0-SNAPSHOT"
+project.version = "1.23.0-addBuildPlugins-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.23.0-addBuildPlugins-SNAPSHOT"
+project.version = "1.23.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/moduleTemplate/build.gradle
+++ b/moduleTemplate/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'org.labkey.build.module'
+}

--- a/src/main/groovy/org/labkey/gradle/task/CreateModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/CreateModule.groovy
@@ -47,7 +47,7 @@ class CreateModule extends DefaultTask
         }
         else {
             project.ant.input(
-                    message: "\nEnter the name for your new module: ",
+                    message: "\nEnter the (Java) name for your new module: ",
                     addProperty: "new_moduleName"
             )
             moduleName = ant.new_moduleName.trim()
@@ -65,7 +65,7 @@ class CreateModule extends DefaultTask
         }
         else {
             project.ant.input(
-                    message: "\nEnter the location for the new module (absolute or relative to '" + new File("").getAbsolutePath() + "'): ",
+                    message: "\nEnter the location for the new module (absolute or relative to '" + project.projectDir.getAbsolutePath() + "'): ",
                     addProperty: "new_moduleDestination"
             )
             moduleDestination = ant.new_moduleDestination.trim()
@@ -73,7 +73,7 @@ class CreateModule extends DefaultTask
         if (moduleDestination == null || moduleDestination == "") {
             throw new GradleException("moduleDestination is not specified")
         }
-        File moduleDestinationFile = new File(moduleDestination).getAbsoluteFile()
+        File moduleDestinationFile = project.file(moduleDestination).getAbsoluteFile()
         if (moduleDestinationFile.exists())
         {
             ant.input(


### PR DESCRIPTION
#### Rationale
We plan to remove the `server/modules/build.gradle` file that has logic to apply plugins for subprojects since that logic is only a heuristic and fails to do the right thing for file-based modules that include only client source code.  Instead, we will update each module's own `build.gradle` file so it applies the appropriate plugins (and add `build.gradle` files where there are none).  When creating modules from our template, they should therefore have a `build.gradle``file included 

#### Changes
* Add a `build.gradle` file to the module template
* Fix the input of the relative path so it can be relative to the current project's directory instead of the Gradle daemon's directory.
