### PR TITLE
Add constants for common licenses, update to Gradle 7.1, and fix check for tomcat plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ on how to do that, including how to develop and test locally and the versioning 
 (Earliest compatible LabKey version: 21.3)
 * Add some constants helpful for declaring external dependencies
 * Fix check for tomcat plugin so `cleanBuild` and `cleanDeploy` will stop tomcat if available
+* Update to gradle 7.1
 
 ### 1.27.0
 *Released*: 26 May 2021

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ If you are making changes to the plugins, please see the [internal docs](https:/
 on how to do that, including how to develop and test locally and the versioning information.
 
 ## Release Notes
+### TBD
+*Released*: TBD
+(Earliest compatible LabKey version: 21.3)
+* Add some constants helpful for declaring external dependencies
+
 ### 1.27.0
 *Released*: 26 May 2021
 (Earliest compatible LabKey version: 21.3)

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ If you are making changes to the plugins, please see the [internal docs](https:/
 on how to do that, including how to develop and test locally and the versioning information.
 
 ## Release Notes
-### TBD
-*Released*: TBD
+### 1.28.0
+*Released*: 16 June 2021
 (Earliest compatible LabKey version: 21.3)
 * Add some constants helpful for declaring external dependencies
 * Fix check for tomcat plugin so `cleanBuild` and `cleanDeploy` will stop tomcat if available

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ on how to do that, including how to develop and test locally and the versioning 
 *Released*: TBD
 (Earliest compatible LabKey version: 21.3)
 * Add some constants helpful for declaring external dependencies
+* Fix check for tomcat plugin so `cleanBuild` and `cleanDeploy` will stop tomcat if available
 
 ### 1.27.0
 *Released*: 26 May 2021

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ on how to do that, including how to develop and test locally and the versioning 
 * Add some constants helpful for declaring external dependencies
 * Fix check for tomcat plugin so `cleanBuild` and `cleanDeploy` will stop tomcat if available
 * Update to gradle 7.1
+* Change from deprecated javaExec.main to javaExec.mainClass
 
 ### 1.27.0
 *Released*: 26 May 2021

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.28.0-versionUpdates217-SNAPSHOT"
+project.version = "1.29.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.28.0-SNAPSHOT"
+project.version = "1.28.0-versionUpdates217-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Thu Jan 16 10:40:53 PST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/src/main/groovy/org/labkey/gradle/plugin/Antlr.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Antlr.groovy
@@ -72,7 +72,7 @@ class Antlr implements Plugin<Project>
                              // Workaround for incremental build (GRADLE-1483)
                              outputs.upToDateSpec = new AndSpec()
 
-                             main = 'org.antlr.Tool'
+                             setMainClass('org.antlr.Tool')
 
                              classpath = project.configurations.antlr
 

--- a/src/main/groovy/org/labkey/gradle/plugin/Gwt.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Gwt.groovy
@@ -123,7 +123,7 @@ class Gwt implements Plugin<Project>
                             java.doLast new GzipAction()
                         }
 
-                        java.main = 'com.google.gwt.dev.Compiler'
+                        java.setMainClass('com.google.gwt.dev.Compiler')
 
                         def paths = []
 

--- a/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
@@ -398,7 +398,7 @@ class ServerDeploy implements Plugin<Project>
         }
         project.tasks.deployApp.dependsOn(project.tasks.named("checkModuleTasks"))
         project.tasks.checkModuleTasks.mustRunAfter(project.tasks.stageApp) // do this so the message appears at the bottom of the output
-        project.pluginManager.withPlugin("tomcat") {
+        if (project.plugins.hasPlugin(Tomcat)) {
             if (project.tomcat.hasCatalinaHome()) {
                 project.tasks.named("cleanBuild").configure {
                     it.dependsOn(project.tasks.stopTomcat)

--- a/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
@@ -86,7 +86,7 @@ class TeamCity extends Tomcat
                 task.dependsOn(project.tasks.jar)
                 task.doLast {
                     project.javaexec({ JavaExecSpec spec ->
-                        spec.main = "org.labkey.test.util.PasswordUtil"
+                        spec.mainClass = "org.labkey.test.util.PasswordUtil"
                         spec.classpath {
                             [project.configurations.uiTestRuntimeClasspath, project.tasks.jar]
                         }

--- a/src/main/groovy/org/labkey/gradle/plugin/TestRunner.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/TestRunner.groovy
@@ -90,7 +90,7 @@ class TestRunner extends UiTest
                 task.dependsOn(project.tasks.jar)
                 task.doFirst({
                     project.javaexec({
-                        main = "org.labkey.test.util.PasswordUtil"
+                        mainClass = "org.labkey.test.util.PasswordUtil"
                         classpath {
                             [project.configurations.uiTestRuntimeClasspath, project.tasks.jar]
                         }
@@ -109,7 +109,7 @@ class TestRunner extends UiTest
                 task.dependsOn(project.tasks.jar)
                 task.doFirst({
                     project.javaexec({
-                        main = "org.labkey.test.util.PasswordUtil"
+                        mainClass = "org.labkey.test.util.PasswordUtil"
                         classpath {
                             [project.configurations.uiTestRuntimeClasspath, project.tasks.jar]
                         }

--- a/src/main/groovy/org/labkey/gradle/task/CreateJsDocs.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/CreateJsDocs.groovy
@@ -43,7 +43,7 @@ class CreateJsDocs extends DefaultTask
     {
         List<File> inputPaths = getInputFiles()
         project.javaexec { exec ->
-            exec.main = "-jar"
+            exec.mainClass = "-jar"
             exec.args = ["${project.jsDoc.root}/jsrun.jar",
                          "${project.jsDoc.root}/app/run.js",
                          "--template=${project.tasks.jsdocTemplate.destinationDir}",

--- a/src/main/groovy/org/labkey/gradle/task/CreateXsdDocs.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/CreateXsdDocs.groovy
@@ -40,7 +40,7 @@ class CreateXsdDocs extends DefaultTask
     {
         List<File> xsdFiles = getXsdFiles()
         project.javaexec {exec ->
-            exec.main = "com.docflex.xml.Generator"
+            exec.mainClass = "com.docflex.xml.Generator"
 
             exec.classpath project.configurations.xsdDoc
 

--- a/src/main/groovy/org/labkey/gradle/task/StopTomcat.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/StopTomcat.groovy
@@ -40,7 +40,7 @@ class StopTomcat extends DefaultTask
         project.tomcat.validateCatalinaHome()
         project.javaexec( {
             JavaExecSpec java ->
-                java.main = "org.apache.catalina.startup.Bootstrap"
+                java.mainClass = "org.apache.catalina.startup.Bootstrap"
                 java.classpath  { ["${project.tomcat.catalinaHome}/bin/bootstrap.jar", "${project.tomcat.catalinaHome}/bin/tomcat-juli.jar"] }
                 java.systemProperties["user.dir"] = project.tomcat.catalinaHome
                 java.args = ["stop"]

--- a/src/main/groovy/org/labkey/gradle/util/ExternalDependency.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/ExternalDependency.groovy
@@ -10,6 +10,8 @@ class ExternalDependency
     public static final String GNU_LESSER_GPL_21_URL = "http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html"
     public static final String BSD_2_LICENSE_NAME = "BSD 2"
     public static final String BSD_2_LICENSE_URL = "https://opensource.org/licenses/BSD-2-Clause"
+    public static final String BSD_LICENSE_NAME = "BSD"
+    public static final String BSD_LICENSE_URL = "http://www.opensource.org/licenses/bsd-license.php"
 
     private String configuration = "external"
     private String coordinates

--- a/src/main/groovy/org/labkey/gradle/util/ExternalDependency.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/ExternalDependency.groovy
@@ -2,6 +2,15 @@ package org.labkey.gradle.util
 
 class ExternalDependency
 {
+    public static final String APACHE_2_LICENSE_NAME = "Apache 2.0"
+    public static final String APACHE_2_LICENSE_URL = "http://www.apache.org/licenses/LICENSE-2.0"
+    public static final String MIT_LICENSE_NAME = "MIT"
+    public static final String MIT_LICENSE_URL = "http://www.opensource.org/licenses/mit-license.php"
+    public static final String GNU_LESSER_GPL_21_NAME = "GNU Lesser GPL V2.1"
+    public static final String GNU_LESSER_GPL_21_URL = "http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html"
+    public static final String BSD_2_LICENSE_NAME = "BSD 2"
+    public static final String BSD_2_LICENSE_URL = "https://opensource.org/licenses/BSD-2-Clause"
+
     private String configuration = "external"
     private String coordinates
     private String component

--- a/src/main/groovy/org/labkey/gradle/util/ExternalDependency.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/ExternalDependency.groovy
@@ -8,6 +8,8 @@ class ExternalDependency
     public static final String MIT_LICENSE_URL = "http://www.opensource.org/licenses/mit-license.php"
     public static final String GNU_LESSER_GPL_21_NAME = "GNU Lesser GPL V2.1"
     public static final String GNU_LESSER_GPL_21_URL = "http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html"
+    public static final String LGPL_LICENSE_NAME = "LGPL"
+    public static final String LGPL_LICENSE_URL = "http://www.gnu.org/copyleft/lesser.html"
     public static final String BSD_2_LICENSE_NAME = "BSD 2"
     public static final String BSD_2_LICENSE_URL = "https://opensource.org/licenses/BSD-2-Clause"
     public static final String BSD_LICENSE_NAME = "BSD"


### PR DESCRIPTION
#### Rationale
As we begin to use the `BuildUtils.addExternalDependency` in order for Gradle to produce the `jars.txt` files for us, we can use some constants for common licenses and URLs.

The check for the existence of the tomcat plugin was not quite right, causing `cleanDeploy` and `cleanBuild` to no longer do a shutdown of tomcat, leaving the dev environment in an unhappy state.

#### Related Pull Requests
#123 

#### Changes
* Add some constants helpful for declaring external dependencies
* Fix check for tomcat plugin so `cleanBuild` and `cleanDeploy` will stop tomcat if available
* Update to gradle 7.1
