### PR TITLE
Disable build caching for 'moduleXml' task

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### TBD
+*Released*: TBD
+(Earliest compatible LabKey version: 21.3)
+* Don't cache the `fileModule` plugin's `moduleXml` task
+
 ### 1.30.2
 *Released*: 29 September 2021
 (Earliest compatible LabKey version: 21.3)

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.31.0-SNAPSHOT"
+project.version = "1.30.3-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
@@ -177,7 +177,7 @@ class FileModule implements Plugin<Project>
         moduleXmlTask.outputs.file(moduleXmlFile)
         if (project.file("build.gradle").exists())
             moduleXmlTask.inputs.file(project.file("build.gradle"))
-        moduleXmlTask.outputs.cacheIf {true} // enable build caching
+        moduleXmlTask.outputs.cacheIf {false} // disable build caching. Has too many undeclared inputs.
 
         // This is added because Intellij started creating this "out" directory when you build through IntelliJ.
         // It copies files there that are actually input files to the build, which causes some problems when later


### PR DESCRIPTION
#### Rationale
`module.xml` is populated with numerous values that aren't explicit inputs to the task, including product version and VCS info. Because of this, a 21.10 build on TeamCity used a cached module.xml from develop. Caching probably doesn't save much time since this task is so simple, so I think it makes sense to just disable it.

This change isn't urgent; the module.xml is mostly informational and TeamCity builds that actually get published/distributed have caching disabled.

#### Changes
* Disable build caching for 'moduleXml' task
