### PR TITLE
Fix extra data source configuration in DoThenSetup

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ _Note: 1.28.0 and later require Gradle 7_
 (Earliest compatible LabKey version: 21.3)
 * Don't cache the `fileModule` plugin's `moduleXml` task
 * Adjust `test.properties.template` usage when running on TeamCity
+* Fix extra data source configuration in DoThenSetup
 
 ### 1.30.2
 *Released*: 29 September 2021

--- a/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
@@ -94,7 +94,7 @@ class DoThenSetup extends DefaultTask
                             line = line.replace("@@ldapSyncConfig@@-->", "")
                             return line
                         }
-                        if (configProperties.hasProperty("extraJdbcDataSource"))
+                        if (configProperties.containsKey("extraJdbcDataSource"))
                         {
                             line = line.replace("<!--@@extraJdbcDataSource@@", "")
                             line = line.replace("@@extraJdbcDataSource@@-->", "")
@@ -143,7 +143,7 @@ class DoThenSetup extends DefaultTask
                             line = line.replace("#context.webAppLocation=", "context.webAppLocation=")
                             line = line.replace("#spring.devtools.restart.additional-paths=", "spring.devtools.restart.additional-paths=")
                         }
-                        if (configProperties.hasProperty("extraJdbcDataSource"))
+                        if (configProperties.containsKey("extraJdbcDataSource"))
                         {
                             line = line.replaceAll("^#(context\\..+\\[1].*)", "\$1")
                         }


### PR DESCRIPTION
#### Rationale
I accidentally used the default Groovy `hasProperty` method to check the contents of a Property map. Need to use `containsKey`.

#### Related Pull Requests
* #133 

#### Changes
* Fix extra data source configuration in DoThenSetup
