### PR TITLE
Add task for purging npm alpha versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### TBD
+*Released*: TBD
+(Earliest compatible LabKey version: 21.3)
+* Add new PurgeNpmAlphaVersion task to make it easier to remove obsolete alpha package versions
+
 ### 1.29.0
 *Released*: 7 July 2021
 (Earliest compatible LabKey version: 21.3)

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
-### TBD
-*Released*: TBD
+### 1.30.0
+*Released*: 27 July 2021
 (Earliest compatible LabKey version: 21.3)
 * Add new PurgeNpmAlphaVersion task to make it easier to remove obsolete alpha package versions
 

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.30.0-purgeAlphaVersions-SNAPSHOT"
+project.version = "1.31.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.30.0-SNAPSHOT"
+project.version = "1.30.0-purgeAlphaVersions-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/task/PurgeNpmAlphaVersions.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/PurgeNpmAlphaVersions.groovy
@@ -1,0 +1,128 @@
+package org.labkey.gradle.task
+
+import groovy.json.JsonSlurper
+import org.apache.http.HttpStatus
+import org.apache.http.client.methods.CloseableHttpResponse
+import org.apache.http.client.methods.HttpDelete
+import org.apache.http.impl.client.CloseableHttpClient
+import org.apache.http.impl.client.HttpClients
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.TaskAction
+
+import java.util.stream.Collectors
+
+class PurgeNpmAlphaVersions extends DefaultTask
+{
+    private static final String REPOSITORY_NAME = 'libs-client-local'
+    public static final String ALPHA_PREFIX_PROPERTY = 'alphaPrefix'
+    public static final String[] PACKAGE_NAMES = [
+            '@labkey/api',
+            '@labkey/assayreport',
+            '@labkey/build',
+            '@labkey/components',
+            '@labkey/freezermanager',
+            '@labkey/test',
+            '@labkey/themes',
+            '@labkey/workflow'
+    ]
+
+    @TaskAction
+    void purgeVersions()
+    {
+        String alphaPrefix;
+        if (!project.hasProperty(ALPHA_PREFIX_PROPERTY))
+            throw new GradleException("No value provided for alphaPrefix.")
+        alphaPrefix = project.property(ALPHA_PREFIX_PROPERTY)
+        String[] undeletedVersions = []
+        for (String packageName : PACKAGE_NAMES)
+        {
+            project.logger.quiet("Considering ${packageName}...")
+            List<String> alphaVersions = getNpmAlphaVersions(packageName, alphaPrefix)
+            project.logger.quiet("Found ${alphaVersions.size()} versions with alpha prefix ${alphaPrefix} in package ${packageName}")
+            if (!alphaVersions.isEmpty())
+            {
+                alphaVersions.forEach(version -> {
+                    if (project.hasProperty("dryRun"))
+                        project.logger.quiet("Removing version ${version} of package ${packageName} -- Skipped for dry run")
+                    else {
+                        project.logger.quiet("Removing version ${version} of package ${packageName}")
+                        if (!makeDeleteRequest(packageName, version)) {
+                            undeletedVersions += "${packageName}: ${version}"
+                        }
+                    }
+                })
+            }
+        }
+        if (undeletedVersions.size() > 0)
+            throw new GradleException("The following versions were not deleted.\n${undeletedVersions}\nCheck the log for more information.")
+    }
+
+
+    private static List<String> getNpmAlphaVersions(String packageName, String alphaPrefix)
+    {
+        String output = "npm view ${packageName} versions --json".execute().text
+        def parsedJson = new JsonSlurper().parseText(output)
+        if (parsedJson instanceof ArrayList) {
+            return parsedJson.stream().filter(version -> {
+                version.matches(".+-" + alphaPrefix + "\\.\\d+")
+            }).collect(Collectors.toList())
+        }
+        else
+            throw new GradleException("Error retrieving versions for package ${packageName}: ${parsedJson.error}")
+    }
+
+    /**
+     * This uses the Artifactory REST Api to request a deletion of a particular package and version.  There does
+     * not appear to be a way to request deletion of multiple versions at once.  Also, though it might seem natural
+     * to use "npm unpublish" for this deletion, this does not work with artifactory, possibly due to this long-standing
+     * issue: https://github.com/npm/npm-registry-client/issues/41
+     * The command appears to work, returning a 200 status code when you use --verbose logging, but the artifact doesn't
+     * go anywhere.
+     *
+     * Another possibility here would be to use the same action as is used in the Web UI.  There, Artifactory sends
+     * a POST request to:
+     *     Request URL: https://artifactory.labkey.com/artifactory/ui/artifactactions/delete
+     * with parameters
+     *     repoKey: libs-client-local
+     *     path: "@labkey/components/-/@labkey/components-2.14.2-fb-update-react-select.1.tgz"
+     * The REST API seems a better approach, though.
+     * @param packageName
+     * @param version
+     * @return true if deletion was successful, false otherwise
+     * @throws IOException
+     */
+    boolean makeDeleteRequest(String packageName, String version) throws IOException
+    {
+        CloseableHttpClient httpClient = HttpClients.createDefault();
+        String endpoint = project.property('artifactory_contextUrl')
+        if (!endpoint.endsWith("/"))
+            endpoint += "/"
+
+        // The coordinates of the packages look like this: "@labkey/components/-/@labkey/components-2.14.2-fb-update-react-select.1.tgz"
+        endpoint += REPOSITORY_NAME + "/" + packageName + "/-/" + packageName + "-" + version + ".tgz"
+        project.logger.debug("Making delete request for package ${packageName} and version ${version} via endpoint ${endpoint}")
+        try
+        {
+            HttpDelete httpDelete = new HttpDelete(endpoint)
+            // N.B. Using Authorization Bearer with an API token does not currently work
+            httpDelete.setHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString("${project.property('artifactory_user')}:${project.property('artifactory_password')}".getBytes()))
+            CloseableHttpResponse response = httpClient.execute(httpDelete)
+            int statusCode = response.getStatusLine().getStatusCode()
+            if (statusCode != HttpStatus.SC_OK && statusCode != HttpStatus.SC_NO_CONTENT) {
+                project.logger.error("Unable to delete using ${endpoint}: ${response.getStatusLine()}")
+                return false
+            }
+            response.close()
+            return true
+        }
+        catch (Exception e)
+        {
+            throw new GradleException("Problem executing delete request with url ${endpoint}", e)
+        }
+        finally
+        {
+            httpClient.close()
+        }
+    }
+}

--- a/src/main/groovy/org/labkey/gradle/task/PurgeNpmAlphaVersions.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/PurgeNpmAlphaVersions.groovy
@@ -87,15 +87,16 @@ class PurgeNpmAlphaVersions extends DefaultTask
      *     repoKey: libs-client-local
      *     path: "@labkey/components/-/@labkey/components-2.14.2-fb-update-react-select.1.tgz"
      * The REST API seems a better approach, though.
-     * @param packageName
-     * @param version
+     * @param packageName the package whose version is to be deleted, including the scope (e.g., @labkey/components)
+     * @param version the version of the pacakge to delete (e.g., 2.14.2-fb-update-react-select.1)
      * @return true if deletion was successful, false otherwise
-     * @throws IOException
+     * @throws GradleException if the delete request throws an exception
      */
-    boolean makeDeleteRequest(String packageName, String version) throws IOException
+    boolean makeDeleteRequest(String packageName, String version)
     {
         CloseableHttpClient httpClient = HttpClients.createDefault();
         String endpoint = project.property('artifactory_contextUrl')
+        boolean success = true
         if (!endpoint.endsWith("/"))
             endpoint += "/"
 
@@ -111,10 +112,10 @@ class PurgeNpmAlphaVersions extends DefaultTask
             int statusCode = response.getStatusLine().getStatusCode()
             if (statusCode != HttpStatus.SC_OK && statusCode != HttpStatus.SC_NO_CONTENT) {
                 project.logger.error("Unable to delete using ${endpoint}: ${response.getStatusLine()}")
-                return false
+                success = false
             }
             response.close()
-            return true
+            return success
         }
         catch (Exception e)
         {


### PR DESCRIPTION
#### Rationale
The alpha versions of our NPM packages never get removed unless we do that manually, and currently the manual method for doing this within the Artifactory web application requires finding and clicking on each version separately.  Even filtering to the proper versions within the Artifactory UI is not really possible.  Here we add a new task that uses an npm command to find the versions and the Artifactory REST API to do the deletions.  Though I might have liked to use `npm unpublish` to remove the alpha versions, that command does not work, possibly due to this [long-standing issue](https://github.com/npm/npm-registry-client/issues/41).

#### Related Pull Requests
* https://github.com/LabKey/server/pull/112

#### Changes
* Add new PurgeNpmAlphaVersion task to make it easier to remove obsolete alpha package versions
