### PR TITLE
Add `--no-multiarch` flag to `InstallRPackage` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### TBD
+*Released*: TBD
+(Earliest compatible LabKey version: 21.3)
+* Add `--no-multiarch` flag to `InstallRPackage` commands
+
 ### 1.30.0
 *Released*: 27 July 2021
 (Earliest compatible LabKey version: 21.3)

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.31.0-SNAPSHOT"
+project.version = "1.30.1-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/task/InstallRPackage.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/InstallRPackage.groovy
@@ -153,7 +153,7 @@ class InstallRPackage extends DefaultTask
                 logError: true
         )
                 {
-                    arg(line: "--vanilla")
+                    arg(line: "--vanilla --no-multiarch")
                     env(key: "R_LIBS_USER", value: getRLibsUserPath(project)) // TODO is this actually necessary?
                 }
     }
@@ -170,7 +170,7 @@ class InstallRPackage extends DefaultTask
                 logError: true
         )
                 {
-                    arg(line: "CMD INSTALL -l ${rLibsUserDir} ${rLibsUserDir}/${archiveFileName}")
+                    arg(line: "CMD INSTALL --no-multiarch -l ${rLibsUserDir} ${rLibsUserDir}/${archiveFileName}")
                 }
     }
 }


### PR DESCRIPTION
#### Rationale
RLabKey install has been failing on Windows:
```
[14:48:32][ant:exec] * installing *source* package 'Rlabkey' ...
[14:48:32][ant:exec] ** using staged installation
[14:48:32][ant:exec] ** libs
[14:48:32][ant:exec] 
[14:48:32][ant:exec] *** arch - i386
[14:49:00][ant:exec] installing to D:/teamcity/work/8c0375c4fe0a826b/r_libs/00LOCK-Rlabkey/00new/Rlabkey/libs/i386
[14:49:00][ant:exec] 
[14:49:00][ant:exec] *** arch - x64
[14:49:07][ant:exec] installing to D:/teamcity/work/8c0375c4fe0a826b/r_libs/00LOCK-Rlabkey/00new/Rlabkey/libs/x64
[14:49:07][ant:exec] ** R
[14:49:07][ant:exec] ** inst
[14:49:07][ant:exec] ** byte-compile and prepare package for lazy loading
[14:49:09][ant:exec] ** help
[14:49:09][ant:exec] *** installing help indices
[14:49:09][ant:exec]     finding HTML links ... done
[14:49:11][ant:exec] ** building package indices
[14:49:11][ant:exec] ** testing if installed package can be loaded from temporary location
[14:49:11][ant:exec] *** arch - i386
[14:49:14][ant:exec] *** arch - x64
[14:49:14][ant:exec] ERROR: loading failed for 'i386'
```
Other R package install methods already include the `--no-multiarch` flag to avoid this error. Not sure why the build has started failing in this way but I don't think we're too worried about 32-bit support.

#### Changes
* Add `--no-multiarch` flag to `InstallRPackage` commands
