### PR TITLE
Support test properties template

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### TBD
+*Released*: TBD
+(Earliest compatible LabKey version: 21.3)
+* Support `test.properties.dist` file in `testAutomation` repository
+* Allow DoThenSetup task to pull extra data source configuration from `config.properties`
+
 ### 1.30.1
 *Released*: 7 September 2021
 (Earliest compatible LabKey version: 21.3)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ _Note: 1.28.0 and later require Gradle 7_
 ### TBD
 *Released*: TBD
 (Earliest compatible LabKey version: 21.3)
-* Support `test.properties.dist` file in `testAutomation` repository
+* Support `test.properties.template` file in `testAutomation` repository
 * Allow DoThenSetup task to pull extra data source configuration from `config.properties`
 
 ### 1.30.1

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ _Note: 1.28.0 and later require Gradle 7_
 (Earliest compatible LabKey version: 21.3)
 * Support `test.properties.template` file in `testAutomation` repository
 * Allow DoThenSetup task to pull extra data source configuration from `config.properties`
+* Stop deploying tomcat jars to `CATALINA_HOME` when it isn't necessary
 
 ### 1.30.1
 *Released*: 7 September 2021

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.31.0-SNAPSHOT"
+project.version = "1.30.2-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
@@ -477,6 +477,11 @@ class ServerDeploy implements Plugin<Project>
 
     private void deployTomcatJars(Task task) {
         Project project = task.project
+        if (BuildUtils.useEmbeddedTomcat(project)) {
+            task.logger.info("Not deploying tomcat jars for embedded deployment")
+            return
+        }
+
         JDBC_JARS.each{String name -> new File("${project.tomcat.catalinaHome}/lib/${name}").delete()}
 
         // Then copy them into the tomcat/lib directory

--- a/src/main/groovy/org/labkey/gradle/plugin/TestRunner.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/TestRunner.groovy
@@ -18,12 +18,10 @@ package org.labkey.gradle.plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.tasks.TaskProvider
-import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.bundling.Zip
 import org.labkey.gradle.plugin.extension.TeamCityExtension
 import org.labkey.gradle.task.RunTestSuite
 import org.labkey.gradle.util.BuildUtils
-import org.labkey.gradle.util.DatabaseProperties
 import org.labkey.gradle.util.GroupNames
 
 class TestRunner extends UiTest
@@ -204,7 +202,7 @@ class TestRunner extends UiTest
         project.tasks.register("uiTests", RunTestSuite) {
             RunTestSuite task ->
                 task.group = GroupNames.VERIFICATION
-                task.description = "Run a LabKey test suite as defined by ${project.file(testRunnerExt.propertiesFile)} and overridden on the command line by -P<prop>=<value> "
+                task.description = "Run a LabKey test suite as defined by ${project.file(testRunnerExt.propertiesFileName)} and overridden on the command line by -P<prop>=<value> "
         }
     }
 

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/UiTestExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/UiTestExtension.groovy
@@ -88,10 +88,20 @@ class UiTestExtension
             {
                 // Create test.properties file if necessary
                 def propertiesDistFile = project.project(BuildUtils.getTestProjectPath(project.gradle)).file(propertiesDistFileName)
-                FileUtils.copyFile(propertiesDistFile, propertiesFile)
+                if (propertiesDistFile.exists())
+                {
+                    FileUtils.copyFile(propertiesDistFile, propertiesFile)
+                }
             }
-            // read test.properties file
-            PropertiesUtils.readProperties(propertiesFile, this.config)
+            if (propertiesFile.exists())
+            {
+                // read test.properties file
+                PropertiesUtils.readProperties(propertiesFile, this.config)
+            }
+            else
+            {
+                project.logger.info("Unable to locate test properties files. Running with defaults.")
+            }
         }
         // if the test.properties file is not available, all properties will need to be provided via project properties
         for (String name : config.propertyNames())

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/UiTestExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/UiTestExtension.groovy
@@ -15,6 +15,7 @@
  */
 package org.labkey.gradle.plugin.extension
 
+import org.apache.commons.io.FileUtils
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.labkey.gradle.util.BuildUtils
@@ -23,7 +24,8 @@ import org.labkey.gradle.util.PropertiesUtils
 
 class UiTestExtension
 {
-    String propertiesFile = "test.properties"
+    final String propertiesFileName = "test.properties"
+    final String propertiesDistFileName = "test.properties.dist"
 
     private Properties config = null
     private Project project
@@ -80,8 +82,17 @@ class UiTestExtension
         }
 
         if (project.findProject(BuildUtils.getTestProjectPath(project.gradle)) != null)
-        // read test.properties file
-            PropertiesUtils.readProperties(project.project(BuildUtils.getTestProjectPath(project.gradle)).file(propertiesFile), this.config)
+        {
+            def propertiesFile = project.project(BuildUtils.getTestProjectPath(project.gradle)).file(propertiesFileName)
+            if (!propertiesFile.exists())
+            {
+                // Create test.properties file if necessary
+                def propertiesDistFile = project.project(BuildUtils.getTestProjectPath(project.gradle)).file(propertiesDistFileName)
+                FileUtils.copyFile(propertiesDistFile, propertiesFile)
+            }
+            // read test.properties file
+            PropertiesUtils.readProperties(propertiesFile, this.config)
+        }
         // if the test.properties file is not available, all properties will need to be provided via project properties
         for (String name : config.propertyNames())
         {

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/UiTestExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/UiTestExtension.groovy
@@ -25,7 +25,7 @@ import org.labkey.gradle.util.PropertiesUtils
 class UiTestExtension
 {
     final String propertiesFileName = "test.properties"
-    final String propertiesDistFileName = "test.properties.dist"
+    final String propertiesTemplateName = "test.properties.template"
 
     private Properties config = null
     private Project project
@@ -87,10 +87,10 @@ class UiTestExtension
             if (!propertiesFile.exists())
             {
                 // Create test.properties file if necessary
-                def propertiesDistFile = project.project(BuildUtils.getTestProjectPath(project.gradle)).file(propertiesDistFileName)
-                if (propertiesDistFile.exists())
+                def propertiesTemplate = project.project(BuildUtils.getTestProjectPath(project.gradle)).file(propertiesTemplateName)
+                if (propertiesTemplate.exists())
                 {
-                    FileUtils.copyFile(propertiesDistFile, propertiesFile)
+                    FileUtils.copyFile(propertiesTemplate, propertiesFile)
                 }
             }
             if (propertiesFile.exists())

--- a/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
@@ -94,7 +94,7 @@ class DoThenSetup extends DefaultTask
                             line = line.replace("@@ldapSyncConfig@@-->", "")
                             return line
                         }
-                        if (project.hasProperty("extraJdbcDataSource"))
+                        if (configProperties.hasProperty("extraJdbcDataSource"))
                         {
                             line = line.replace("<!--@@extraJdbcDataSource@@", "")
                             line = line.replace("@@extraJdbcDataSource@@-->", "")
@@ -143,7 +143,7 @@ class DoThenSetup extends DefaultTask
                             line = line.replace("#context.webAppLocation=", "context.webAppLocation=")
                             line = line.replace("#spring.devtools.restart.additional-paths=", "spring.devtools.restart.additional-paths=")
                         }
-                        if (databaseProperties.hasProperty("extraJdbcDataSource"))
+                        if (configProperties.hasProperty("extraJdbcDataSource"))
                         {
                             line = line.replaceAll("^#(context\\..+\\[1].*)", "\$1")
                         }

--- a/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
@@ -157,6 +157,10 @@ class DoThenSetup extends DefaultTask
         }
     }
 
+    /**
+     * Get 'extraJdbc*' properties from TeamCity.
+     * Used as string replacements when deploying 'labkey.xml' and 'application.properties'
+     */
     private Properties getExtraJdbcProperties()
     {
         def extraJdbcProperties = new Properties();

--- a/src/main/groovy/org/labkey/gradle/task/RunUiTest.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/RunUiTest.groovy
@@ -16,14 +16,10 @@
 package org.labkey.gradle.task
 
 import org.apache.commons.lang3.StringUtils
-import org.apache.commons.lang3.SystemUtils
-import org.gradle.api.Project
-import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.testing.Test
 import org.labkey.gradle.plugin.extension.LabKeyExtension
 import org.labkey.gradle.plugin.extension.TomcatExtension
 import org.labkey.gradle.plugin.extension.UiTestExtension
-import org.labkey.gradle.util.BuildUtils
 
 /**
  * Class that sets up jvmArgs and our standard output options
@@ -53,17 +49,13 @@ class RunUiTest extends Test
         outputs.upToDateWhen( { return false }) // always run tests when asked to
     }
 
-    @Input
-    protected String getDebugPort()
-    {
-        return testExt.getTestConfig("selenium.debug.port")
-    }
-
     void setJvmArgs()
     {
         List<String> jvmArgsList = ["-Xmx512m",
                                     "-Xdebug",
-                                    "-Xrunjdwp:transport=dt_socket,server=y,suspend=${testExt.getTestConfig("debugSuspendSelenium")},address=${getDebugPort()}",
+                                    "-Xrunjdwp:transport=dt_socket,server=y," +
+                                            "suspend=${testExt.getTestConfig("debugSuspendSelenium")}," +
+                                            "address=${testExt.getTestConfig("selenium.debug.port")}",
                                     "-Dfile.encoding=UTF-8"]
 
         if (project.hasProperty("uiTestJvmOpts"))


### PR DESCRIPTION
#### Rationale
<!-- Rationale describing why this pull request is needed, what behavior it's adding/changing/removing, etc. (replace this comment) -->

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/870

#### Changes
* Support `test.properties.dist` file in `testAutomation` repository
* Allow DoThenSetup task to pull extra data source configuration from `config.properties`
* Don't deploy tomcat jars when deploying with embedded Tomcat
