### PR TITLE
Issue 43207: Don't create a jar file for file modules

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="12" />
+    <bytecodeTargetLevel target="15" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -7,5 +7,5 @@
   <component name="JavaScriptSettings">
     <option name="languageLevel" value="ES6" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_12" default="true" project-jdk-name="12" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_15" default="true" project-jdk-name="15" project-jdk-type="JavaSDK" />
 </project>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ on how to do that, including how to develop and test locally and the versioning 
 ### TBD
 *Released*: TBD
 (Earliest compatible LabKey version: 21.3)
-* [Issue 43207](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43207): When building a file module, we don't want to create a jar file because that prevents the module from being used in the module editor
+* [Issue 43207](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43207): When building a file module, we don't want to create a jar file because that prevents the module from being used in the module loader
 
 ### 1.26.0
 *Released*: 9 April 2021

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ If you are making changes to the plugins, please see the [internal docs](https:/
 on how to do that, including how to develop and test locally and the versioning information.
 
 ## Release Notes
+### TBD
+*Released*: TBD
+(Earliest compatible LabKey version: 21.3)
+* [Issue 43207](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43207): When building a file module, we don't want to create a jar file because that prevents the module from being used in the module editor
+
 ### 1.26.0
 *Released*: 9 April 2021
 (Earliest compatible LabKey version: 21.3)

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.27.0-fileModules-SNAPSHOT"
+project.version = "1.27.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.27.0-SNAPSHOT"
+project.version = "1.27.0-fileModules-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
@@ -211,10 +211,6 @@ class FileModule implements Plugin<Project>
             Task moduleFile = project.tasks.module
 
             moduleFile.dependsOn(project.tasks.named('processResources'))
-
-
-            if (SpringConfig.isApplicable(project))
-                moduleFile.dependsOn(project.tasks.named('processResources'))
             moduleFile.dependsOn(moduleXmlTask)
             setJarManifestAttributes(project, (Manifest) moduleFile.manifest)
             if (!LabKeyExtension.isDevMode(project))

--- a/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
@@ -210,33 +210,8 @@ class FileModule implements Plugin<Project>
 
             Task moduleFile = project.tasks.module
 
-            if (project.plugins.findPlugin(JavaModule.class) != null) {
-                def populateLib = project.tasks.register("populateExplodedLib", Copy) {
-                    CopySpec copy ->
-                        copy.group = GroupNames.MODULE
-                        copy.description = "Copy the jar files needed for the module into the ${project.labkey.explodedModuleLibDir} directory from their respective output directories"
-                        copy.into project.labkey.explodedModuleLibDir
-                        if (project.tasks.findByName("jar") != null)
-                            copy.from project.tasks.named("jar")
-                        if (project.tasks.findByName("apiJar") != null)
-                            copy.from project.tasks.named("apiJar")
-                        if (project.tasks.findByName("jspJar") != null)
-                            copy.from project.tasks.named('jspJar')
-                        if (project.tasks.findByName("copyExternalLibs") != null)
-                            copy.from project.tasks.named('copyExternalLibs')
-                }
-                populateLib.configure {
-                    it.doFirst {
-                        File explodedLibDir = new File(project.labkey.explodedModuleLibDir)
-                        if (explodedLibDir.exists())
-                            explodedLibDir.delete()
-                    }
-                }
-                moduleFile.dependsOn(populateLib)
-            }
-            else {
-                moduleFile.dependsOn(project.tasks.named('processResources'))
-            }
+            moduleFile.dependsOn(project.tasks.named('processResources'))
+
 
             if (SpringConfig.isApplicable(project))
                 moduleFile.dependsOn(project.tasks.named('processResources'))


### PR DESCRIPTION
#### Rationale
If a file module contains a jar file, even if it's an empty jar file, it can't be used in the module editor (since that's interpreted as a module that contains java code).  With PR #122, some dependencies were added that inadvertently caused the jar task for be run for every file module.  This PR fixes that

#### Related Pull Requests
* #122 

#### Changes
* Don't create or configure the `populateExplodedLib` task for file modules
