### PR TITLE
npmInstall: add --legacy-peer-deps flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
-### TBD
-*Released*: TBD
+### 1.32.0
+*Released*: 5 January 2022
 (Earliest compatible LabKey version: 22.2)
 * Add `--legacy-peer-deps` flag to `npmInstall` command.
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### TBD
+*Released*: TBD
+(Earliest compatible LabKey version: 22.2)
+* Add `--legacy-peer-deps` flag to `npmInstall` command.
+
 ### 1.31.0
 *Released*: 15 December 2021
 (Earliest compatible LabKey version: 22.1)

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.32.0-updateNodeNPM-SNAPSHOT"
+project.version = "1.33.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.32.0-SNAPSHOT"
+project.version = "1.32.0-updateNodeNPM-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/plugin/NpmRun.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/NpmRun.groovy
@@ -175,6 +175,8 @@ class NpmRun implements Plugin<Project>
                     task.inputs.file project.file(NPM_PROJECT_FILE)
                     if (project.file(NPM_PROJECT_LOCK_FILE).exists())
                         task.inputs.file project.file(NPM_PROJECT_LOCK_FILE)
+                    // Specify legacy peer dependency mode for npm v7+
+                    task.args = ["--legacy-peer-deps"]
                 }
         project.tasks.npmInstall.outputs.upToDateWhen { project.file(NODE_MODULES_DIR).exists() }
 


### PR DESCRIPTION
#### Rationale
This adds the `--legacy-peer-deps` flag ([documentation](https://docs.npmjs.com/cli/v8/using-npm/config#legacy-peer-deps)) to the `npmInstall` task. This is being done to support updating our Node environment to v16 and npm to v8.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/161
* https://github.com/LabKey/labkey-ui-components/pull/699
* https://github.com/LabKey/biologics/pull/1112
* https://github.com/LabKey/sampleManagement/pull/792
* https://github.com/LabKey/inventory/pull/356

#### Changes
* Add `--legacy-peer-deps` flag to `npmInstall` command.
