### PR TITLE
Move the patchApiModule task into its own plugin to be applied where needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ on how to do that, including how to develop and test locally and the versioning 
 ### 1.24.2
 *Released*: TBD
 (Earliest compatible LabKey version: 21.1)
-* move `patchApiModule` task into distributions project so the patched module can be built just once and avoid the race
-condition when multiple distributions are being built.
+* Separate `patchApiModule` task, its dependencies and configurations to a new plugin that can be applied where needed 
 
 ### 1.24.1
 *Released*: 26 January 2021

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ If you are making changes to the plugins, please see the [internal docs](https:/
 on how to do that, including how to develop and test locally and the versioning information.
 
 ## Release Notes
+### 1.24.2
+*Released*: TBD
+(Earliest compatible LabKey version: 21.1)
+* move `patchApiModule` task into distributions project so the patched module can be built just once and avoid the race
+condition when multiple distributions are being built.
+
 ### 1.24.1
 *Released*: 26 January 2021
 (Earliest compatible LabKey version: 21.1)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ on how to do that, including how to develop and test locally and the versioning 
 
 ## Release Notes
 ### 1.24.2
-*Released*: TBD
+*Released*: 2 February 2021
 (Earliest compatible LabKey version: 21.1)
 * Separate `patchApiModule` task, its dependencies and configurations to a new plugin that can be applied where needed 
 

--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,10 @@ gradlePlugin {
             id = 'org.labkey.build.api'
             implementationClass = 'org.labkey.gradle.plugin.Api'
         }
+        applyLicenses {
+            id = 'org.labkey.build.applyLicenses'
+            implementationClass = 'org.labkey.gradle.plugin.ApplyLicenses'
+        }
         base {
             id = 'org.labkey.build.base'
             implementationClass = 'org.labkey.gradle.plugin.LabKey'

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.24.2-patchApiModuleDep-SNAPSHOT"
+project.version = "1.25.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.25.0-SNAPSHOT"
+project.version = "1.24.2-patchApiModuleDep-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/plugin/ApplyLicenses.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ApplyLicenses.groovy
@@ -57,7 +57,7 @@ class ApplyLicenses implements Plugin<Project>
                     jar.archiveVersion.set(project.getVersion().toString())
                     jar.archiveClassifier.set("extJsCommercial")
                     jar.archiveExtension.set('module')
-                    jar.destinationDirectory = project.file("${project.buildDir.parent}/patchApiModule")
+                    jar.destinationDirectory = project.file("${project.buildDir}/patchApiModule")
                     jar.outputs.cacheIf({ true })
                     // first include the ext-3.4.1 and ext-4.2.1 directories from the extjs configuration artifacts
                     jar.into('web') {

--- a/src/main/groovy/org/labkey/gradle/plugin/ApplyLicenses.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ApplyLicenses.groovy
@@ -1,0 +1,82 @@
+package org.labkey.gradle.plugin;
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.tasks.bundling.Jar
+import org.labkey.gradle.util.BuildUtils
+import org.labkey.gradle.util.GroupNames
+import org.gradle.api.file.DuplicatesStrategy
+
+class ApplyLicenses implements Plugin<Project>
+{
+    @Override
+    public void apply(Project project)
+    {
+        if (project.findProject(BuildUtils.getApiProjectPath(project.gradle)))
+            project.evaluationDependsOn(BuildUtils.getApiProjectPath(project.gradle))
+        addConfigurations(project)
+        addDependencies(project)
+        addTasks(project)
+    }
+
+    private void addConfigurations(Project project)
+    {
+        project.configurations
+        {
+            extJsCommercial
+            licensePatch {
+                canBeConsumed = true
+                canBeResolved = true
+            }
+        }
+        project.configurations.extJsCommercial.setDescription("extJs commercial license libraries")
+        project.configurations.licensePatch.setDescription("Modules that require patching with commercial-license libraries")
+    }
+
+
+    private void addDependencies(Project project)
+    {
+        if (!BuildUtils.isOpenSource(project)) {
+            project.dependencies {
+                extJsCommercial "com.sencha.extjs:extjs:4.2.1:commercial@zip"
+                extJsCommercial "com.sencha.extjs:extjs:3.4.1:commercial@zip"
+            }
+
+            BuildUtils.addLabKeyDependency(project, "licensePatch", BuildUtils.getApiProjectPath(project.gradle), "published", project.getVersion().toString(), "module")
+        }
+    }
+
+    private static void addTasks(Project project)
+    {
+        if (!BuildUtils.isOpenSource(project)) {
+            project.tasks.register('patchApiModule', Jar) {
+                Jar jar ->
+                    jar.group = GroupNames.DISTRIBUTION
+                    jar.description = "Patches the api module to replace ExtJS libraries with commercial versions"
+                    jar.archiveBaseName.set("api")
+                    jar.archiveVersion.set(project.getVersion().toString())
+                    jar.archiveClassifier.set("extJsCommercial")
+                    jar.archiveExtension.set('module')
+                    jar.destinationDirectory = project.file("${project.buildDir.parent}/patchApiModule")
+                    jar.outputs.cacheIf({ true })
+                    // first include the ext-3.4.1 and ext-4.2.1 directories from the extjs configuration artifacts
+                    jar.into('web') {
+                        from project.configurations.extJsCommercial.collect {
+                            project.zipTree(it)
+                        }
+                    }
+                    // include the original module file ...
+                    jar.from project.configurations.licensePatch.collect {
+                        project.zipTree(it)
+                    }
+                    // ... but don't use the ext directories that come from that file
+                    jar.setDuplicatesStrategy(DuplicatesStrategy.EXCLUDE)
+                    jar.manifest.attributes(
+                            "Implementation-Version": project.version,
+                            "Implementation-Title": "Internal API classes",
+                            "Implementation-Vendor": "LabKey"
+                    )
+            }
+        }
+    }
+}

--- a/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
@@ -57,9 +57,6 @@ class Distribution implements Plugin<Project>
         // we also depend on the jar task from the embedded project, if available
         if (BuildUtils.useEmbeddedTomcat(project))
             project.evaluationDependsOn(BuildUtils.getEmbeddedProjectPath(project.gradle))
-        // for non-open-source distributions, we depend on a task from the api project.
-        if (project.findProject(BuildUtils.getApiProjectPath(project.gradle)) && BuildUtils.isOpenSource(project))
-            project.evaluationDependsOn(BuildUtils.getApiProjectPath(project.gradle))
         addConfigurations(project)
         addDependencies(project)
         addTasks(project)

--- a/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
@@ -15,7 +15,6 @@
  */
 package org.labkey.gradle.plugin
 
-import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -23,19 +22,16 @@ import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.file.DeleteSpec
-import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.internal.artifacts.dependencies.DefaultProjectDependency
-import org.gradle.api.java.archives.Manifest
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.tasks.Delete
-import org.gradle.api.tasks.bundling.Jar
 import org.labkey.gradle.plugin.extension.DistributionExtension
 import org.labkey.gradle.plugin.extension.LabKeyExtension
 import org.labkey.gradle.plugin.extension.TeamCityExtension
 import org.labkey.gradle.task.ModuleDistribution
-import org.labkey.gradle.util.PomFileHelper
-import org.labkey.gradle.util.GroupNames
 import org.labkey.gradle.util.BuildUtils
+import org.labkey.gradle.util.GroupNames
+import org.labkey.gradle.util.PomFileHelper
 
 class Distribution implements Plugin<Project>
 {

--- a/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
@@ -65,7 +65,7 @@ class ModuleDistribution extends DefaultTask
         this.dependsOn(serverProject.tasks.named("setup"))
         this.dependsOn(serverProject.tasks.named("stageApp"))
         if (!BuildUtils.isOpenSource(project))
-            this.dependsOn(project.tasks.named("patchApiModule"))
+            this.dependsOn(project.project(":distributions").tasks.named("patchApiModule"))
         if (BuildUtils.useEmbeddedTomcat(project))
             this.dependsOn(project.project(BuildUtils.getEmbeddedProjectPath()).tasks.named("build"))
 
@@ -146,7 +146,7 @@ class ModuleDistribution extends DefaultTask
         {
             project.copy {
                 CopySpec copy ->
-                    copy.from(project.tasks.patchApiModule.outputs.files.singleFile)
+                    copy.from(project.project(":distributions").tasks.patchApiModule.outputs.files.singleFile)
                     copy.rename { String fileName ->
                         fileName.replace("-extJsCommercial", "")
                     }


### PR DESCRIPTION
#### Rationale
It seems that when each module declares a dependency on its own `patchApiModule` task, the patched module gets created multiple times.  Since the patch is being put into the same output directory for each distribution this can cause race conditions with distributions ending up with partial api modules.  Moving this `patchApiModule` task into its own plugin means we can avoid overlapping output from the `patchApiModule` tasks when more than one distribution is being built.

#### Related Pull Requests
#114 

#### Changes
* Move `patchApiModule` and its relatives out of the individual distribution
