### PR TITLE
Add checkModuleTasks task as part of the deployApp chain; remove jcenter; remove support for ModuleDependencies in module.properties file

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ If you are making changes to the plugins, please see the [internal docs](https:/
 on how to do that, including how to develop and test locally and the versioning information.
 
 ## Release Notes
+### TBD
+*Released*: TBD
+(Earliest compatible LabKey version: 21.3)
+* Remove support for ModuleDependencies in module.properties file
+* Add `checkModuleTasks` task that is in the `deployApp` dependencies chain and will warn if a modules i found that has a `module.properties` file but no `module` task.
+
 ### 1.24.2
 *Released*: 2 February 2021
 (Earliest compatible LabKey version: 21.1)

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ If you are making changes to the plugins, please see the [internal docs](https:/
 on how to do that, including how to develop and test locally and the versioning information.
 
 ## Release Notes
-### TBD
-*Released*: TBD
+### 1.25.0
+*Released*: 8 February 2021
 (Earliest compatible LabKey version: 21.3)
 * Remove support for ModuleDependencies in module.properties file
 * Add `checkModuleTasks` task that is in the `deployApp` dependencies chain and will warn if a modules i found that has a `module.properties` file but no `module` task.
@@ -20,6 +20,7 @@ on how to do that, including how to develop and test locally and the versioning 
 
 ### 1.24.3
 *Released*: 3 February 2021
+(Earliest compatible LabKey version: 21.1)
 * Fix infinite loop in `findLicensingProject`
 
 ### 1.24.2

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ on how to do that, including how to develop and test locally and the versioning 
 (Earliest compatible LabKey version: 21.3)
 * Remove support for ModuleDependencies in module.properties file
 * Add `checkModuleTasks` task that is in the `deployApp` dependencies chain and will warn if a modules i found that has a `module.properties` file but no `module` task.
+* Replace `jcenter`, which is going away, with `mavenCentral`, which is not
 
 ### 1.24.2
 *Released*: 2 February 2021

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ import java.nio.file.Paths
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath "org.jfrog.buildinfo:build-info-extractor-gradle:${artifactoryPluginVersion}"
@@ -25,7 +25,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
     maven {
         url "${artifactory_contextUrl}/libs-release"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.25.0-noModuleBuildGradle-SNAPSHOT"
+project.version = "1.26.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.25.0-SNAPSHOT"
+project.version = "1.25.0-noModuleBuildGradle-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/plugin/LabKey.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/LabKey.groovy
@@ -48,7 +48,6 @@ class LabKey implements Plugin<Project>
                 subproject.buildDir = "${project.rootProject.buildDir}/installer/${subproject.name}"
             else
                 subproject.buildDir = "${project.rootProject.buildDir}/modules/${subproject.name}"
-
         }
 
         addConfigurations(project)

--- a/src/main/groovy/org/labkey/gradle/plugin/MultiGit.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/MultiGit.groovy
@@ -472,9 +472,8 @@ class MultiGit implements Plugin<Project>
             }
         }
 
-        // Hmmm. This doesn't really work as intended for a few reasons:
+        // Hmmm. This doesn't really work as intended:
         //  - if the project is not in the settings file, it will be null
-        //  - the ModuleDependencies property in the module.properties file list modules, which does not include the path required to get to that module (e.g., modules/base/some_module)
         List<String> getModuleDependencies()
         {
             if (project == null)
@@ -487,16 +486,6 @@ class MultiGit implements Plugin<Project>
                     Dependency dep ->
                         moduleNames.add(dep.getName())
                 })
-            }
-            else if (project.file(ModuleExtension.MODULE_PROPERTIES_FILE).exists())
-            {
-                Properties props = new Properties()
-                props.load(new FileInputStream(project.file(ModuleExtension.MODULE_PROPERTIES_FILE)))
-                if (props.hasProperty(ModuleExtension.MODULE_DEPENDENCIES_PROPERTY))
-                {
-                    for (String name : ((String) props.get(ModuleExtension.MODULE_DEPENDENCIES_PROPERTY)).split(","))
-                        moduleNames.add(name.strip())
-                }
             }
 
             return moduleNames;

--- a/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
@@ -76,9 +76,6 @@ class ServerDeploy implements Plugin<Project>
             DeployApp task ->
                 task.group = GroupNames.DEPLOY
                 task.description = "Deploy the application locally into ${serverDeploy.dir}"
-                task.doLast {
-
-                }
         }
 
         StagingExtension staging = project.getExtensions().getByType(StagingExtension.class)

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/ModuleExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/ModuleExtension.groovy
@@ -84,7 +84,7 @@ class ModuleExtension
             if (logDeprecations) {
                 List<String> deprecationMsgs = [];
                 if (this.modProperties.get(MODULE_DEPENDENCIES_PROPERTY))
-                    deprecationMsgs += "Use of the '" + MODULE_DEPENDENCIES_PROPERTY + "' property in " + MODULE_PROPERTIES_FILE + " has been deprecated and will be removed with the 21.3.0 release of LabKey Server." +
+                    deprecationMsgs += "The '" + MODULE_DEPENDENCIES_PROPERTY + "' property is no longer supported as of gradlePlugin version 1.25.0 (LabKey Server version 21.3.0)." +
                             " Declare the dependency in the module's build.gradle file instead using the 'modules' configuration." +
                             " See https://www.labkey.org/Documentation/wiki-page.view?name=gradleDepend for more information."
 
@@ -97,6 +97,8 @@ class ModuleExtension
                             + deprecationMsgs.join("\n\t")
                             + "\nRefer to https://www.labkey.org/Documentation/wiki-page.view?name=includeModulePropertiesFile for the current set of supported properties.")
             }
+            if (this.modProperties.get(MODULE_DEPENDENCIES_PROPERTY))
+                this.modProperties.remove(MODULE_DEPENDENCIES_PROPERTY)
         }
         else
             project.logger.info("${project.path} - no ${MODULE_PROPERTIES_FILE} found")


### PR DESCRIPTION
#### Rationale
We are removing the `server/modules/build.gradle` file and its somtimes-flawed logic to decide when to apply which plugins.  Instead each module will need to apply plugins themselves.  If there is a Gradle project for a module but there is no `module` task defined, the module will not be included when the `deployApp` command runs.  This might happen silently, so we add a new task, `chedkModuleTasks` that will display a message indicating that the module won't be included.

We removing support for declaring `ModuleDependencies` in the `module.properties` file, as advertised. We still display a message if the property exists but don't use it when writing the module.xml files.

jcenter is going away in a few months, so we replace it with mavenCentral.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/46

#### Changes
* Remove support for ModuleDependencies in module.properties file
* Add `checkModuleTasks` task that is in the `deployApp` dependencies chain and will warn if a modules i found that has a `module.properties` file but no `module` task.
* Replace `jcenter`, which is going away, with `mavenCentral`, which is not
