### PR TITLE
Add isOpenSource property to ModuleDistribution task to support packaging differently licensed libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ on how to do that, including how to develop and test locally and the versioning 
 * [Issue 42227](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42227) 
   Don't automatically clean the embedded deploy directory since it won't get copied to if the deployApp task is otherwise up-to-date
 * Enable configuring an additional data source when deploying on TeamCity 
-* Add isOpenSource property to ModuleDistribution task (default is false) to support packaging differently licensed libraries 
+* Add check for isOpenSource project property in Distribution plugin to support packaging differently licensed libraries 
 
 ### version 1.23.0
 *Released*: 7 January 2021

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ on how to do that, including how to develop and test locally and the versioning 
 * [Issue 42227](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42227) 
   Don't automatically clean the embedded deploy directory since it won't get copied to if the deployApp task is otherwise up-to-date
 * Enable configuring an additional data source when deploying on TeamCity 
+* Add isOpenSource property to ModuleDistribution task (default is false) to support packaging differently licensed libraries 
 
 ### version 1.23.0
 *Released*: 7 January 2021

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ If you are making changes to the plugins, please see the [internal docs](https:/
 on how to do that, including how to develop and test locally and the versioning information.
 
 ## Release Notes
-### TBD
-*Released*: TBD
+### 1.24.0
+*Released*: 21 January 2021
 (Earliest compatible LabKey version: 21.1)
 * [Issue 42227](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42227) 
   Don't automatically clean the embedded deploy directory since it won't get copied to if the deployApp task is otherwise up-to-date

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.24.0-SNAPSHOT"
+project.version = "1.24.0-senchaLicense-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -28,18 +28,6 @@ repositories {
     jcenter()
     maven {
         url "${artifactory_contextUrl}/libs-release"
-
-        if (hasProperty('artifactory_user') && hasProperty('artifactory_password'))
-        {
-            credentials {
-                username = artifactory_user
-                password = artifactory_password
-            }
-            authentication {
-                basic(BasicAuthentication)
-                // enable preemptive authentication to get around https://www.jfrog.com/jira/browse/RTFACT-4434
-            }
-        }
     }
 }
 
@@ -188,42 +176,43 @@ project.tasks.register("zipDistributionResources", Zip) {
 }
 project.tasks.processResources.dependsOn(project.tasks.zipDistributionResources)
 
-publishing {
-    repositories {
-        if (project.version.contains("SNAPSHOT")) {
-            maven {
-                url "${artifactory_contextUrl}/plugins-snapshot-local"
-                credentials {
-                    username = artifactory_user
-                    password = artifactory_password
-                }
-                authentication {
-                    basic(BasicAuthentication)
-                    // enable preemptive authentication to get around https://www.jfrog.com/jira/browse/RTFACT-4434
-                }
-            }
-        }
-        else {
-            maven {
-                url "${artifactory_contextUrl}/plugins-release"
-                credentials {
-                    username = artifactory_user
-                    password = artifactory_password
-                }
-                authentication {
-                    basic(BasicAuthentication)
-                    // enable preemptive authentication to get around https://www.jfrog.com/jira/browse/RTFACT-4434
-                }
-            }
-
-        }
-    }
-    publications {
-        maven(MavenPublication) {
-            artifactId = 'gradlePlugins'
-            from components.java
-        }
-    }
+if (hasProperty('artifactory_user') && hasProperty('artifactory_password'))
+{
+   publishing {
+       repositories {
+           if (project.version.contains("SNAPSHOT")) {
+               maven {
+                   url "${artifactory_contextUrl}/plugins-snapshot-local"
+                   credentials {
+                       username = artifactory_user
+                       password = artifactory_password
+                   }
+                   authentication {
+                       basic(BasicAuthentication)
+                       // enable preemptive authentication to get around https://www.jfrog.com/jira/browse/RTFACT-4434
+                   }
+               }
+           }
+           else {
+               maven {
+                   url "${artifactory_contextUrl}/plugins-release"
+                   credentials {
+                       username = artifactory_user
+                       password = artifactory_password
+                   }
+                   authentication {
+                       basic(BasicAuthentication)
+                       // enable preemptive authentication to get around https://www.jfrog.com/jira/browse/RTFACT-4434
+                   }
+               }
+   
+           }
+       }
+       publications {
+           maven(MavenPublication) {
+               artifactId = 'gradlePlugins'
+               from components.java
+           }
+       }
+   }
 }
-
-

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.24.0-senchaLicense-SNAPSHOT"
+project.version = "1.24.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
@@ -53,6 +53,8 @@ class Distribution implements Plugin<Project>
         // we also depend on the jar task from the embedded project, if available
         if (BuildUtils.useEmbeddedTomcat(project))
             project.evaluationDependsOn(BuildUtils.getEmbeddedProjectPath(project.gradle))
+        // for non-open-source distributions, we depend on a task from the api project. No need to di things differently for open source, though.
+        project.evaluationDependsOn(BuildUtils.getApiProjectPath(project.gradle))
         addConfigurations(project)
         addDependencies(project)
         addTasks(project)

--- a/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
@@ -130,7 +130,7 @@ class Distribution implements Plugin<Project>
         if (!BuildUtils.isOpenSource(project)) {
             project.tasks.register('patchApiModule', Jar) {
                 Jar jar ->
-                    jar.group = GroupNames.MODULE
+                    jar.group = GroupNames.DISTRIBUTION
                     jar.description = "Patches the api module to replace ExtJS libraries with commercial versions"
                     Project apiProject = project.project(BuildUtils.getApiProjectPath(project.gradle))
                     jar.archiveBaseName.set(apiProject.name)

--- a/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
@@ -53,8 +53,8 @@ class Distribution implements Plugin<Project>
         // we also depend on the jar task from the embedded project, if available
         if (BuildUtils.useEmbeddedTomcat(project))
             project.evaluationDependsOn(BuildUtils.getEmbeddedProjectPath(project.gradle))
-        addDependencies(project)
         addConfigurations(project)
+        addDependencies(project)
         addTasks(project)
         addTaskDependencies(project)
         // commented out until we start publishing distribution artifacts, and then we'll examine the publications more closely
@@ -67,8 +67,11 @@ class Distribution implements Plugin<Project>
         project.configurations
                 {
                     distribution
+                    extJsCommercial
                 }
         project.configurations.distribution.setDescription("Artifacts of creating a LabKey distribution (aka installer)")
+        project.configurations.extJsCommercial.setDescription("Module patched with extJs commercial license libraries")
+
         if (project.configurations.findByName("utilities") == null)
         {
             project.configurations
@@ -86,6 +89,7 @@ class Distribution implements Plugin<Project>
             project.dependencies {
                 utilities "org.labkey.tools.windows:utils:${project.windowsUtilsVersion}@zip"
             }
+        project.dependencies.add("extJsCommercial", project.dependencies.project(path: BuildUtils.getApiProjectPath(project.gradle), configuration: "extJsCommercial"))
     }
 
     private static void addTasks(Project project)

--- a/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
@@ -156,7 +156,7 @@ class DoThenSetup extends DefaultTask
                             line = line.replace("#context.webAppLocation=", "context.webAppLocation=")
                             line = line.replace("#spring.devtools.restart.additional-paths=", "spring.devtools.restart.additional-paths=")
                         }
-                        if (databaseProperties.hasProperty("extraJdbcDataSource") && databaseProperties.getProperty("extraJdbcDataSource"))
+                        if (databaseProperties.hasProperty("extraJdbcDataSource"))
                         {
                             line = line.replaceAll("^#(context\\..+\\[1].*)", "\$1")
                         }

--- a/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
@@ -156,7 +156,7 @@ class DoThenSetup extends DefaultTask
                             line = line.replace("#context.webAppLocation=", "context.webAppLocation=")
                             line = line.replace("#spring.devtools.restart.additional-paths=", "spring.devtools.restart.additional-paths=")
                         }
-                        if (databaseProperties.getProperty("extraJdbcDataSource"))
+                        if (databaseProperties.hasProperty("extraJdbcDataSource") && databaseProperties.getProperty("extraJdbcDataSource"))
                         {
                             line = line.replaceAll("^#(context\\..+\\[1].*)", "\$1")
                         }

--- a/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
@@ -49,6 +49,8 @@ class ModuleDistribution extends DefaultTask
     String archivePrefix = "LabKey"
     @Optional @Input
     String archiveName
+    @Optional @Input
+    Boolean isOpenSource = false
 
     @OutputDirectory
     File distributionDir
@@ -130,11 +132,24 @@ class ModuleDistribution extends DefaultTask
     {
         File modulesDir = getModulesDir()
         modulesDir.deleteDir()
-        project.copy
-        { CopySpec copy ->
-            copy.from { project.configurations.distribution }
-            copy.setDuplicatesStrategy(DuplicatesStrategy.EXCLUDE)
-            copy.into modulesDir
+        project.copy {
+            CopySpec copy ->
+                copy.from { project.configurations.distribution }
+                copy.setDuplicatesStrategy(DuplicatesStrategy.EXCLUDE)
+                copy.into modulesDir
+        }
+        if (!isOpenSource)
+        {
+            this.logger.quiet("Copying patched api module")
+            project.copy {
+                CopySpec copy ->
+                    copy.from(project.configurations.extJsCommercial)
+                    copy.rename { String fileName ->
+                        fileName.replace("-extJsCommercial", "")
+                    }
+                    copy.into modulesDir
+                    copy.setDuplicatesStrategy(DuplicatesStrategy.INCLUDE)
+            }
         }
     }
 

--- a/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
@@ -65,6 +65,8 @@ class ModuleDistribution extends DefaultTask
         Project serverProject = BuildUtils.getServerProject(project)
         this.dependsOn(serverProject.tasks.setup)
         this.dependsOn(serverProject.tasks.stageApp)
+        if (!isOpenSource)
+            this.dependsOn(project.project(BuildUtils.getApiProjectPath(project.gradle)).tasks.patchModule)
         if (BuildUtils.useEmbeddedTomcat(project))
             this.dependsOn(project.project(BuildUtils.getEmbeddedProjectPath()).tasks.build)
 
@@ -140,7 +142,6 @@ class ModuleDistribution extends DefaultTask
         }
         if (!isOpenSource)
         {
-            this.logger.quiet("Copying patched api module")
             project.copy {
                 CopySpec copy ->
                     copy.from(project.configurations.extJsCommercial)

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -429,7 +429,7 @@ class BuildUtils
 
     static boolean isOpenSource(Project project)
     {
-        return project.hasProperty("isOpenSource")
+        return project.hasProperty("isOpenSource") && Boolean.valueOf((String) project.property("isOpenSource"))
     }
 
     /**

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -427,6 +427,11 @@ class BuildUtils
         return distVersion
     }
 
+    static boolean isOpenSource(Project project)
+    {
+        return project.hasProperty("isOpenSource")
+    }
+
     /**
      * Returns a module version to be used as a LabKey Module property.  This must be a decimal
      * number (e.g., 19.1), so we use only the first two parts of the artifact version number


### PR DESCRIPTION
#### Rationale
Our open source distributions should include only open source versions of our dependencies.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Add optional `isOpenSource` property to `ModuleDistribution` task
* Wire up dependencies for distribution task so it will include the proper api module based on the `isOpenSource` property
