### PR TITLE
Update inputs for moduleXml task

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ If you are making changes to the plugins, please see the [internal docs](https:/
 on how to do that, including how to develop and test locally and the versioning information.
 
 ## Release Notes
+### TBD
+*Released*: TBD
+(Earliest compatible LabKey version: 21.3)
+* Add `build.gradle` file as input to `moduleXml` task
+
 ### 1.25.0
 *Released*: 8 February 2021
 (Earliest compatible LabKey version: 21.3)

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ If you are making changes to the plugins, please see the [internal docs](https:/
 on how to do that, including how to develop and test locally and the versioning information.
 
 ## Release Notes
-### TBD
-*Released*: TBD
+### 1.25.1
+*Released*: 15 February 2021
 (Earliest compatible LabKey version: 21.3)
 * Add `build.gradle` file as input to `moduleXml` task
 

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.26.0-SNAPSHOT"
+project.version = "1.25.1-moduleXmlCaching-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,6 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:${artifactoryPluginVersion}"
         classpath "org.ajoberstar.grgit:grgit-gradle:${grgitGradleVersion}"
     }
 }
@@ -46,7 +45,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.25.1-moduleXmlCaching-SNAPSHOT"
+project.version = "1.26.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
@@ -174,6 +174,8 @@ class FileModule implements Plugin<Project>
         else
             project.logger.info("${project.path} - ${ModuleExtension.MODULE_PROPERTIES_FILE} not found so not added as input to 'moduleXml'")
         moduleXmlTask.outputs.file(moduleXmlFile)
+        if (project.file("build.gradle").exists())
+            moduleXmlTask.inputs.file(project.file("build.gradle"))
         moduleXmlTask.outputs.cacheIf {true} // enable build caching
 
         // This is added because Intellij started creating this "out" directory when you build through IntelliJ.


### PR DESCRIPTION
#### Rationale
The `moduleXm` task depends on the `build.gradle` file to get the ModuleDependencies, so it should be declared as an input in order to not pull from the cache if dependencies change.

#### Changes
* Add `build.gradle` file as input to `moduleXml` task