### PR TITLE
Set defaults for properties needed by `RunUiTest`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ _Note: 1.28.0 and later require Gradle 7_
 *Released*: TBD
 (Earliest compatible LabKey version: 22.2)
 * Include `testAuotmation` resources in TestRunner sourceSets
+* Set defaults for properties needed by `RunUiTest`
 
 ### 1.32.0
 *Released*: 5 January 2022

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/UiTestExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/UiTestExtension.groovy
@@ -42,7 +42,9 @@ class UiTestExtension
     private void setConfig()
     {
         this.config = new Properties()
+        // Set defaults for properties needed by `RunUiTest`
         this.config.setProperty("debugSuspendSelenium", "n")
+        this.config.setProperty("selenium.debug.port", "5005")
 
         // Issue 32153: When running tests and the pickDb tasks within the same command if the config.properties file
         // does not exist (or exists and is a different database than intended), the set of tests run will not be


### PR DESCRIPTION
#### Rationale
The `uiTests` task fails if the `test.properties` file hasn't been created. It needs the debug port to be defined.
[[Issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44331)]

#### Changes
* Set default value for `selenium.debug.port`
