### PR TITLE
Include `testAutomation` resources in TestRunner sourceSets

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### 1.32.1
+*Released*: TBD
+(Earliest compatible LabKey version: 22.2)
+* Include `testAuotmation` resources in TestRunner sourceSets 
+
 ### 1.32.0
 *Released*: 5 January 2022
 (Earliest compatible LabKey version: 22.2)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
-### 1.32.1
+### TBD
 *Released*: TBD
 (Earliest compatible LabKey version: 22.2)
 * Include `testAuotmation` resources in TestRunner sourceSets 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ _Note: 1.28.0 and later require Gradle 7_
 ### TBD
 *Released*: TBD
 (Earliest compatible LabKey version: 22.2)
-* Include `testAuotmation` resources in TestRunner sourceSets 
+* Include `testAuotmation` resources in TestRunner sourceSets
 
 ### 1.32.0
 *Released*: 5 January 2022

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.33.0-SNAPSHOT"
+project.version = "1.32.1-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/plugin/TestRunner.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/TestRunner.groovy
@@ -64,7 +64,7 @@ class TestRunner extends UiTest
                     }
                 }
                 resources {
-                    srcDirs = []
+                    srcDirs = [project.file("resources")]
                     project.rootProject.allprojects { Project otherProj ->
                         if (otherProj.file(TEST_RESOURCES_DIR).exists())
                         {


### PR DESCRIPTION
#### Rationale
I recently updated our Selenium tests to use Log4J for logging. Log4J searches the resources directory for its configuration files but `testAutomation/resources` isn't included in the `uiTest.java.resources` sourceSet (though it is included for individual modules).

No rush to push a new release for this. There is a workaround currently in place.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/965

#### Changes
* Include `testAutomation` resources in TestRunner sourceSets
