### PR TITLE
Issue 42187: Throw exception when publishing artifacts or building distributions with deployMode=dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ on how to do that, including how to develop and test locally and the versioning 
 *Released*: TBD
 (Earliest compatible LabKey version: 21.1)
 * [Issue 42227](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42227) 
-  Don't automatically clean the embedded deploy directory since it won't get copied to if the deployApp task is otherwise up-to-date
+  Don't automatically clean the embedded deploy directory since it won't get copied to if the deployApp task is otherwise up-to-date\
+* [Issue 42187](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42187) 
+  Throw exceptions if trying to publish artifacts produced in dev mode or create distributions in dev mode. 
 
 ### version 1.23.0
 *Released*: 7 January 2021

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.24.0-SNAPSHOT"
+project.version = "1.24.0-noDevPublishing-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.24.0-noDevPublishing-SNAPSHOT"
+project.version = "1.24.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
@@ -15,6 +15,7 @@
  */
 package org.labkey.gradle.plugin
 
+import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -40,6 +41,10 @@ class Distribution implements Plugin<Project>
     @Override
     void apply(Project project)
     {
+        if (LabKeyExtension.isDevMode(project) && !project.hasProperty("devDistribution"))
+            throw new GradleException("Distributions should never be created with deployMode=dev as dev modules are not portable. " +
+                    "Use -PdevDistribution if you need to override this exception for debugging.")
+
         project.group = DISTRIBUTION_GROUP
         project.extensions.create("dist", DistributionExtension, project)
         // We add the TeamCity extension here if it doesn't exist because we will use the build
@@ -57,6 +62,7 @@ class Distribution implements Plugin<Project>
         addConfigurations(project)
         addTasks(project)
         addTaskDependencies(project)
+
         // commented out until we start publishing distribution artifacts, and then we'll examine the publications more closely
 //        if (BuildUtils.shouldPublishDistribution(project))
 //            addArtifacts(project)

--- a/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
@@ -41,10 +41,6 @@ class Distribution implements Plugin<Project>
     @Override
     void apply(Project project)
     {
-        if (LabKeyExtension.isDevMode(project) && !project.hasProperty("devDistribution"))
-            throw new GradleException("Distributions should never be created with deployMode=dev as dev modules are not portable. " +
-                    "Use -PdevDistribution if you need to override this exception for debugging.")
-
         project.group = DISTRIBUTION_GROUP
         project.extensions.create("dist", DistributionExtension, project)
         // We add the TeamCity extension here if it doesn't exist because we will use the build

--- a/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
@@ -457,6 +457,8 @@ class FileModule implements Plugin<Project>
 
                     if (BuildUtils.shouldPublish(project))
                     {
+                        if (LabKeyExtension.isDevMode(project))
+                            throw new GradleException("Modules produced with deployMode=dev are not portable and should never be published.")
                         project.artifactoryPublish {
                             if (project.hasProperty('module'))
                             {

--- a/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
@@ -16,12 +16,14 @@
 package org.labkey.gradle.task
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.file.CopySpec
 import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.file.FileTree
 import org.gradle.api.tasks.*
 import org.labkey.gradle.plugin.extension.DistributionExtension
+import org.labkey.gradle.plugin.extension.LabKeyExtension
 import org.labkey.gradle.plugin.extension.StagingExtension
 import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.PomFileHelper
@@ -111,6 +113,10 @@ class ModuleDistribution extends DefaultTask
     @TaskAction
     void doAction()
     {
+        if (LabKeyExtension.isDevMode(project) && !project.hasProperty("devDistribution"))
+            throw new GradleException("Distributions should never be created with deployMode=dev as dev modules are not portable. " +
+                    "Use -PdevDistribution if you need to override this exception for debugging.")
+
         if (makeDistribution)
             createDistributionFiles()
         gatherModules()


### PR DESCRIPTION
#### Rationale
Modules built in dev mode are not portable to other machines so we should never publish these to artifactory.  We should also  not build distributions in dev mode since these are built solely for use on other machines.  To ease debugging of distribution tasks, an escape-hatch property is made available so it isn't necessary to spend the extra time to build in production mode if just testing the logic of building a distribution.

#### Changes
* Check for devMode property settings in conjunction with publishing and producing distributions
