### PR TITLE
Issue 42227: Don't automatically clean the embedded deploy directory with deployApp

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ If you are making changes to the plugins, please see the [internal docs](https:/
 on how to do that, including how to develop and test locally and the versioning information.
 
 ## Release Notes
+### TBD
+*Released*: TBD
+(Earliest compatible LabKey version: 21.1)
+* [Issue 42227](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42227) 
+  Don't automatically clean the embedded deploy directory since it won't get copied to if the deployApp task is otherwise up-to-date
+
 ### version 1.23.0
 *Released*: 7 January 2021
 (Earliest compatible LabKey version: 21.1)

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.24.0-SNAPSHOT"
+project.version = "1.24.0-embeddedDeployAppFix-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.24.0-embeddedDeployAppFix-SNAPSHOT"
+project.version = "1.24.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
@@ -239,7 +239,7 @@ class ServerDeploy implements Plugin<Project>
                         project.delete project.serverDeploy.embeddedDir
                     }
             }
-            project.tasks.deployApp.dependsOn(project.tasks.cleanEmbeddedDeploy)
+            project.tasks.deployApp.mustRunAfter(project.tasks.cleanEmbeddedDeploy)
             project.tasks.stageApp.dependsOn(embeddedProject.tasks.build)
             project.tasks.setup.mustRunAfter(project.tasks.cleanEmbeddedDeploy)
             project.tasks.deployApp.doLast({
@@ -314,6 +314,7 @@ class ServerDeploy implements Plugin<Project>
                     spec.delete serverDeploy.dir
                 })
         }
+        project.tasks.deployApp.mustRunAfter(project.tasks.cleanDeploy)
 
         project.tasks.register("cleanTomcatLib") {
             Task task ->
@@ -341,6 +342,7 @@ class ServerDeploy implements Plugin<Project>
                     spec.delete project.rootProject.buildDir
                 })
         }
+        project.tasks.deployApp.mustRunAfter(project.tasks.cleanBuild)
 
 
     }


### PR DESCRIPTION
#### Rationale
The dependencies for the `deployApp` command were incorrectly set to include the `cleanEmbeddedDeploy` command.  This results in the embedded jar file being removed and possibly not replaced when a `deployApp` is run after changing other modules.  This should have actually been a `mustRunAfter` constraint so that a cleaning won't happen after the `deployApp` if both are on the command line.

#### Changes
* Update dependencies for `deployApp` relative to various cleaning tasks.
