### PR TITLE
Fix Distribution patchApiModule task to work when not building the api module

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ If you are making changes to the plugins, please see the [internal docs](https:/
 on how to do that, including how to develop and test locally and the versioning information.
 
 ## Release Notes
+### TBD
+*Released*: TBD
+(Earliest compatible LabKey version: 21.1)
+* Fix Distribution patchApiModule task to work when not building the api module 
+* Fix gatherModules to use the proper configuration
+
 ### 1.24.0
 *Released*: 21 January 2021
 (Earliest compatible LabKey version: 21.1)

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ If you are making changes to the plugins, please see the [internal docs](https:/
 on how to do that, including how to develop and test locally and the versioning information.
 
 ## Release Notes
-### TBD
-*Released*: TBD
+### 1.24.1
+*Released*: 26 January 2021
 (Earliest compatible LabKey version: 21.1)
 * Fix Distribution patchApiModule task to work when not building the api module 
 * Fix gatherModules to use the proper configuration

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.24.1-distributionApiDepFix-SNAPSHOT"
+project.version = "1.25.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.25.0-SNAPSHOT"
+project.version = "1.24.1-distributionApiDepFix-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
@@ -153,16 +153,6 @@ class Distribution implements Plugin<Project>
                     jar.from project.configurations.licensePatch.collect {
                         project.zipTree(it)
                     }
-//                    if (project.findProject(BuildUtils.getApiProjectPath(project.gradle)))
-//                    {
-//                        Project apiProject = project.project(BuildUtils.getApiProjectPath(project.gradle))
-//
-//                        jar.from(project.zipTree(apiProject.tasks.module.outputs.files.singleFile))
-//                    }
-//                    else
-//                    {
-//                        jar.from(project.zipTree(BuildUtils.getLabKeyArtifactName(project, BuildUtils.getApiProjectPath(project.gradle), project.getVersion().toString(), "module")))
-//                    }
                     // ... but don't use the ext directories that come from that file
                     jar.setDuplicatesStrategy(DuplicatesStrategy.EXCLUDE)
                     jar.manifest.attributes(

--- a/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
@@ -146,7 +146,7 @@ class ModuleDistribution extends DefaultTask
         {
             project.copy {
                 CopySpec copy ->
-                    copy.from(project.configurations.extJsCommercial)
+                    copy.from(project.tasks.patchApiModule.outputs.files.singleFile)
                     copy.rename { String fileName ->
                         fileName.replace("-extJsCommercial", "")
                     }


### PR DESCRIPTION
#### Rationale
Building distributions should work even without an enlistment in the platform modules, so we need to add a dependency on the published module artifact when that is the case.

#### Related Pull Requests
#114 

#### Changes
* Use a configuration and declared dependency to be able to patch a published .module file instead of a locally built one
* Fix the `gatherModules` task so it will pick up the patched api module instead of the ext libraries (missed after updating configuration dependencies).
