### PR TITLE
Enable configuring an additional data source when deploying on TeamCity

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ If you are making changes to the plugins, please see the [internal docs](https:/
 on how to do that, including how to develop and test locally and the versioning information.
 
 ## Release Notes
+### version 1.24.0
+*Released*: TBD
+(Earliest compatible LabKey version: 21.2)
+* Automated configuration of additional data sources
+
 ### version 1.23.0
 *Released*: 7 January 2021
 (Earliest compatible LabKey version: 21.1)

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.24.0_extraDataSource-SNAPSHOT"
+project.version = "1.24.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.24.0-SNAPSHOT"
+project.version = "1.24.0_extraDataSource-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/TeamCityExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/TeamCityExtension.groovy
@@ -141,6 +141,18 @@ class TeamCityExtension
             return defaultValue
     }
 
+    static Properties getTeamCityProperties(Project project)
+    {
+        if (isOnTeamCity(project))
+        {
+            def tcProps = new Properties()
+            tcProps.putAll(project.teamcity)
+            return tcProps
+        }
+        else
+            return new Properties()
+    }
+
     static String getLabKeyServer(Project project)
     {
         return getTeamCityProperty(project, "labkey.server", "http://localhost")

--- a/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
@@ -158,6 +158,10 @@ class DoThenSetup extends DefaultTask
                             line = line.replace("#context.webAppLocation=", "context.webAppLocation=")
                             line = line.replace("#spring.devtools.restart.additional-paths=", "spring.devtools.restart.additional-paths=")
                         }
+                        if (databaseProperties.getProperty("extraJdbcDataSource"))
+                        {
+                            line = line.replace("#@@extraJdbcDataSource@@.", "")
+                        }
                         if (line.startsWith("#")) {
                             return line // Don't apply replacements to comments
                         }

--- a/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
@@ -94,29 +94,27 @@ class DoThenSetup extends DefaultTask
                     copy.into "${project.rootProject.buildDir}"
                     copy.include "labkey.xml"
                     copy.filter({ String line ->
-                        String newLine = line
-
                         if (project.ext.has('enableJms') && project.ext.enableJms) {
-                            newLine = newLine.replace("<!--@@jmsConfig@@", "")
-                            newLine = newLine.replace("@@jmsConfig@@-->", "")
-                            return newLine
+                            line = line.replace("<!--@@jmsConfig@@", "")
+                            line = line.replace("@@jmsConfig@@-->", "")
+                            return line
                         }
                         // If we want to automatically enable an LDAP Sync that is hardcoded in the labkey.xml
                         // for testing purposes, this will uncomment that stanza if the enableLdapSync
                         // property is defined.
                         if (project.hasProperty('enableLdapSync')) {
-                            newLine = newLine.replace("<!--@@ldapSyncConfig@@", "")
-                            newLine = newLine.replace("@@ldapSyncConfig@@-->", "")
-                            return newLine
+                            line = line.replace("<!--@@ldapSyncConfig@@", "")
+                            line = line.replace("@@ldapSyncConfig@@-->", "")
+                            return line
                         }
                         if (project.hasProperty("extraJdbcDataSource"))
                         {
-                            newLine = newLine.replace("<!--@@extraJdbcDataSource@@", "")
-                            newLine = newLine.replace("@@extraJdbcDataSource@@-->", "")
+                            line = line.replace("<!--@@extraJdbcDataSource@@", "")
+                            line = line.replace("@@extraJdbcDataSource@@-->", "")
                         }
-                        if (isNextLineComment || newLine.contains("<!--")) {
-                            isNextLineComment = !newLine.contains("-->")
-                            return newLine // Don't apply replacements to comments
+                        if (isNextLineComment || line.contains("<!--")) {
+                            isNextLineComment = !line.contains("-->")
+                            return line // Don't apply replacements to comments
                         }
                         return PropertiesUtils.replaceProps(line, configProperties, true)
                     })

--- a/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
@@ -160,7 +160,7 @@ class DoThenSetup extends DefaultTask
                         }
                         if (databaseProperties.getProperty("extraJdbcDataSource"))
                         {
-                            line = line.replace("#@@extraJdbcDataSource@@.", "")
+                            line = line.replaceAll("^#(context\\..+\\[1].*)", "\$1")
                         }
                         if (line.startsWith("#")) {
                             return line // Don't apply replacements to comments


### PR DESCRIPTION
#### Rationale
We need a non-manual method to define a second data source in order to test Redshift on TeamCity.

#### Changes
* Pull `extraJdbc*` from TeamCity properties and inject them into `labkey.xml` and `application.properties` when deploying on TeamCity