### PR TITLE
Remove unneeded output directory declaration for undeployModule to ge…

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ If you are making changes to the plugins, please see the [internal docs](https:/
 on how to do that, including how to develop and test locally and the versioning information.
 
 ## Release Notes
-### TBD
-*Released*: TBD
+### 1.28.1
+*Released*: 24 June 2021
 (Earliest compatible LabKey version: 21.3)
 - Remove unneeded output directory declaration for undeployModule to get rid of lots of warnings
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ If you are making changes to the plugins, please see the [internal docs](https:/
 on how to do that, including how to develop and test locally and the versioning information.
 
 ## Release Notes
+### TBD
+*Released*: TBD
+(Earliest compatible LabKey version: 21.3)
+- Remove unneeded output directory declaration for undeployModule to get rid of lots of warnings
+
 ### 1.28.0
 *Released*: 16 June 2021
 (Earliest compatible LabKey version: 21.3)

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.29.0-SNAPSHOT"
+project.version = "1.29.0-undeployModuleWarnings-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.29.0-undeployModuleWarnings-SNAPSHOT"
+project.version = "1.29.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
@@ -15,7 +15,7 @@
  */
 package org.labkey.gradle.plugin
 
-import org.gradle.api.DefaultTask
+
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -25,7 +25,6 @@ import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.file.CopySpec
 import org.gradle.api.java.archives.Manifest
 import org.gradle.api.publish.maven.MavenPublication
-import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.Delete
 import org.gradle.api.tasks.bundling.Jar
 import org.labkey.gradle.plugin.extension.LabKeyExtension

--- a/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
@@ -15,6 +15,7 @@
  */
 package org.labkey.gradle.plugin
 
+import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -257,7 +258,6 @@ class FileModule implements Plugin<Project>
                                 else
                                     delete.inputs.file file
                         })
-                        delete.outputs.dir "${ServerDeployExtension.getServerDeployDirectory(project)}/modules"
                     })
                     task.doFirst {
                         undeployModule(project)


### PR DESCRIPTION
#### Rationale
Declaring an output directory for a delete operation seems kind of strange in an case, and in this particular case, since each `undeployModule` command declared the same output directory, modern Gradle didn't like it much, producing warning such as this:
```
Gradle detected a problem with the following location: '/Users/susanhert/Development/labkey/root/build/deploy/modules/pipeline-21.7-SNAPSHOT.module'. Reason: Task ':server:modules:platform:pipeline:undeployModule' uses this output of task ':server:testAutomation:modules:triggerTestModule:undeployModule' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.1/userguide/validation_problems.html#implicit_dependency for more details about this problem. This behaviour has been deprecated and is scheduled to be removed in Gradle 8.0. Execution optimizations are disabled to ensure correctness. See https://docs.gradle.org/7.1/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.
```

#### Related Pull Requests
* NA

#### Changes
* Remove output directory declaration from `undeployModule` task.
