### PR TITLE
Adjust `test.properties.template` usage when running on TeamCity

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ _Note: 1.28.0 and later require Gradle 7_
 *Released*: TBD
 (Earliest compatible LabKey version: 21.3)
 * Don't cache the `fileModule` plugin's `moduleXml` task
+* Adjust `test.properties.template` usage when running on TeamCity
 
 ### 1.30.2
 *Released*: 29 September 2021

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/UiTestExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/UiTestExtension.groovy
@@ -15,7 +15,7 @@
  */
 package org.labkey.gradle.plugin.extension
 
-import org.apache.commons.io.FileUtils
+
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.labkey.gradle.util.BuildUtils
@@ -84,16 +84,17 @@ class UiTestExtension
         if (project.findProject(BuildUtils.getTestProjectPath(project.gradle)) != null)
         {
             def propertiesFile = project.project(BuildUtils.getTestProjectPath(project.gradle)).file(propertiesFileName)
-            if (!propertiesFile.exists())
+            if (TeamCityExtension.isOnTeamCity(project))
             {
-                // Create test.properties file if necessary
+                // Load properties from template when running on TeamCity.
+                // These properties control which TeamCity properties are loaded by `RunTestSuite.setTeamCityProperties`
                 def propertiesTemplate = project.project(BuildUtils.getTestProjectPath(project.gradle)).file(propertiesTemplateName)
                 if (propertiesTemplate.exists())
                 {
-                    FileUtils.copyFile(propertiesTemplate, propertiesFile)
+                    PropertiesUtils.readProperties(propertiesTemplate, this.config)
                 }
             }
-            if (propertiesFile.exists())
+            else if (propertiesFile.exists())
             {
                 // read test.properties file
                 PropertiesUtils.readProperties(propertiesFile, this.config)


### PR DESCRIPTION
#### Rationale
`test.properties` is ignored now, so can leak between branches. Should just reference the template directly on TeamCity. The test runner will generate the non-template properties file if needed, so the gradle plugin doesn't need to worry about it.

#### Related Pull Requests
* #133 

#### Changes
* Load properties from template when running on TeamCity
