### PR TITLE
Enable standalone modules to build distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ on how to do that, including how to develop and test locally and the versioning 
 ### TBD
 *Released*: TBD
 (Earliest compatible LabKey version: 21.3)
-* Enable build, deploy, and distributions without `server` repository
+* Allow modules that utilize LabKey JSP tags to build without platform repository present (_Requires LabKey version 21.3.5+ or 21.6+_)
+* Enable building distributions without `server` repository
+  * Requires module to be configured for a [standalone build](https://www.labkey.org/Documentation/wiki-page.view?name=gradleModules)
 
 ## Release Notes
 ### 1.26.0
@@ -27,7 +29,6 @@ on how to do that, including how to develop and test locally and the versioning 
 * (incubating) Add ability to generate jars.txt from the build 
   * Add `BuildUtils.addExternalDependency` method for declaring dependencies to be included in the `jars.txt` file
   * Modify `WriteDependenciesFile` to also write a new jars.txt file if `addExternalDependency` has been used
-    
 
 ### 1.25.1
 *Released*: 15 February 2021

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ on how to do that, including how to develop and test locally and the versioning 
 * Allow modules that utilize LabKey JSP tags to build without platform repository present
 * Add `standalone` plugin to enable building distributions without `server` repository
   * Requires module to be configured for a [standalone build](https://www.labkey.org/Documentation/wiki-page.view?name=gradleModules)
-  * Requires `org.labkey.build:tomcat-libs` artifact; available for LabKey version 21.3.5+ and 21.5+
+  * Requires `org.labkey.build:tomcat-libs` artifact; available for LabKey version 21.3.5+ and 21.6+ (it is not available for 21.4 or 21.5)
 
 ### 1.26.0
 *Released*: 9 April 2021

--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ on how to do that, including how to develop and test locally and the versioning 
 ### TBD
 *Released*: TBD
 (Earliest compatible LabKey version: 21.3)
-* Allow modules that utilize LabKey JSP tags to build without platform repository present (_Requires LabKey version 21.3.5+ or 21.6+_)
-* Enable building distributions without `server` repository
+* Allow modules that utilize LabKey JSP tags to build without platform repository present
+* Add `standalone` plugin to enable building distributions without `server` repository
   * Requires module to be configured for a [standalone build](https://www.labkey.org/Documentation/wiki-page.view?name=gradleModules)
+  * Requires `org.labkey.build:tomcat-libs` artifact; available for LabKey version 21.3.5+ and 21.5+
 
 ## Release Notes
 ### 1.26.0

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ If you are making changes to the plugins, please see the [internal docs](https:/
 on how to do that, including how to develop and test locally and the versioning information.
 
 ## Release Notes
+### TBD
+*Released*: TBD
+(Earliest compatible LabKey version: 21.3)
+* Enable build, deploy, and distributions without `server` repository
+
+## Release Notes
 ### 1.26.0
 *Released*: 9 April 2021
 (Earliest compatible LabKey version: 21.3)

--- a/build.gradle
+++ b/build.gradle
@@ -146,6 +146,10 @@ gradlePlugin {
             id = 'org.labkey.build.xsddoc'
             implementationClass = 'org.labkey.gradle.plugin.XsdDoc'
         }
+        standalone {
+            id = 'org.labkey.build.standalone'
+            implementationClass = 'org.labkey.gradle.plugin.Standalone'
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.27.0_standaloneBuild-SNAPSHOT"
+project.version = "1.27.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.27.0-SNAPSHOT"
+project.version = "1.27.0_standaloneBuild-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/distributionResources/labkey.xml
+++ b/distributionResources/labkey.xml
@@ -1,0 +1,60 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!-- https://www.labkey.org/Documentation/wiki-page.view?name=installComponents#4 -->
+<Context docBase="@@appDocBase@@" reloadable="true" crossContext="true">
+    
+    <Resource name="jdbc/labkeyDataSource" auth="Container"
+        type="javax.sql.DataSource"
+        username="@@jdbcUser@@"
+        password="@@jdbcPassword@@"
+        driverClassName="@@jdbcDriverClassName@@"
+        url="@@jdbcURL@@"
+        maxTotal="20"
+        maxIdle="10"
+        maxWaitMillis="120000"
+        accessToUnderlyingConnectionAllowed="true"
+        validationQuery="SELECT 1"
+        />
+
+    <!-- https://www.labkey.org/Documentation/wiki-page.view?name=cpasxml#SMTPsettings -->
+    <Resource name="mail/Session" auth="Container"
+        type="javax.mail.Session"
+        mail.smtp.host="@@smtpHost@@"
+        mail.smtp.user="@@smtpUser@@"
+        mail.smtp.port="@@smtpPort@@"/>
+
+    <Resources cachingAllowed="true" cacheMaxSize="20000" />
+
+    <Loader loaderClass="org.labkey.bootstrap.LabKeyBootstrapClassLoader" />
+
+    <!-- Encryption key for encrypted property store: https://www.labkey.org/Documentation/wiki-page.view?name=cpasxml#encrypt -->
+    <Parameter name="MasterEncryptionKey" value="@@masterEncryptionKey@@" />
+
+    <!-- Additional data source(s): https://www.labkey.org/Documentation/wiki-page.view?name=externalSchemas#config -->
+    <!--@@extraJdbcDataSource@@
+    <Resource name="jdbc/@@extraJdbcDataSource@@" auth="Container"
+              type="javax.sql.DataSource"
+              username="@@extraJdbcUsername@@"
+              password="@@extraJdbcPassword@@"
+              driverClassName="@@extraJdbcDriverClassName@@"
+              url="@@extraJdbcUrl@@"
+              maxTotal="20"
+              maxIdle="10"
+              accessToUnderlyingConnectionAllowed="true"
+              validationQuery="SELECT 1"/>
+    @@extraJdbcDataSource@@-->
+
+    <!-- mzML support via JNI -->
+    <!-- 
+    <Parameter name="org.labkey.api.ms2.mzmlLibrary" value="pwiz_swigbindings"></Parameter>
+    -->
+
+    <!-- Pipeline configuration -->
+    <!--@@pipeline@@    <Parameter name="org.labkey.api.pipeline.config" value="@@pipelineConfigPath@@"/> @@pipeline@@-->
+
+    <!--@@jmsConfig@@ <Resource name="jms/ConnectionFactory" auth="Container"
+        type="org.apache.activemq.ActiveMQConnectionFactory"
+        factory="org.apache.activemq.jndi.JNDIReferenceFactory"
+        description="JMS Connection Factory"
+        brokerURL="vm://localhost?broker.persistent=false&amp;broker.useJmx=false"
+        brokerName="LocalActiveMQBroker"/> @@jmsConfig@@-->
+</Context>

--- a/distributionResources/log4j2.xml
+++ b/distributionResources/log4j2.xml
@@ -1,0 +1,283 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<Configuration packages="org.labkey.api.util">
+
+    <Appenders>
+        <Console name="CONSOLE" target="SYSTEM_OUT">
+            <!-- p=priority c=category d=datetime t=thread m=message n=newline -->
+            <PatternLayout pattern="%-5p %-24.24c{1} %d{ISO8601} %24.24t : %m%n" />
+
+        </Console>
+
+        <RollingFile name="ERRORS"
+                     fileName="${sys:labkey.log.home}/labkey-errors.log"
+                     append="true"
+                     bufferedIO="false"
+                     filePattern="${sys:labkey.log.home}/labkey-errors.log.%i">
+            <ThresholdFilter level="ERROR" onMatch="ACCEPT" onMismatch="DENY"/>
+            <!-- p=priority c=category d=datetime t=thread m=message n=newline   -->
+            <PatternLayout>
+                <Pattern>%-5p %-24.24c{1} %d{ISO8601} %24.24t : %m%n</Pattern>
+            </PatternLayout>
+            <Policies>
+                <OnStartupTriggeringPolicy />
+            </Policies>
+            <DefaultRolloverStrategy max="3"/>
+
+        </RollingFile>
+
+        <RollingFile name="ACTION_STATS"
+                     fileName="${sys:labkey.log.home}/labkey-action-stats.tsv"
+                     append="true"
+                     bufferedIO="false"
+                     filePattern="${sys:labkey.log.home}/labkey-action-stats.tsv.%i">
+            <!-- p=priority c=category d=datetime t=thread m=message n=newline -->
+            <PatternLayout>
+                <Pattern>%m%n</Pattern>
+            </PatternLayout>
+            <Policies>
+                <OnStartupTriggeringPolicy />
+                <SizeBasedTriggeringPolicy size="100 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="3"/>
+        </RollingFile>
+
+        <RollingFile name="QUERY_STATS"
+                     fileName="${sys:labkey.log.home}/labkey-query-stats.tsv"
+                     append="true"
+                     bufferedIO="false"
+                     filePattern="${sys:labkey.log.home}/labkey-query-stats.tsv.%i">
+            <!-- p=priority c=category d=datetime t=thread m=message n=newline -->
+            <PatternLayout>
+                <Pattern>%m%n</Pattern>
+            </PatternLayout>
+            <Policies>
+                <OnStartupTriggeringPolicy />
+                <SizeBasedTriggeringPolicy size="100 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="3"/>
+        </RollingFile>
+
+        <RollingFile name="LABKEY"
+                     fileName="${sys:labkey.log.home}/labkey.log"
+                     append="true"
+                     bufferedIO="false"
+                     filePattern="${sys:labkey.log.home}/labkey.log.%i">
+            <!-- p=priority c=category d=datetime t=thread m=message n=newline -->
+            <PatternLayout>
+                <Pattern>%-5p %-24.24c{1} %d{ISO8601} %24.24t : %m%n</Pattern>
+            </PatternLayout>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="10 MB"/>
+            </Policies>
+        </RollingFile>
+
+        <RollingFile name="LABKEY_AUDIT"
+                     fileName="${sys:labkey.log.home}/labkey-audit.log"
+                     append="true"
+                     bufferedIO="false"
+                     filePattern="${sys:labkey.log.home}/labkey-audit.log.%i">
+            <!-- p=priority c=category d=datetime t=thread m=message n=newline -->
+            <PatternLayout>
+                <Pattern>%-5p %-24.24c{1} %d{ISO8601} %24.24t : %m%n</Pattern>
+            </PatternLayout>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="10 MB"/>
+            </Policies>
+        </RollingFile>
+
+        <SessionAppender name="SessionAppender">
+            <PatternLayout>
+                <Pattern>%-5p %-24.24c{1} %d{ISO8601} %24.24t : %m%n</Pattern>
+            </PatternLayout>
+        </SessionAppender>
+
+        <RollingFile name="LABKEYMemory"
+                     fileName="${sys:labkey.log.home}/labkeyMemory.log"
+                     append="true"
+                     filePattern="${sys:labkey.log.home}/labkeyMemory.log.%i">
+            <!-- p=priority c=category d=datetime t=thread m=message n=newline -->
+            <PatternLayout>
+                <Pattern>%d{yyyy-MM-dd HH:mm:ss}%m%n</Pattern>
+            </PatternLayout>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="1000 KB"/>
+            </Policies>
+        </RollingFile>
+
+        <RollingFile name="THREAD_DUMP"
+                     fileName="${sys:labkey.log.home}/thread-dump.log"
+                     append="true"
+                     filePattern="${sys:labkey.log.home}/thread-dump.log.%i">
+            <!-- p=priority c=category d=datetime t=thread m=message n=newline -->
+            <PatternLayout>
+                <Pattern>%m%n</Pattern>
+            </PatternLayout>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="10 MB"/>
+            </Policies>
+        </RollingFile>
+
+    </Appenders>
+
+    <Loggers>
+
+        <!-- category for server side script messages -->
+        <Logger name="org.labkey.api.script.ScriptService.Console" level="info">
+            <AppenderRef ref="SessionAppender"/>
+        </Logger>
+
+
+        <!-- category for Mule messages -->
+        <Logger name="org.mule.MuleManager" level="info"/>
+
+        <!--
+            <Logger name="org.labkey.pipeline.mule.transformers" level="debug"/>
+         -->
+
+        <!-- category for jasper messages -->
+        <Logger name="org.apache.jasper" level="warn"/>
+
+        <!-- application classes -->
+        <Logger name="org.fhcrc" level="info"/>
+
+
+        <Logger name="org.labkey" level="info">
+            <AppenderRef ref="CONSOLE"/>
+            <AppenderRef ref="LABKEY"/>
+        </Logger>
+
+        <Logger name="mondrian." level="info" />
+
+        <!--
+            <Logger name="org.labkey.wiki" level="debug"/>
+        -->
+
+        <!--
+            <Logger name="org.labkey.api.action.SpringActionController" level="debug"/>
+        -->
+
+        <!-- only show errors from PipelineJob output -->
+        <Logger name="org.labkey.api.pipeline.PipelineJob" level="error"/>
+
+        <!-- don't need to log PDFBox errors (e.g., FlateFilter, PDCIDFontType2) -->
+        <Logger name="org.apache.pdfbox" level="fatal"/>
+
+        <!-- this is a very verbose logger for security/permissions checking -->
+        <!--
+            <Logger name="org.labkey.api.security.SecurityManager" level="debug"/>
+        -->
+
+        <!-- Add specific module packages or classes to get debug information about
+         features you are working on. -->
+
+        <!--
+            <Logger name="org.labkey.api.data.Table" level="debug"/>
+        -->
+
+        <Logger name="org.labkey.api.data"/>
+
+        <Logger name="org.labkey.api.dataiterator"/>
+
+        <Logger name="org.labkey.docker">
+            <level value="info"/>
+        </Logger>
+
+        <Logger name="org.labkey.rstudio" level="info"/>
+
+
+        <!--
+            <Logger name="org.labkey.api.cache" level="debug"/>
+        -->
+
+        <!--
+            <Logger name="org.labkey.api.data.TempTableTracker" level="debug"/>
+        -->
+
+        <!--
+            <Logger name="org.labkey.query" level="debug"/>
+        -->
+
+        <!--
+            <Logger name="org.labkey.pipeline.mule" level="debug"/>
+        -->
+
+        <!--
+            <Logger name="org.labkey.search" level="debug"/>
+        -->
+
+        <!--
+            <Logger name="org.labkey.search.model.LuceneSearchServiceImpl" level="debug"/>
+        -->
+
+        <Logger name="org.labkey.api.util.MemTracker" additivity="false" level="debug">
+            <AppenderRef ref="LABKEYMemory"/>
+        </Logger>
+
+        <Logger name="org.labkey.api.util.DebugInfoDumper" level="debug">
+            <AppenderRef ref="THREAD_DUMP"/>
+        </Logger>
+
+        <!--
+            <Logger name="org.labkey.api.view.ViewServlet" additivity="false" level="debug"/>
+        -->
+
+        <!--
+            <Logger name="org.labkey" level="debug">
+                <AppenderRef ref="SESSION"/>
+            </Logger>
+         -->
+
+        <Logger name="org.labkey.core.admin.ActionsTsvWriter" additivity="false" level="info">
+            <AppenderRef ref="ACTION_STATS"/>
+        </Logger>
+
+        <Logger name="org.labkey.api.data.queryprofiler.QueryProfiler.QueryProfilerThread" additivity="false" level="info">
+            <AppenderRef ref="QUERY_STATS"/>
+        </Logger>
+
+        <Logger name="org.labkey.audit.event" level="OFF">
+            <AppenderRef ref="LABKEY_AUDIT"/>
+            <AppenderRef ref="CONSOLE"/>
+        </Logger>
+
+        <!--
+          Other audit event types include, but are not limited to:
+            AppPropsEvent
+            AssayPublishAuditEvent
+            AttachmentAuditEvent
+            AuthenticationProviderConfiguration
+            ClientAPIActions
+            ContainerAuditEvent
+            DatasetAuditEvent
+            DomainAuditEvent
+            ExperimentAuditEvent
+            FileSystem
+            FileSystemBatch
+            GroupAuditEvent
+            ListAuditEvent
+            LoggedQuery
+            MessageAuditEvent
+            pipelineProtocolEvent
+            QueryExportAuditEvent
+            QueryUpdateAuditEvent
+            SampleTypeAuditEvent
+            SearchAuditEvent
+            SelectQuery
+         To enable logging of all events, set the level for the org.labkey.audit.event to
+         something other than "OFF".  To enable individual audit event logging, configure the
+         individual stanza like the one shown below, where you prefix the audit event type
+         with 'org.labkey.audit.event'. Then set the level to INFO and specify the appenders.
+        -->
+        <Logger name="org.labkey.audit.event.UserAuditEvent" additivity="false" level="OFF">
+            <AppenderRef ref="LABKEY_AUDIT"/>
+            <AppenderRef ref="CONSOLE"/>
+        </Logger>
+
+        <Logger name="NoOpLogger" level="OFF" additivity="false"/>
+
+        <Root level="error">
+            <AppenderRef ref="ERRORS"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,2 @@
-// Empty settings file to allow wrapper to be used within this pseudo sub-project
+// Ensure root project name is consistent, regardless of clone directory
+rootProject.name='gradlePlugin'

--- a/src/main/groovy/org/labkey/gradle/plugin/ClientLibraries.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ClientLibraries.groovy
@@ -32,7 +32,8 @@ class ClientLibraries
                 includes: ["**/*${ClientLibsCompress.LIB_XML_EXTENSION}"],
                 // Issue 31367: exclude files that end up in the "out" directory created by IntelliJ
                 // exclude node_modules for efficiency
-                excludes: ["node_modules", "**/out/*"]
+                // exclude 'build' to prevent warnings building standalone modules
+                excludes: ["node_modules", "**/out/*", "build"]
         )
     }
 

--- a/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
@@ -48,12 +48,13 @@ class Distribution implements Plugin<Project>
         if (TeamCityExtension.isOnTeamCity(project) && teamCityExt == null)
             project.extensions.create("teamCity", TeamCityExtension, project)
 
-        if (project.findProject(BuildUtils.getServerProjectPath(project.gradle)) != null) {
+        if (BuildUtils.getServerProject(project) != null) {
             // we depend on tasks from the server project, so it needs to have been evaluated first
             project.evaluationDependsOn(BuildUtils.getServerProjectPath(project.gradle))
-            // we also depend on the jar task from the embedded project, if available
-            if (BuildUtils.useEmbeddedTomcat(project))
-                project.evaluationDependsOn(BuildUtils.getEmbeddedProjectPath(project.gradle))
+        }
+        // we also depend on the jar task from the embedded project, if available
+        if (BuildUtils.useEmbeddedTomcat(project)) {
+            project.evaluationDependsOn(BuildUtils.getEmbeddedProjectPath(project.gradle))
         }
 
         addConfigurations(project)

--- a/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
@@ -48,11 +48,14 @@ class Distribution implements Plugin<Project>
         if (TeamCityExtension.isOnTeamCity(project) && teamCityExt == null)
             project.extensions.create("teamCity", TeamCityExtension, project)
 
-        // we depend on tasks from the server project, so it needs to have been evaluated first
-        project.evaluationDependsOn(BuildUtils.getServerProjectPath(project.gradle))
-        // we also depend on the jar task from the embedded project, if available
-        if (BuildUtils.useEmbeddedTomcat(project))
-            project.evaluationDependsOn(BuildUtils.getEmbeddedProjectPath(project.gradle))
+        if (project.findProject(BuildUtils.getServerProjectPath(project.gradle)) != null) {
+            // we depend on tasks from the server project, so it needs to have been evaluated first
+            project.evaluationDependsOn(BuildUtils.getServerProjectPath(project.gradle))
+            // we also depend on the jar task from the embedded project, if available
+            if (BuildUtils.useEmbeddedTomcat(project))
+                project.evaluationDependsOn(BuildUtils.getEmbeddedProjectPath(project.gradle))
+        }
+
         addConfigurations(project)
         addDependencies(project)
         addTasks(project)

--- a/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
@@ -512,9 +512,10 @@ class FileModule implements Plugin<Project>
         Project serverProject = BuildUtils.getServerProject(project)
         if (serverProject != null && serverProject != project)
         {
-            BuildUtils.addLabKeyDependency(project: serverProject, config: 'modules', depProjectPath: project.path, depProjectConfig: 'published', depExtension: 'module')
+            project.evaluationDependsOn(BuildUtils.getServerProjectPath(project.gradle))
             // This is done after the project is evaluated otherwise the dependencies for the modules configuration will not have been added yet.
             project.afterEvaluate({
+                BuildUtils.addLabKeyDependency(project: serverProject, config: 'modules', depProjectPath: project.path, depProjectConfig: 'published', depExtension: 'module')
                 if (project.configurations.findByName("modules") != null)
                     project.configurations.modules.dependencies.each {
                         Dependency dep ->

--- a/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
@@ -19,12 +19,12 @@ import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.api.tasks.Copy
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.file.CopySpec
 import org.gradle.api.java.archives.Manifest
 import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.Delete
 import org.gradle.api.tasks.bundling.Jar
 import org.labkey.gradle.plugin.extension.LabKeyExtension
@@ -510,7 +510,7 @@ class FileModule implements Plugin<Project>
     private static void addDependencies(Project project)
     {
         Project serverProject = BuildUtils.getServerProject(project)
-        if (serverProject != null)
+        if (serverProject != null && serverProject != project)
         {
             BuildUtils.addLabKeyDependency(project: serverProject, config: 'modules', depProjectPath: project.path, depProjectConfig: 'published', depExtension: 'module')
             // This is done after the project is evaluated otherwise the dependencies for the modules configuration will not have been added yet.

--- a/src/main/groovy/org/labkey/gradle/plugin/Jsp.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Jsp.groovy
@@ -217,9 +217,8 @@ class Jsp implements Plugin<Project>
                         copy.from( { project.zipTree(project.configurations.jspTagLibs.getSingleFile()) } )
                         copy.filesMatching("web/WEB-INF/*") {it.path = it.path.replace("web/", "/") }
                         prefix = "web/"
-                        // exclude intermediate directories to avoid empty directories in destination
-                        copy.exclude "web"
-                        copy.exclude "web/WEB-INF"
+                        // 'path.replace' leaves some empty directories
+                        copy.setIncludeEmptyDirs false
                     }
                     copy.into "${project.buildDir}/${WEBAPP_DIR}"
                     copy.include "${prefix}WEB-INF/web.xml"

--- a/src/main/groovy/org/labkey/gradle/plugin/Jsp.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Jsp.groovy
@@ -210,7 +210,7 @@ class Jsp implements Plugin<Project>
                     String prefix = ""
                     if (project.findProject(BuildUtils.getApiProjectPath(project.gradle)) != null) {
                         // Copy taglib from source
-                        copy.from "${BuildUtils.getApiProjectPath(project.gradle).replace(":", "/").substring(1)}/webapp"
+                        copy.from project.rootProject.file("${BuildUtils.convertPathToRelativeDir(BuildUtils.getApiProjectPath(project.gradle))}/webapp")
                     }
                     else {
                         // Copy taglib from API module dependency

--- a/src/main/groovy/org/labkey/gradle/plugin/Jsp.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Jsp.groovy
@@ -108,12 +108,6 @@ class Jsp implements Plugin<Project>
                     jsp ("org.apache.tomcat:tomcat-jasper:${project.apacheTomcatVersion}") { transitive = false }
                     jsp ("org.apache.tomcat:tomcat-juli:${project.apacheTomcatVersion}") { transitive = false }
                 }
-        // We need this declaration for IntelliJ to be able to find the .tld files, but if we include
-        // it for the command line, there will be lots of warnings about .tld files on the classpath where
-        // they don't belong ("CLASSPATH element .../labkey.tld is not a JAR.").  These warnings may appear if
-        // building within IntelliJ but perhaps we can live with that (for now).
-//        if (BuildUtils.isIntellij())
-//            project.dependencies.add("implementation", getCopyTagLibsBase(project.gradle).get().inputs.files)
     }
 
     private void addJspTasks(Project project)
@@ -158,6 +152,10 @@ class Jsp implements Plugin<Project>
 
         def copyTagLibs = getCopyTagLibs(project)
         if (BuildUtils.isIntellij()) {
+            // We need this declaration for IntelliJ to be able to find the .tld files, but if we include
+            // it for the command line, there will be lots of warnings about .tld files on the classpath where
+            // they don't belong ("CLASSPATH element .../labkey.tld is not a JAR.").  These warnings may appear if
+            // building within IntelliJ but perhaps we can live with that (for now).
             project.dependencies.add("implementation", copyTagLibs.get().inputs.files)
         }
 

--- a/src/main/groovy/org/labkey/gradle/plugin/Jsp.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Jsp.groovy
@@ -233,6 +233,9 @@ class Jsp implements Plugin<Project>
                                     .ifPresentOrElse( { d -> copy.from(project.zipTree(d.getSingleFile()) ) } , { throw new GradleException("Unable to locate API artifact")})
                             copy.filesMatching("web/WEB-INF/*") {it.path = it.path.replace("web/", "/") }
                             prefix = "web/"
+                            // exclude intermediate directories to avoid empty directories in destination
+                            copy.exclude "web"
+                            copy.exclude "web/WEB-INF"
                         }
                         copy.into "${project.buildDir}/webapp"
                         copy.include "${prefix}WEB-INF/web.xml"

--- a/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
@@ -25,6 +25,7 @@ import org.gradle.api.artifacts.Dependency
 import org.gradle.api.file.CopySpec
 import org.gradle.api.file.DeleteSpec
 import org.gradle.api.file.FileCollection
+import org.gradle.api.file.FileTree
 import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency
 import org.gradle.api.internal.artifacts.dependencies.DefaultProjectDependency
 import org.gradle.api.tasks.Delete
@@ -313,7 +314,7 @@ class ServerDeploy implements Plugin<Project>
             Delete task ->
                 task.group = GroupNames.DEPLOY
                 task.description = "Removes the deploy directory ${serverDeploy.dir}"
-                task.dependsOn (project.tasks.stopTomcat, project.tasks.cleanStaging)
+                task.dependsOn (project.tasks.cleanStaging)
                 task.configure({ DeleteSpec spec ->
                     spec.delete serverDeploy.dir
                 })
@@ -341,12 +342,37 @@ class ServerDeploy implements Plugin<Project>
             Delete task ->
                 task.group = GroupNames.DEPLOY
                 task.description = "Remove the build directory ${project.rootProject.buildDir}"
-                task.dependsOn (project.tasks.stopTomcat)
                 task.configure({ DeleteSpec spec ->
                     spec.delete project.rootProject.buildDir
                 })
         }
         project.tasks.deployApp.mustRunAfter(project.tasks.cleanBuild)
+
+        Project serverProject = BuildUtils.getServerProject(project)
+        if (serverProject != null) {
+            project.tasks.register('stageTomcatJars', DefaultTask) {
+                DefaultTask task ->
+                    task.group = GroupNames.DEPLOY
+                    task.description = "Copy runtime Tomcat dependencies to ${staging.tomcatLibDir}"
+                    task.dependsOn(serverProject.configurations.tomcatJars)
+                    task.doLast({
+                        stageTomcatJars(task)
+                    })
+            }
+
+            project.tasks.register('deployTomcatJars', DefaultTask) {
+                DefaultTask task ->
+                    task.group = GroupNames.DEPLOY
+                    task.description = "Copying files from ${staging.tomcatLibDir} to \$CATALINA_HOME/lib"
+                    task.dependsOn(serverProject.tasks.stageTomcatJars)
+                    task.doLast({
+                        deployTomcatJars(task)
+                    })
+            }
+
+            project.tasks.stageApp.dependsOn(project.tasks.stageTomcatJars)
+            project.tasks.deployApp.dependsOn(project.tasks.deployTomcatJars)
+        }
 
         project.tasks.register(
                 'checkModuleTasks', DefaultTask) {
@@ -371,6 +397,96 @@ class ServerDeploy implements Plugin<Project>
         }
         project.tasks.deployApp.dependsOn(project.tasks.named("checkModuleTasks"))
         project.tasks.checkModuleTasks.mustRunAfter(project.tasks.stageApp) // do this so the message appears at the bottom of the output
+        project.pluginManager.withPlugin("tomcat") {
+            if (project.tomcat.hasCatalinaHome()) {
+                project.tasks.named("cleanBuild").configure {
+                    it.dependsOn(project.tasks.stopTomcat)
+                }
+                project.tasks.named("cleanDeploy").configure {
+                    it.dependsOn(project.tasks.stopTomcat)
+                }
+            }
+        }
+    }
+
+    private void stageTomcatJars(Task task) {
+        Project project = task.project
+        Project serverProject = BuildUtils.getServerProject(project)
+        // Remove the staging tomcatLib directory before copying into it to avoid duplicates.
+        project.delete project.staging.tomcatLibDir
+        // set debug logging for ant to see what's going wrong with the pickMssql task on Windows
+        task.ant.project.buildListeners[0].messageOutputLevel = 4
+        // for consistency with a distribution deployment and the treatment of all other deployment artifacts,
+        // first copy the tomcat jars into the staging directory
+
+        // We resolve the tomcatJars files outside of the ant copy because this seems to avoid
+        // an error we saw on TeamCity when running the pickMssql task on Windows when updating to Gradle 6.7
+        // The error in the gradle log was:
+        //       org.apache.tools.ant.BuildException: copy doesn't support the nested "exec" element.
+        // Theory is that when the files in the configuration have not been resolved, they get resolved
+        // inside the node being added to the ant task below and that is not supported.
+        FileTree tomcatJars = serverProject.configurations.tomcatJars.getAsFileTree()
+
+        if (tomcatJars.size() == 1 && tomcatJars.getAt(0).getName().endsWith(".zip")) {
+            // Crack open zipped published tomcat libs
+            tomcatJars = project.zipTree(tomcatJars.singleFile)
+        }
+        task.logger.info("Copying to ${project.staging.tomcatLibDir}")
+        task.logger.info("tomcatFiles are ${tomcatJars.files}")
+        project.ant.copy(
+                todir: project.staging.tomcatLibDir,
+                preserveLastModified: true,
+                overwrite: true // Issue 33473: overwrite the existing jars to facilitate switching to older versions of labkey with older dependencies
+        )
+                {
+                    tomcatJars.addToAntBuilder(project.ant, "fileset", FileCollection.AntType.FileSet)
+
+                    // Put unversioned files into the tomcatLibDir.  These files are meant to be copied into
+                    // the tomcat/lib directory when deploying a build or a distribution.  When version numbers change,
+                    // you will end up with multiple versions of these jar files on the classpath, which will often
+                    // result in problems of compatibility.  Additionally, we want to maintain the (incorrect) names
+                    // of the files that have been used with the Ant build process.
+                    //
+                    // We may employ CATALINA_BASE in order to separate our libraries from the ones that come with
+                    // the tomcat distribution. This will require updating our instructions for installation by clients
+                    // but would allow us to use artifacts with more self-documenting names.
+                    chainedmapper()
+                            {
+                                flattenmapper()
+                                // get rid of the version numbers on the jar files
+                                // matches on: name-X.Y.Z-SNAPSHOT.jar, name-X.Y.Z_branch-SNAPSHOT.jar, name-X.Y.Z.jar
+                                //
+                                // N.B.  Attempts to use BuildUtils.VERSIONED_ARTIFACT_NAME_PATTERN here fail for the javax.mail-X.Y.Z.jar file.
+                                // The Ant regexpmapper chooses only javax as \\1, which is not what is wanted
+                                regexpmapper(from: "^(.*?)(-\\d+(\\.\\d+)*(_.+)?(-SNAPSHOT)?)?\\.jar", to: "\\1.jar")
+                                filtermapper()
+                                        {
+                                            replacestring(from: "mysql-connector-java", to: "mysql")
+                                            // the Ant build used mysql.jar
+                                            replacestring(from: "javax.mail", to: "mail") // the Ant build used mail.jar
+                                            replacestring(from: "jakarta.mail", to: "mail")
+                                            // the Ant build used mail.jar
+                                            replacestring(from: "jakarta.activation", to: "javax.activation")
+                                            // the Ant build used javax.activation.jar
+                                        }
+                            }
+                }
+    }
+
+    private void deployTomcatJars(Task task) {
+        Project project = task.project
+        JDBC_JARS.each{String name -> new File("${project.tomcat.catalinaHome}/lib/${name}").delete()}
+
+        // Then copy them into the tomcat/lib directory
+        task.logger.info("Copying files from ${project.staging.tomcatLibDir} to ${project.tomcat.catalinaHome}/lib")
+        project.ant.copy(
+                todir: "${project.tomcat.catalinaHome}/lib",
+                preserveLastModified: true,
+                overwrite: true
+        )
+                {
+                    fileset(dir: project.staging.tomcatLibDir)
+                }
     }
 
     private linkBinaries(Project project, String packageMgr, String version, workDirectory) {

--- a/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
@@ -409,15 +409,16 @@ class ServerDeploy implements Plugin<Project>
         }
     }
 
+    /**
+     * For consistency with a distribution deployment and the treatment of all other deployment artifacts,
+     * first copy the tomcat jars into the staging directory
+     * @param task
+     */
     private void stageTomcatJars(Task task) {
         Project project = task.project
         Project serverProject = BuildUtils.getServerProject(project)
         // Remove the staging tomcatLib directory before copying into it to avoid duplicates.
         project.delete project.staging.tomcatLibDir
-        // set debug logging for ant to see what's going wrong with the pickMssql task on Windows
-        task.ant.project.buildListeners[0].messageOutputLevel = 4
-        // for consistency with a distribution deployment and the treatment of all other deployment artifacts,
-        // first copy the tomcat jars into the staging directory
 
         // We resolve the tomcatJars files outside of the ant copy because this seems to avoid
         // an error we saw on TeamCity when running the pickMssql task on Windows when updating to Gradle 6.7

--- a/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
@@ -58,7 +58,6 @@ class ServerDeploy implements Plugin<Project>
         serverDeploy.modulesDir = "${serverDeploy.dir}/modules"
         serverDeploy.webappDir = "${serverDeploy.dir}/labkeyWebapp"
         serverDeploy.binDir = "${serverDeploy.dir}/bin"
-        serverDeploy.rootWebappsDir = BuildUtils.getWebappConfigPath(project)
         serverDeploy.pipelineLibDir = "${serverDeploy.dir}/pipelineLib"
 
         project.apply plugin: 'org.labkey.build.base'

--- a/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
@@ -285,6 +285,7 @@ class ServerDeploy implements Plugin<Project>
                     task.group = GroupNames.DISTRIBUTION
                     task.description = "Deploy a LabKey distribution file from directory dist or directory specified with distDir property.  Use property distType to specify zip or tar.gz (default)."
                     task.dependsOn(project.tasks.stageDistribution, project.tasks.configureLog4j, project.tasks.setup)
+                    task.doFirst {deployTomcatJars(task)}
             }
 
 

--- a/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
@@ -194,16 +194,18 @@ class ServerDeploy implements Plugin<Project>
                 task.description = "Copy files needed for using remote pipeline jobs into ${staging.pipelineLibDir}"
                 task.doLast(
                         {
-                            project.ant.copy(
-                                    todir: staging.pipelineLibDir,
-                                    preserveLastModified: true
-                            )
-                                    {
-                                        project.configurations.remotePipelineJars { Configuration collection ->
-                                            collection.addToAntBuilder(project.ant, "fileset", FileCollection.AntType.FileSet)
+                            if (!project.configurations.remotePipelineJars.getFiles().isEmpty()) {
+                                project.ant.copy(
+                                        todir: staging.pipelineLibDir,
+                                        preserveLastModified: true
+                                )
+                                        {
+                                            project.configurations.remotePipelineJars { Configuration collection ->
+                                                collection.addToAntBuilder(project.ant, "fileset", FileCollection.AntType.FileSet)
 
+                                            }
                                         }
-                                    }
+                            }
                         }
                 )
         }
@@ -255,7 +257,7 @@ class ServerDeploy implements Plugin<Project>
 
         }
 
-        String log4jFile = project.hasProperty('log4j2Version') ? 'log4j2.xml' : 'log4j.xml'
+        String log4jFile = 'log4j2.xml'
         project.tasks.register('configureLog4j', ConfigureLog4J) {
             ConfigureLog4J task ->
                 task.fileName = log4jFile

--- a/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
@@ -58,7 +58,7 @@ class ServerDeploy implements Plugin<Project>
         serverDeploy.modulesDir = "${serverDeploy.dir}/modules"
         serverDeploy.webappDir = "${serverDeploy.dir}/labkeyWebapp"
         serverDeploy.binDir = "${serverDeploy.dir}/bin"
-        serverDeploy.rootWebappsDir = BuildUtils.getWebappConfigPath(project)
+        serverDeploy.rootWebappsDir = BuildUtils.getWebappConfigPath(project, this)
         serverDeploy.pipelineLibDir = "${serverDeploy.dir}/pipelineLib"
 
         project.apply plugin: 'org.labkey.build.base'

--- a/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
@@ -58,7 +58,7 @@ class ServerDeploy implements Plugin<Project>
         serverDeploy.modulesDir = "${serverDeploy.dir}/modules"
         serverDeploy.webappDir = "${serverDeploy.dir}/labkeyWebapp"
         serverDeploy.binDir = "${serverDeploy.dir}/bin"
-        serverDeploy.rootWebappsDir = BuildUtils.getWebappConfigPath(project, this)
+        serverDeploy.rootWebappsDir = BuildUtils.getWebappConfigPath(project)
         serverDeploy.pipelineLibDir = "${serverDeploy.dir}/pipelineLib"
 
         project.apply plugin: 'org.labkey.build.base'

--- a/src/main/groovy/org/labkey/gradle/plugin/Standalone.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Standalone.groovy
@@ -5,22 +5,19 @@ import org.gradle.api.Project
 import org.labkey.gradle.util.BuildUtils
 
 /**
- * Use to build modules without platform repository and to build distributions without the server repository
- * Module will build normally unless the 'standaloneBuild' property is set, in which case, additional plugins will be
- * applied to allow the module to build distributions outside of a server repository.
+ * Use to build distributions without the server repository.
+ * Apply to the 'distributions' project of a standalone module.
+ * Plugin will no-op if target project doesn't match 'gradle.ext.serverProjectPath'
  */
 class Standalone implements Plugin<Project> {
 
     void apply(Project project) {
-        project.apply plugin: 'org.labkey.build.module'
-
-        if (BuildUtils.isStandaloneBuild(project)) {
+        if (BuildUtils.getServerProjectPath(project.gradle).equals(project.getPath())) {
             project.apply plugin: 'org.labkey.build.serverDeploy'
 
-            project.dependencies
-                    {
-                        tomcatJars  "org.labkey.build:tomcat-libs:${project.labkeyVersion}"
-                    }
+            project.dependencies {
+                tomcatJars  "org.labkey.build:tomcat-libs:${project.labkeyVersion}"
+            }
         }
     }
 }

--- a/src/main/groovy/org/labkey/gradle/plugin/Standalone.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Standalone.groovy
@@ -1,0 +1,59 @@
+package org.labkey.gradle.plugin
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+/**
+ * Use to build modules without platform repository and to build distributions without the server repository
+ */
+class Standalone implements Plugin<Project> {
+
+    void apply(Project project) {
+        project.apply plugin: 'org.labkey.build.module'
+
+        if (project.standaloneBuild) {
+            project.apply plugin: 'org.labkey.build.tomcat'
+            project.apply plugin: 'org.labkey.build.serverDeploy'
+
+            project.allprojects {
+                repositories {
+                    mavenLocal()
+                    maven {
+                        url "${project.artifactory_contextUrl}/ext-tools-local"
+                    }
+                    maven {
+                        url "${project.artifactory_contextUrl}/libs-release"
+                    }
+                    maven {
+                        url "${project.artifactory_contextUrl}/libs-snapshot"
+                    }
+                    jcenter()
+                }
+            }
+
+            project.dependencies
+                    {
+                        tomcatJars  "org.labkey.build:tomcat-libs:${project.labkeyVersion}"
+                    }
+        }
+
+        project.dependencies {
+
+            modules("org.labkey.module:api:${project.labkeyVersion}@module") {
+                transitive = true
+            }
+            modules("org.labkey.module:internal:${project.labkeyVersion}@module") {
+                transitive = true
+            }
+            modules("org.labkey.module:audit:${project.labkeyVersion}@module") {
+                transitive = true
+            }
+            modules("org.labkey.module:core:${project.labkeyVersion}@module") {
+                transitive = true
+            }
+
+            // include core API
+            implementation "org.labkey.api:core:${project.labkeyVersion}"
+        }
+    }
+}

--- a/src/main/groovy/org/labkey/gradle/plugin/Standalone.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Standalone.groovy
@@ -2,16 +2,19 @@ package org.labkey.gradle.plugin
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.labkey.gradle.util.BuildUtils
 
 /**
  * Use to build modules without platform repository and to build distributions without the server repository
+ * Module will build normally unless the 'standaloneBuild' property is set, in which case, additional plugins will be
+ * applied to allow the module to build distributions outside of a server repository.
  */
 class Standalone implements Plugin<Project> {
 
     void apply(Project project) {
         project.apply plugin: 'org.labkey.build.module'
 
-        if (project.hasProperty("standaloneBuild")) {
+        if (BuildUtils.isStandaloneBuild(project)) {
             project.apply plugin: 'org.labkey.build.tomcat'
             project.apply plugin: 'org.labkey.build.serverDeploy'
 

--- a/src/main/groovy/org/labkey/gradle/plugin/Standalone.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Standalone.groovy
@@ -15,7 +15,6 @@ class Standalone implements Plugin<Project> {
         project.apply plugin: 'org.labkey.build.module'
 
         if (BuildUtils.isStandaloneBuild(project)) {
-            project.apply plugin: 'org.labkey.build.tomcat'
             project.apply plugin: 'org.labkey.build.serverDeploy'
 
             project.dependencies

--- a/src/main/groovy/org/labkey/gradle/plugin/Standalone.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Standalone.groovy
@@ -22,24 +22,5 @@ class Standalone implements Plugin<Project> {
                         tomcatJars  "org.labkey.build:tomcat-libs:${project.labkeyVersion}"
                     }
         }
-
-        project.dependencies {
-
-            modules("org.labkey.module:api:${project.labkeyVersion}@module") {
-                transitive = true
-            }
-            modules("org.labkey.module:internal:${project.labkeyVersion}@module") {
-                transitive = true
-            }
-            modules("org.labkey.module:audit:${project.labkeyVersion}@module") {
-                transitive = true
-            }
-            modules("org.labkey.module:core:${project.labkeyVersion}@module") {
-                transitive = true
-            }
-
-            // include core API
-            implementation "org.labkey.api:core:${project.labkeyVersion}"
-        }
     }
 }

--- a/src/main/groovy/org/labkey/gradle/plugin/Standalone.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Standalone.groovy
@@ -18,22 +18,6 @@ class Standalone implements Plugin<Project> {
             project.apply plugin: 'org.labkey.build.tomcat'
             project.apply plugin: 'org.labkey.build.serverDeploy'
 
-            project.allprojects {
-                repositories {
-                    mavenLocal()
-                    maven {
-                        url "${project.artifactory_contextUrl}/ext-tools-local"
-                    }
-                    maven {
-                        url "${project.artifactory_contextUrl}/libs-release"
-                    }
-                    maven {
-                        url "${project.artifactory_contextUrl}/libs-snapshot"
-                    }
-                    jcenter()
-                }
-            }
-
             project.dependencies
                     {
                         tomcatJars  "org.labkey.build:tomcat-libs:${project.labkeyVersion}"

--- a/src/main/groovy/org/labkey/gradle/plugin/Standalone.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Standalone.groovy
@@ -11,7 +11,7 @@ class Standalone implements Plugin<Project> {
     void apply(Project project) {
         project.apply plugin: 'org.labkey.build.module'
 
-        if (project.standaloneBuild) {
+        if (project.hasProperty("standaloneBuild")) {
             project.apply plugin: 'org.labkey.build.tomcat'
             project.apply plugin: 'org.labkey.build.serverDeploy'
 

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/ServerDeployExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/ServerDeployExtension.groovy
@@ -16,7 +16,6 @@
 package org.labkey.gradle.plugin.extension
 
 import org.gradle.api.Project
-import org.gradle.api.file.FileTree
 
 class ServerDeployExtension
 {
@@ -25,7 +24,6 @@ class ServerDeployExtension
     String modulesDir
     String webappDir
     String binDir
-    FileTree rootWebappsDir
     String pipelineLibDir
 
     static String getServerDeployDirectory(Project project)

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/ServerDeployExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/ServerDeployExtension.groovy
@@ -16,6 +16,7 @@
 package org.labkey.gradle.plugin.extension
 
 import org.gradle.api.Project
+import org.gradle.api.file.FileTree
 
 class ServerDeployExtension
 {
@@ -24,7 +25,7 @@ class ServerDeployExtension
     String modulesDir
     String webappDir
     String binDir
-    String rootWebappsDir
+    FileTree rootWebappsDir
     String pipelineLibDir
 
     static String getServerDeployDirectory(Project project)

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/TomcatExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/TomcatExtension.groovy
@@ -74,6 +74,11 @@ class TomcatExtension
         }
     }
 
+    boolean hasCatalinaHome()
+    {
+        return catalinaHome != null && !catalinaHome.isEmpty()
+    }
+
     private void setCatalinaDirs(Project project)
     {
         if (System.getenv("CATALINA_HOME") != null)

--- a/src/main/groovy/org/labkey/gradle/task/ConfigureLog4J.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ConfigureLog4J.groovy
@@ -37,7 +37,7 @@ class ConfigureLog4J extends DefaultTask
     @InputFile
     File getLog4jXml()
     {
-        return new File((String) project.serverDeploy.rootWebappsDir, fileName)
+        return project.serverDeploy.rootWebappsDir.matching {include fileName}.singleFile
     }
 
     @OutputFile

--- a/src/main/groovy/org/labkey/gradle/task/ConfigureLog4J.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ConfigureLog4J.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.labkey.gradle.plugin.extension.LabKeyExtension
+import org.labkey.gradle.util.BuildUtils
 
 /**
  * Used to copy over the log4j.xml template file and replace the consoleAppender value
@@ -37,7 +38,7 @@ class ConfigureLog4J extends DefaultTask
     @InputFile
     File getLog4jXml()
     {
-        return project.serverDeploy.rootWebappsDir.matching {include fileName}.singleFile
+        return BuildUtils.getWebappConfigFile(project, fileName)
     }
 
     @OutputFile

--- a/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
@@ -89,7 +89,7 @@ class DoThenSetup extends DefaultTask
                 configProperties.putAll(getExtraJdbcProperties())
                 configProperties.setProperty("appDocBase", appDocBase)
                 boolean isNextLineComment = false
-                FileTree webappsDir = BuildUtils.getWebappConfigPath(project)
+                FileTree webappsDir = BuildUtils.getWebappConfigPath(project, this)
                 project.copy({ CopySpec copy ->
                     copy.from webappsDir
                     copy.into "${project.rootProject.buildDir}"

--- a/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
@@ -87,11 +87,10 @@ class DoThenSetup extends DefaultTask
                 configProperties.putAll(getExtraJdbcProperties())
                 configProperties.setProperty("appDocBase", appDocBase)
                 boolean isNextLineComment = false
-                FileTree webappsDir = BuildUtils.getWebappConfigPath(project)
+                File labkeyXml = BuildUtils.getWebappConfigFile(project, "labkey.xml")
                 project.copy({ CopySpec copy ->
-                    copy.from webappsDir
+                    copy.from labkeyXml
                     copy.into "${project.rootProject.buildDir}"
-                    copy.include "labkey.xml"
                     copy.filter({ String line ->
                         if (project.ext.has('enableJms') && project.ext.enableJms) {
                             line = line.replace("<!--@@jmsConfig@@", "")

--- a/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.CopySpec
 import org.gradle.api.file.FileCollection
+import org.gradle.api.file.FileTree
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
@@ -88,7 +89,7 @@ class DoThenSetup extends DefaultTask
                 configProperties.putAll(getExtraJdbcProperties())
                 configProperties.setProperty("appDocBase", appDocBase)
                 boolean isNextLineComment = false
-                String webappsDir = BuildUtils.getWebappConfigPath(project)
+                FileTree webappsDir = BuildUtils.getWebappConfigPath(project)
                 project.copy({ CopySpec copy ->
                     copy.from webappsDir
                     copy.into "${project.rootProject.buildDir}"

--- a/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
@@ -89,7 +89,7 @@ class DoThenSetup extends DefaultTask
                 configProperties.putAll(getExtraJdbcProperties())
                 configProperties.setProperty("appDocBase", appDocBase)
                 boolean isNextLineComment = false
-                FileTree webappsDir = BuildUtils.getWebappConfigPath(project, this)
+                FileTree webappsDir = BuildUtils.getWebappConfigPath(project)
                 project.copy({ CopySpec copy ->
                     copy.from webappsDir
                     copy.into "${project.rootProject.buildDir}"

--- a/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
@@ -17,14 +17,10 @@ package org.labkey.gradle.task
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
-import org.gradle.api.Project
 import org.gradle.api.file.CopySpec
-import org.gradle.api.file.FileCollection
-import org.gradle.api.file.FileTree
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
-import org.labkey.gradle.plugin.ServerDeploy
 import org.labkey.gradle.plugin.extension.TeamCityExtension
 import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.DatabaseProperties
@@ -36,13 +32,6 @@ class DoThenSetup extends DefaultTask
     protected DatabaseProperties databaseProperties
     @Input
     boolean dbPropertiesChanged = false
-
-    DoThenSetup()
-    {
-        Project serverProject = BuildUtils.getServerProject(project)
-        if (serverProject != null)
-            this.dependsOn serverProject.configurations.tomcatJars
-    }
 
     private static boolean canCreate(File file)
     {
@@ -166,9 +155,6 @@ class DoThenSetup extends DefaultTask
                 })
             }
         }
-        if (BuildUtils.getServerProject(project) != null)
-            copyTomcatJars()
-
     }
 
     private Properties getExtraJdbcProperties()
@@ -207,80 +193,6 @@ class DoThenSetup extends DefaultTask
             }
         }
         return false
-    }
-
-    private void copyTomcatJars()
-    {
-        Project serverProject = BuildUtils.getServerProject(project)
-        // Remove the staging tomcatLib directory before copying into it to avoid duplicates.
-        project.delete project.staging.tomcatLibDir
-        // set debug logging for ant to see what's going wrong with the pickMssql task on Windows
-        ant.project.buildListeners[0].messageOutputLevel = 4
-        // for consistency with a distribution deployment and the treatment of all other deployment artifacts,
-        // first copy the tomcat jars into the staging directory
-
-        // We resolve the tomcatJars files outside of the ant copy because this seems to avoid
-        // an error we saw on TeamCity when running the pickMssql task on Windows when updating to Gradle 6.7
-        // The error in the gradle log was:
-        //       org.apache.tools.ant.BuildException: copy doesn't support the nested "exec" element.
-        // Theory is that when the files in the configuration have not been resolved, they get resolved
-        // inside the node being added to the ant task below and that is not supported.
-        FileTree tomcatJars = serverProject.configurations.tomcatJars.getAsFileTree()
-
-        if (tomcatJars.size() == 1 && tomcatJars.getAt(0).getName().endsWith(".zip")) {
-            // Crack open zipped published tomcat libs
-            tomcatJars = project.zipTree(tomcatJars.singleFile)
-        }
-        this.logger.info("Copying to ${project.staging.tomcatLibDir}")
-        this.logger.info("tomcatFiles are ${tomcatJars.files}")
-        project.ant.copy(
-                todir: project.staging.tomcatLibDir,
-                preserveLastModified: true,
-                overwrite: true // Issue 33473: overwrite the existing jars to facilitate switching to older versions of labkey with older dependencies
-        )
-            {
-                tomcatJars.addToAntBuilder(project.ant, "fileset", FileCollection.AntType.FileSet)
-
-                // Put unversioned files into the tomcatLibDir.  These files are meant to be copied into
-                // the tomcat/lib directory when deploying a build or a distribution.  When version numbers change,
-                // you will end up with multiple versions of these jar files on the classpath, which will often
-                // result in problems of compatibility.  Additionally, we want to maintain the (incorrect) names
-                // of the files that have been used with the Ant build process.
-                //
-                // We may employ CATALINA_BASE in order to separate our libraries from the ones that come with
-                // the tomcat distribution. This will require updating our instructions for installation by clients
-                // but would allow us to use artifacts with more self-documenting names.
-                chainedmapper()
-                        {
-                            flattenmapper()
-                            // get rid of the version numbers on the jar files
-                            // matches on: name-X.Y.Z-SNAPSHOT.jar, name-X.Y.Z_branch-SNAPSHOT.jar, name-X.Y.Z.jar
-                            //
-                            // N.B.  Attempts to use BuildUtils.VERSIONED_ARTIFACT_NAME_PATTERN here fail for the javax.mail-X.Y.Z.jar file.
-                            // The Ant regexpmapper chooses only javax as \\1, which is not what is wanted
-                            regexpmapper(from: "^(.*?)(-\\d+(\\.\\d+)*(_.+)?(-SNAPSHOT)?)?\\.jar", to: "\\1.jar")
-                            filtermapper()
-                                    {
-                                        replacestring(from: "mysql-connector-java", to: "mysql") // the Ant build used mysql.jar
-                                        replacestring(from: "javax.mail", to: "mail") // the Ant build used mail.jar
-                                        replacestring(from: "jakarta.mail", to: "mail") // the Ant build used mail.jar
-                                        replacestring(from: "jakarta.activation", to: "javax.activation") // the Ant build used javax.activation.jar
-                                    }
-                        }
-            }
-
-        ServerDeploy.JDBC_JARS.each{String name -> new File("${project.tomcat.catalinaHome}/lib/${name}").delete()}
-
-        // Then copy them into the tomcat/lib directory
-        this.logger.info("Copying files from ${project.staging.tomcatLibDir} to ${project.tomcat.catalinaHome}/lib")
-        project.ant.copy(
-                todir: "${project.tomcat.catalinaHome}/lib",
-                preserveLastModified: true,
-                overwrite: true
-        )
-        {
-            fileset(dir: project.staging.tomcatLibDir)
-        }
     }
 
     boolean embeddedConfigUpToDate()

--- a/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
@@ -195,7 +195,7 @@ class ModuleDistribution extends DefaultTask
 
         project.copy
         { CopySpec copy ->
-            copy.from(BuildUtils.getWebappConfigPath(project))
+            copy.from(BuildUtils.getWebappConfigPath(project, this))
             copy.include("labkey.xml")
             copy.into(project.buildDir)
             copy.filter({ String line ->
@@ -494,7 +494,7 @@ class ModuleDistribution extends DefaultTask
     {
         writeDistributionFile()
         writeVersionFile()
-        FileTree zipFile = getDistributionResources(project)
+        FileTree zipFile = getDistributionResources(project, this)
         project.copy({ CopySpec copy ->
             copy.from(zipFile)
             copy.exclude "*.xml"
@@ -506,11 +506,11 @@ class ModuleDistribution extends DefaultTask
         project.ant.fixcrlf (srcdir: project.buildDir, includes: "manual-upgrade.sh", eol: "unix")
     }
 
-    public static FileTree getDistributionResources(Project project) {
+    static FileTree getDistributionResources(Project project, Object taskOrPlugin) {
         // This seems a very convoluted way to get to the zip file in the jar file.  Using the classLoader did not
         // work as expected, however.  Following the example from here:
         // https://discuss.gradle.org/t/gradle-plugin-copy-directory-tree-with-files-from-resources/12767/7
-        FileTree jarTree = project.zipTree(ModuleDistribution.class.getProtectionDomain().getCodeSource().getLocation().toExternalForm())
+        FileTree jarTree = project.zipTree(taskOrPlugin.getClass().getProtectionDomain().getCodeSource().getLocation().toExternalForm())
 
         def tree = project.zipTree(
                 jarTree.matching({

--- a/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
@@ -51,6 +51,8 @@ class ModuleDistribution extends DefaultTask
     String archivePrefix = "LabKey"
     @Optional @Input
     String archiveName
+    @Optional @Input
+    boolean simpleDistribution = false
 
     @OutputDirectory
     File distributionDir
@@ -193,7 +195,7 @@ class ModuleDistribution extends DefaultTask
 
         project.copy
         { CopySpec copy ->
-            copy.from("${project.rootProject.projectDir}/webapps")
+            copy.from(BuildUtils.getWebappConfigPath(project))
             copy.include("labkey.xml")
             copy.into(project.buildDir)
             copy.filter({ String line ->
@@ -303,9 +305,11 @@ class ModuleDistribution extends DefaultTask
                     exclude(name: "bootstrap.jar")
                 }
 
-                tarfileset(dir: utilsDir.path, prefix: "${archiveName}/bin")
+                if (!simpleDistribution) {
+                    tarfileset(dir: utilsDir.path, prefix: "${archiveName}/bin")
 
-                tarfileset(dir: staging.pipelineLibDir, prefix: "${archiveName}/pipeline-lib")
+                    tarfileset(dir: staging.pipelineLibDir, prefix: "${archiveName}/pipeline-lib")
+                }
 
                 tarfileset(dir: "${project.buildDir}/",
                         prefix: archiveName,
@@ -361,9 +365,11 @@ class ModuleDistribution extends DefaultTask
                     exclude(name: "bootstrap.jar")
                 }
 
-                zipfileset(dir: utilsDir.path, prefix: "${archiveName}/bin")
+                if (!simpleDistribution) {
+                    zipfileset(dir: utilsDir.path, prefix: "${archiveName}/bin")
 
-                zipfileset(dir: staging.pipelineLibDir, prefix: "${archiveName}/pipeline-lib")
+                    zipfileset(dir: staging.pipelineLibDir, prefix: "${archiveName}/pipeline-lib")
+                }
 
                 zipfileset(dir: "${project.buildDir}/",
                         prefix: "${archiveName}",

--- a/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
@@ -66,7 +66,6 @@ class ModuleDistribution extends DefaultTask
         distExtension = project.extensions.findByType(DistributionExtension.class)
 
         Project serverProject = BuildUtils.getServerProject(project)
-        this.dependsOn(serverProject.tasks.named("setup"))
         this.dependsOn(serverProject.tasks.named("stageApp"))
         if (!BuildUtils.isOpenSource(project)) {
             this.dependsOn(findLicensingProject().tasks.named("patchApiModule"))

--- a/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
@@ -195,8 +195,7 @@ class ModuleDistribution extends DefaultTask
 
         project.copy
         { CopySpec copy ->
-            copy.from(BuildUtils.getWebappConfigPath(project))
-            copy.include("labkey.xml")
+            copy.from(BuildUtils.getWebappConfigFile(project, "labkey.xml"))
             copy.into(project.buildDir)
             copy.filter({ String line ->
                 return PropertiesUtils.replaceProps(line, copyProps, true)

--- a/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
@@ -51,7 +51,7 @@ class ModuleDistribution extends DefaultTask
     String archivePrefix = "LabKey"
     @Optional @Input
     String archiveName
-    @Optional @Input
+    @Input
     boolean simpleDistribution = false // Set to true to exclude pipeline tools and remote pipeline libraries
 
     @OutputDirectory

--- a/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
@@ -195,7 +195,7 @@ class ModuleDistribution extends DefaultTask
 
         project.copy
         { CopySpec copy ->
-            copy.from(BuildUtils.getWebappConfigPath(project, this))
+            copy.from(BuildUtils.getWebappConfigPath(project))
             copy.include("labkey.xml")
             copy.into(project.buildDir)
             copy.filter({ String line ->
@@ -494,7 +494,7 @@ class ModuleDistribution extends DefaultTask
     {
         writeDistributionFile()
         writeVersionFile()
-        FileTree zipFile = getDistributionResources(project, this)
+        FileTree zipFile = getDistributionResources(project)
         project.copy({ CopySpec copy ->
             copy.from(zipFile)
             copy.exclude "*.xml"
@@ -506,11 +506,11 @@ class ModuleDistribution extends DefaultTask
         project.ant.fixcrlf (srcdir: project.buildDir, includes: "manual-upgrade.sh", eol: "unix")
     }
 
-    static FileTree getDistributionResources(Project project, Object taskOrPlugin) {
+    public static FileTree getDistributionResources(Project project) {
         // This seems a very convoluted way to get to the zip file in the jar file.  Using the classLoader did not
         // work as expected, however.  Following the example from here:
         // https://discuss.gradle.org/t/gradle-plugin-copy-directory-tree-with-files-from-resources/12767/7
-        FileTree jarTree = project.zipTree(taskOrPlugin.getClass().getProtectionDomain().getCodeSource().getLocation().toExternalForm())
+        FileTree jarTree = project.zipTree(ModuleDistribution.class.getProtectionDomain().getCodeSource().getLocation().toExternalForm())
 
         def tree = project.zipTree(
                 jarTree.matching({

--- a/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
@@ -52,7 +52,7 @@ class ModuleDistribution extends DefaultTask
     @Optional @Input
     String archiveName
     @Optional @Input
-    boolean simpleDistribution = false
+    boolean simpleDistribution = false // Set to true to exclude pipeline tools and remote pipeline libraries
 
     @OutputDirectory
     File distributionDir

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -689,11 +689,6 @@ class BuildUtils
         return project.hasProperty("doDistributionPublish")
     }
 
-    static Boolean isStandaloneBuild(Project project)
-    {
-        return project.hasProperty("standaloneBuild")
-    }
-
     static Boolean isIntellij()
     {
         return System.properties.'idea.active'

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -756,14 +756,14 @@ class BuildUtils
             return jarFiles[0]
     }
 
-    static FileTree getWebappConfigPath(Project project)
+    static FileTree getWebappConfigPath(Project project, Object taskOrPlugin)
     {
         if (project.rootProject.file("webapps").exists())
             return project.rootProject.fileTree("webapps")
         else if (project.rootProject.file("server/configs/webapps").exists())
             return project.rootProject.fileTree("server/configs/webapps")
         else
-            return ModuleDistribution.getDistributionResources(project)
+            return ModuleDistribution.getDistributionResources(project, taskOrPlugin)
     }
 
     static boolean useEmbeddedTomcat(Project project)

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -18,12 +18,14 @@ package org.labkey.gradle.util
 import org.apache.commons.lang3.StringUtils
 import org.gradle.api.GradleException
 import org.gradle.api.Project
+import org.gradle.api.file.FileTree
 import org.gradle.api.initialization.Settings
 import org.gradle.api.invocation.Gradle
 import org.labkey.gradle.plugin.extension.LabKeyExtension
 import org.labkey.gradle.plugin.extension.ModuleExtension
 import org.labkey.gradle.plugin.extension.ServerDeployExtension
 import org.labkey.gradle.plugin.extension.TeamCityExtension
+import org.labkey.gradle.task.ModuleDistribution
 
 import java.nio.file.Files
 import java.nio.file.Paths
@@ -754,14 +756,14 @@ class BuildUtils
             return jarFiles[0]
     }
 
-    static String getWebappConfigPath(Project project)
+    static FileTree getWebappConfigPath(Project project)
     {
         if (project.rootProject.file("webapps").exists())
-            return "${project.rootProject.projectDir}/webapps/"
+            return project.rootProject.fileTree("webapps")
         else if (project.rootProject.file("server/configs/webapps").exists())
-            return "${project.rootProject.projectDir}/server/configs/webapps/"
+            return project.rootProject.fileTree("server/configs/webapps")
         else
-            throw new GradleException("Unable to find webapps config directory")
+            return ModuleDistribution.getDistributionResources(project)
     }
 
     static boolean useEmbeddedTomcat(Project project)

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -689,6 +689,11 @@ class BuildUtils
         return project.hasProperty("doDistributionPublish")
     }
 
+    static Boolean isStandaloneBuild(Project project)
+    {
+        return project.hasProperty("standaloneBuild")
+    }
+
     static Boolean isIntellij()
     {
         return System.properties.'idea.active'

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -18,7 +18,6 @@ package org.labkey.gradle.util
 import org.apache.commons.lang3.StringUtils
 import org.gradle.api.GradleException
 import org.gradle.api.Project
-import org.gradle.api.file.FileTree
 import org.gradle.api.initialization.Settings
 import org.gradle.api.invocation.Gradle
 import org.labkey.gradle.plugin.extension.LabKeyExtension
@@ -756,14 +755,14 @@ class BuildUtils
             return jarFiles[0]
     }
 
-    static FileTree getWebappConfigPath(Project project)
+    static File getWebappConfigFile(Project project, String fileName)
     {
-        if (project.rootProject.file("webapps").exists())
-            return project.rootProject.fileTree("webapps")
-        else if (project.rootProject.file("server/configs/webapps").exists())
-            return project.rootProject.fileTree("server/configs/webapps")
+        if (project.rootProject.file("webapps/" + fileName).exists())
+            return project.rootProject.fileTree("webapps/" + fileName).singleFile
+        else if (project.rootProject.file("server/configs/webapps/" + fileName).exists())
+            return project.rootProject.fileTree("server/configs/webapps/" + fileName).singleFile
         else
-            return ModuleDistribution.getDistributionResources(project)
+            return ModuleDistribution.getDistributionResources(project).matching {fileName}.singleFile
     }
 
     static boolean useEmbeddedTomcat(Project project)

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -756,14 +756,14 @@ class BuildUtils
             return jarFiles[0]
     }
 
-    static FileTree getWebappConfigPath(Project project, Object taskOrPlugin)
+    static FileTree getWebappConfigPath(Project project)
     {
         if (project.rootProject.file("webapps").exists())
             return project.rootProject.fileTree("webapps")
         else if (project.rootProject.file("server/configs/webapps").exists())
             return project.rootProject.fileTree("server/configs/webapps")
         else
-            return ModuleDistribution.getDistributionResources(project, taskOrPlugin)
+            return ModuleDistribution.getDistributionResources(project)
     }
 
     static boolean useEmbeddedTomcat(Project project)

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -762,7 +762,7 @@ class BuildUtils
         else if (project.rootProject.file("server/configs/webapps/" + fileName).exists())
             return project.rootProject.fileTree("server/configs/webapps/" + fileName).singleFile
         else
-            return ModuleDistribution.getDistributionResources(project).matching {fileName}.singleFile
+            return ModuleDistribution.getDistributionResources(project).matching {include fileName}.singleFile
     }
 
     static boolean useEmbeddedTomcat(Project project)


### PR DESCRIPTION
#### Rationale
Plugin requires updates to allow modules to build distributions outside of a normal development environment.

#### Related Pull Requests
* FDA-MyStudies/Response#14
* LabKey/server#72

#### Changes
* Update `copyTagLibs` to build JSPs without platform repository present
* Enable standalone modules to build distributions
  * Create `standalone` plugin to access `tomcat-libs` and staging tasks without `server` repository
  * Add `labkey.xml` and `log4j2.xml` do `distributionResoureces`
