### PR TITLE
Publish v1.30.3 and move to next snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
-### TBD
-*Released*: TBD
+### 1.30.3
+*Released*: 18 October 2021
 (Earliest compatible LabKey version: 21.3)
 * Don't cache the `fileModule` plugin's `moduleXml` task
 * Adjust `test.properties.template` usage when running on TeamCity

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.30.3"
+project.version = "1.31.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.30.3-SNAPSHOT"
+project.version = "1.30.3"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins


### PR DESCRIPTION
#### Rationale
Version 1.30.3 has been published.  Moving on to next snapshot version


