### PR TITLE
Add methods to allow external dependencies to be declared with enough data to generate jars.txt files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ If you are making changes to the plugins, please see the [internal docs](https:/
 on how to do that, including how to develop and test locally and the versioning information.
 
 ## Release Notes
+### TBD
+*Released*: TBD
+(Earliest compatible LabKey version: 21.3)
+* (incubating) Add ability to generate jars.txt from the build 
+  * Add `BuildUtils.addExternalDependency` method for declaring dependencies to be included in the `jars.txt` file
+  * Modify `WriteDependenciesFile` to also write a new jars.txt file if `addExternalDependency` has been used
+
 ### 1.25.1
 *Released*: 15 February 2021
 (Earliest compatible LabKey version: 21.3)

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.26.0-jarsTxt-SNAPSHOT"
+project.version = "1.26.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.26.0-SNAPSHOT"
+project.version = "1.26.0-jarsTxt-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/ModuleExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/ModuleExtension.groovy
@@ -15,8 +15,10 @@
  */
 package org.labkey.gradle.plugin.extension
 
+import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.labkey.gradle.util.BuildUtils
+import org.labkey.gradle.util.ExternalDependency
 import org.labkey.gradle.util.PropertiesUtils
 
 import java.text.SimpleDateFormat
@@ -31,6 +33,7 @@ class ModuleExtension
     public static final String MODULE_DEPENDENCIES_PROPERTY = "ModuleDependencies"
     private Properties modProperties
     private Project project
+    private Map<String, ExternalDependency> externalDependencies = new HashMap<>()
 
     ModuleExtension(Project project, boolean logDeprecations)
     {
@@ -162,5 +165,22 @@ class ModuleExtension
             modProperties.setProperty("Name", project.name)
         if (modProperties.getProperty("ModuleClass") == null)
             modProperties.setProperty("ModuleClass", "org.labkey.api.module.SimpleModule")
+    }
+
+    void addExternalDependency(ExternalDependency dependency)
+    {
+        if (dependency.coordinates == null)
+            throw new GradleException("${project.path}: All external dependencies must have group-name-version coordinates. ${dependency}")
+        externalDependencies.put(dependency.coordinates, dependency)
+    }
+
+    ExternalDependency getExternalDependency(String coordinates)
+    {
+        return externalDependencies.get(coordinates)
+    }
+
+    Map<String, ExternalDependency> getExternalDependencies()
+    {
+        return externalDependencies;
     }
 }

--- a/src/main/groovy/org/labkey/gradle/task/WriteDependenciesFile.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/WriteDependenciesFile.groovy
@@ -83,6 +83,7 @@ class WriteDependenciesFile extends DefaultTask
                 if (dep) {
                     List<String> parts = new ArrayList<>()
                     parts.add(artifact.file.getName())
+                    parts.add(dep.getComponent())
                     if (dep.getSource() != null) {
                         if (dep.getSourceURL() != null)
                             parts.add("{link:${dep.getSource()}|${dep.getSourceURL()}}")
@@ -123,7 +124,7 @@ class WriteDependenciesFile extends DefaultTask
         try {
             outputStream = new FileOutputStream(jarsTxtFile)
             outputStream.write("{table}\n".getBytes())
-            outputStream.write("Filename|Source|License|Purpose\n".getBytes())
+            outputStream.write("Filename|Component|Source|License|Purpose\n".getBytes())
             writeDependencies("externalsNotTrans", outputStream)
             writeDependencies("creditable", outputStream)
             outputStream.write("{table}\n".getBytes())

--- a/src/main/groovy/org/labkey/gradle/task/WriteDependenciesFile.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/WriteDependenciesFile.groovy
@@ -83,7 +83,6 @@ class WriteDependenciesFile extends DefaultTask
                 if (dep) {
                     List<String> parts = new ArrayList<>()
                     parts.add(artifact.file.getName())
-                    parts.add(artifact.moduleVersion.toString())
                     if (dep.getSource() != null) {
                         if (dep.getSourceURL() != null)
                             parts.add("{link:${dep.getSource()}|${dep.getSourceURL()}}")
@@ -124,7 +123,7 @@ class WriteDependenciesFile extends DefaultTask
         try {
             outputStream = new FileOutputStream(jarsTxtFile)
             outputStream.write("{table}\n".getBytes())
-            outputStream.write("Filename|Version|Source|License|Purpose\n".getBytes())
+            outputStream.write("Filename|Source|License|Purpose\n".getBytes())
             writeDependencies("externalsNotTrans", outputStream)
             writeDependencies("creditable", outputStream)
             outputStream.write("{table}\n".getBytes())

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -771,7 +771,7 @@ class BuildUtils
 
     static void addExternalDependency(Project project, ExternalDependency dependency, Closure closure=null)
     {
-        project.dependencies.add("external", dependency.coordinates, closure)
+        project.dependencies.add(dependency.configuration, dependency.coordinates, closure)
         ModuleExtension extension = project.extensions.findByType(ModuleExtension.class)
         extension.addExternalDependency(dependency)
     }

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -775,4 +775,11 @@ class BuildUtils
         ModuleExtension extension = project.extensions.findByType(ModuleExtension.class)
         extension.addExternalDependency(dependency)
     }
+
+    static void addExternalDependencies(Project project, List<ExternalDependency> dependencies)
+    {
+        dependencies.forEach({
+            dependency -> addExternalDependency(project, dependency)
+        })
+    }
 }

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -768,4 +768,11 @@ class BuildUtils
     {
         return project.hasProperty(USE_EMBEDDED_TOMCAT) && project.findProject(getEmbeddedProjectPath(project.gradle)) != null
     }
+
+    static void addExternalDependency(Project project, ExternalDependency dependency, Closure closure=null)
+    {
+        project.dependencies.add("external", dependency.coordinates, closure)
+        ModuleExtension extension = project.extensions.findByType(ModuleExtension.class)
+        extension.addExternalDependency(dependency)
+    }
 }

--- a/src/main/groovy/org/labkey/gradle/util/ExternalDependency.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/ExternalDependency.groovy
@@ -2,6 +2,7 @@ package org.labkey.gradle.util
 
 class ExternalDependency
 {
+    private String configuration = "external"
     private String coordinates
     private String licenseName
     private String licenseURL
@@ -13,14 +14,30 @@ class ExternalDependency
 
     }
 
-    ExternalDependency(String coordinates, String licenseName, String licenseURL, String source, String sourceURL, String purpose)
+    ExternalDependency(String coordinates, String source, String sourceURL, String licenseName, String licenseURL, String purpose)
     {
-        this.coordinates = coordinates;
-        this.licenseName = licenseName;
-        this.licenseURL = licenseURL;
-        this.source = source;
+        this("external", coordinates, source, sourceURL, licenseName, licenseURL, purpose)
+    }
+
+    ExternalDependency(String configuration, String coordinates, String source, String sourceURL, String licenseName, String licenseURL, String purpose)
+    {
+        this.configuration = configuration
+        this.coordinates = coordinates
+        this.source = source
         this.sourceURL = sourceURL
+        this.licenseName = licenseName
+        this.licenseURL = licenseURL
         this.purpose = purpose
+    }
+
+    String getConfiguration()
+    {
+        return configuration
+    }
+
+    void setConfiguration(String configuration)
+    {
+        this.configuration = configuration
     }
 
     String getCoordinates()

--- a/src/main/groovy/org/labkey/gradle/util/ExternalDependency.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/ExternalDependency.groovy
@@ -4,25 +4,25 @@ class ExternalDependency
 {
     private String configuration = "external"
     private String coordinates
+    private String component
     private String licenseName
     private String licenseURL
     private String source
     private String sourceURL
     private String purpose
 
-    ExternalDependency() {
+    ExternalDependency() { }
 
-    }
-
-    ExternalDependency(String coordinates, String source, String sourceURL, String licenseName, String licenseURL, String purpose)
+    ExternalDependency(String coordinates, String component, String source, String sourceURL, String licenseName, String licenseURL, String purpose)
     {
-        this("external", coordinates, source, sourceURL, licenseName, licenseURL, purpose)
+        this("external", coordinates, component, source, sourceURL, licenseName, licenseURL, purpose)
     }
 
-    ExternalDependency(String configuration, String coordinates, String source, String sourceURL, String licenseName, String licenseURL, String purpose)
+    ExternalDependency(String configuration, String coordinates, String component, String source, String sourceURL, String licenseName, String licenseURL, String purpose)
     {
         this.configuration = configuration
         this.coordinates = coordinates
+        this.component = component
         this.source = source
         this.sourceURL = sourceURL
         this.licenseName = licenseName
@@ -48,6 +48,16 @@ class ExternalDependency
     void setCoordinates(String coordinates)
     {
         this.coordinates = coordinates
+    }
+
+    String getComponent()
+    {
+        return component
+    }
+
+    void setComponent(String component)
+    {
+        this.component = component
     }
 
     String getLicenseName()

--- a/src/main/groovy/org/labkey/gradle/util/ExternalDependency.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/ExternalDependency.groovy
@@ -1,0 +1,91 @@
+package org.labkey.gradle.util
+
+class ExternalDependency
+{
+    private String coordinates
+    private String licenseName
+    private String licenseURL
+    private String source
+    private String sourceURL
+    private String purpose
+
+    ExternalDependency() {
+
+    }
+
+    ExternalDependency(String coordinates, String licenseName, String licenseURL, String source, String sourceURL, String purpose)
+    {
+        this.coordinates = coordinates;
+        this.licenseName = licenseName;
+        this.licenseURL = licenseURL;
+        this.source = source;
+        this.sourceURL = sourceURL
+        this.purpose = purpose
+    }
+
+    String getCoordinates()
+    {
+        return coordinates
+    }
+
+    void setCoordinates(String coordinates)
+    {
+        this.coordinates = coordinates
+    }
+
+    String getLicenseName()
+    {
+        return licenseName
+    }
+
+    void setLicenseName(String licenseName)
+    {
+        this.licenseName = licenseName
+    }
+
+    String getLicenseURL()
+    {
+        return licenseURL
+    }
+
+    void setLicenseURL(String licenseURL)
+    {
+        this.licenseURL = licenseURL
+    }
+
+    String getSource()
+    {
+        return source
+    }
+
+    void setSource(String source)
+    {
+        this.source = source
+    }
+
+    String getSourceURL()
+    {
+        return sourceURL
+    }
+
+    void setSourceURL(String sourceURL)
+    {
+        this.sourceURL = sourceURL
+    }
+
+    String getPurpose()
+    {
+        return purpose
+    }
+
+    void setPurpose(String purpose)
+    {
+        this.purpose = purpose
+    }
+
+//    String toString()
+//    {
+//        StringBuilder builder = new StringBuilder()
+//
+//    }
+}

--- a/src/main/groovy/org/labkey/gradle/util/ExternalDependency.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/ExternalDependency.groovy
@@ -99,10 +99,4 @@ class ExternalDependency
     {
         this.purpose = purpose
     }
-
-//    String toString()
-//    {
-//        StringBuilder builder = new StringBuilder()
-//
-//    }
 }


### PR DESCRIPTION
#### Rationale
Maintaining the `jars.txt` files is tedious.  Much of the data in this file is also maintained within the `build.gradle` files so it will make for more consistency and eliminate the need for generating and comparing to the `dependencies.txt` file if we can produce the `jars.txt` from the build.  This PR adds a utility method and updates the `WriteDependenciesFile` task to get us one step closer to not needing to maintain the `jars.txt` files.

The following assumptions were made:
* Since our jar files contain version numbers, we do not need to list the version number separately in the `jars.txt`.
* The `Component` column does not provide much value and can be removed.
* The `LabKey Dev` column does not provide much value and can be removed.
* All dependencies should provide license information, otherwise the build should fail
* All external dependencies will be declared using the current method or the new method but we do not need to support a combination of both. 

If any assumptions are wrong, we can adjust.  Just starting minimal.  I'm not sure if the auditors that have asked for this kind of data are more interested in seeing the name of the jar file or more build-like coordinates (e.g., org.apache.commons:commons-math3:3.4.1), but if this is more informative, we can use that instead.

An example usage:
```
   BuildUtils.addExternalDependency(
           project,
           new ExternalDependency(
                   "org.apache.commons:commons-math3:${commonsMath3Version}",
                   "Apache",
                   "http://commons.apache.org/math/",
                   "Apache 2.0",
                   "http://www.apache.org/licenses/LICENSE-2.0",
                   "Lightweight, self-contained mathematics and statistics components"
           )
   )
```
And the corresponding `jars.txt` file:
```
{table}
Filename|Source|License|Purpose
commons-math3-3.6.1.jar|{link:Apache|http://commons.apache.org/math/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|Lightweight, self-contained mathematics and statistics components
{table}
```

There may need to be some iteration on this to handle some special cases of dependencies, particularly for the `platform` modules, but the basics should work.

While this feature is incubating or in transition, we will continue to produce the `dependencies.txt` file and the checks on the credits page will remain.  Once all modules have transitioned to the new method of declaring dependencies, we can remove the generation of `dependencies.txt` and the corresponding checks.


#### Changes
* Add `BuildUtils.addExternalDependency` and `BuildUtils.addExternalDependencies` methods for declaring external dependencies with data needed to produce the `jars.txt` file
* Modify `WriteDependenciesFile` to also write a new jars.txt file if one of the new methods has been used.
