### PR TITLE
Update PurgeNpmAlphaVersions so it works for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
-### TBD
-*Released*: TBD
+### 1.30.1
+*Released*: 7 September 2021
 (Earliest compatible LabKey version: 21.3)
 * Add `--no-multiarch` flag to `InstallRPackage` commands
 * Update `PurgeNpmAlphaVersions` task to use `npm.cmd` on Windows

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ _Note: 1.28.0 and later require Gradle 7_
 *Released*: TBD
 (Earliest compatible LabKey version: 21.3)
 * Add `--no-multiarch` flag to `InstallRPackage` commands
+* Update `PurgeNpmAlphaVersions` task to use `npm.cmd` on Windows
 
 ### 1.30.0
 *Released*: 27 July 2021

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.30.1-purgeForWindows-SNAPSHOT"
+project.version = "1.31.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.30.1-SNAPSHOT"
+project.version = "1.30.1-purgeForWindows-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
@@ -154,7 +154,7 @@ class Distribution implements Plugin<Project>
      * to easily build upon one another.
      * @param project the project that is to inherit dependencies
      * @param inheritedProjectPath the project whose dependencies are inherited
-     * @param list of paths for modules that are to be included from the set of inherited modules (e.g., [":server:modules:search"])
+     * @param list of paths for modules that are to be excluded from the set of inherited modules (e.g., [":server:modules:search"])
      */
     static void inheritDependencies(Project project, String inheritedProjectPath, List<String> excludedModules=[])
     {

--- a/src/main/groovy/org/labkey/gradle/plugin/MultiGit.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/MultiGit.groovy
@@ -394,6 +394,7 @@ class MultiGit implements Plugin<Project>
                         return branch.name == remoteBranch
                 })
             }
+            return false
         }
 
         void enlist(String branchName)

--- a/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
@@ -225,7 +225,7 @@ class ServerDeploy implements Plugin<Project>
                 "setup",  DoThenSetup) {
             DoThenSetup task ->
                 task.group = GroupNames.DEPLOY
-                task.description = "Installs labkey.xml and various jar files into the tomcat directory.  Sets default database properties."
+                task.description = "Installs labkey.xml and application.properties (for embedded tomcat) into the tomcat configuraiton directory.  Sets default database properties."
                 // stage the application first to try to avoid multiple Tomcat restarts
                 task.mustRunAfter(project.tasks.stageApp)
         }

--- a/src/main/groovy/org/labkey/gradle/task/PurgeNpmAlphaVersions.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/PurgeNpmAlphaVersions.groovy
@@ -1,6 +1,7 @@
 package org.labkey.gradle.task
 
 import groovy.json.JsonSlurper
+import org.apache.commons.lang3.SystemUtils
 import org.apache.http.HttpStatus
 import org.apache.http.client.methods.CloseableHttpResponse
 import org.apache.http.client.methods.HttpDelete
@@ -61,7 +62,8 @@ class PurgeNpmAlphaVersions extends DefaultTask
 
     private static List<String> getNpmAlphaVersions(String packageName, String alphaPrefix)
     {
-        String output = "npm view ${packageName} versions --json".execute().text
+        String npmCmd = SystemUtils.IS_OS_WINDOWS ? "npm.cmd" : "npm"
+        String output = (npmCmd + " view ${packageName} versions --json").execute().text
         def parsedJson = new JsonSlurper().parseText(output)
         if (parsedJson instanceof ArrayList) {
             return parsedJson.stream().filter(version -> {


### PR DESCRIPTION
#### Rationale
Need to use `npm.cmd` not just `npm` when running bare npm commands on Windows.

#### Related Pull Requests
#130 

#### Changes
* Update PurgeNpmAlphaVersions
* Misc wording and return value changes
