### PR TITLE
Add support for new encryptionKey property name and updates to support later versions of xmlBeans

### DIFF
--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="GroovyAccessibility" enabled="true" level="ERROR" enabled_by_default="true" />
+  </profile>
+</component>

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
-### TBD
-*Released*: TBD
+### 1.32.1
+*Released*: 24 January 2022
 (Earliest compatible LabKey version: 22.2)
 * Include `testAutomation` resources in TestRunner sourceSets
 * Set defaults for properties needed by `RunUiTest`
 * [Issue 44600](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44600) Support new 'EncryptionKey' property name
-* Stop specifying `javasource` parameter when invoking XMLBeans build; recent XMLBeans versions fail if this parameter is provided.
+* Stop specifying `javasource` parameter when invoking XMLBeans build for version 5.0.0 or later; recent XMLBeans versions fail if this parameter is provided.
 
 ### 1.32.0
 *Released*: 5 January 2022

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ _Note: 1.28.0 and later require Gradle 7_
 (Earliest compatible LabKey version: 22.2)
 * Include `testAuotmation` resources in TestRunner sourceSets
 * Set defaults for properties needed by `RunUiTest`
+* [Issue 44600](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44600) Support new 'EncryptionKey' property name
 
 ### 1.32.0
 *Released*: 5 January 2022

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 ## gradlePlugin
 
 The gradlePlugin jar is a jar file containing plugins, tasks, extensions and utilities used for building the [LabKey](https://www.labkey.org)
@@ -17,9 +18,10 @@ _Note: 1.28.0 and later require Gradle 7_
 ### TBD
 *Released*: TBD
 (Earliest compatible LabKey version: 22.2)
-* Include `testAuotmation` resources in TestRunner sourceSets
+* Include `testAutomation` resources in TestRunner sourceSets
 * Set defaults for properties needed by `RunUiTest`
 * [Issue 44600](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44600) Support new 'EncryptionKey' property name
+* Stop specifying `javasource` parameter when invoking XMLBeans build; recent XMLBeans versions fail if this parameter is provided.
 
 ### 1.32.0
 *Released*: 5 January 2022

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.33.0-encryptionKey-SNAPSHOT"
+project.version = "1.33.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation gradleApi()
     implementation localGroovy()
     api "org.apache.commons:commons-lang3:${commonsLang3Version}"
+    api "org.apache.commons:commons-text:${commonsTextVersion}"
     api "commons-io:commons-io:${commonsIoVersion}"
     api "com.yahoo.platform.yui:yuicompressor:${yuiCompressorVersion}"
     api "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
@@ -45,7 +46,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.32.1-SNAPSHOT"
+project.version = "1.33.0-encryptionKey-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/distributionResources/labkey.xml
+++ b/distributionResources/labkey.xml
@@ -27,7 +27,7 @@
     <Loader loaderClass="org.labkey.bootstrap.LabKeyBootstrapClassLoader" />
 
     <!-- Encryption key for encrypted property store: https://www.labkey.org/Documentation/wiki-page.view?name=cpasxml#encrypt -->
-    <Parameter name="MasterEncryptionKey" value="@@masterEncryptionKey@@" />
+    <Parameter name="EncryptionKey" value="@@encryptionKey@@" />
 
     <!-- Additional data source(s): https://www.labkey.org/Documentation/wiki-page.view?name=externalSchemas#config -->
     <!--@@extraJdbcDataSource@@

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,7 @@ artifactoryPluginVersion=4.21.0
 
 commonsIoVersion=2.8.0
 commonsLang3Version=3.12.0
+commonsTextVersion=1.9
 
 grgitGradleVersion=4.1.0
 graphqlJavaVersion=16.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/groovy/org/labkey/gradle/task/SchemaCompile.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/SchemaCompile.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.labkey.gradle.plugin.XmlBeans
+import org.labkey.gradle.util.BuildUtils
 
 /**
  * Task to compile XSD schema files into Java class files using the ant XMLBean
@@ -60,8 +61,8 @@ class SchemaCompile extends DefaultTask {
             classname: 'org.apache.xmlbeans.impl.tool.XMLBean',
             classpath: project.configurations.xmlbeans.asPath
     )
-    // TODO get rid of this once we have updated to the later xmlbeans version
-    if (project.property('xmlbeansVersion') == '3.0.1') {
+    // TODO get rid of this once we have updated to the later xmlbeans version please
+    if (BuildUtils.compareVersions(project.property('xmlbeansVersion'), '5.0.0') == -1) {
       ant.xmlbean(
               javasource: "1.8",
               schema: getSchemasDir(),

--- a/src/main/groovy/org/labkey/gradle/task/SchemaCompile.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/SchemaCompile.groovy
@@ -60,12 +60,25 @@ class SchemaCompile extends DefaultTask {
             classname: 'org.apache.xmlbeans.impl.tool.XMLBean',
             classpath: project.configurations.xmlbeans.asPath
     )
-    ant.xmlbean(
-            schema: getSchemasDir(),
-            srcgendir: getSrcGenDir(),
-            classgendir: getClassesDir(),
-            classpath: project.configurations.xmlbeans.asPath,
-            failonerror: true
-    )
+    // TODO get rid of this once we have updated to the later xmlbeans version
+    if (project.property('xmlbeansVersion') == '3.0.1') {
+      ant.xmlbean(
+              javasource: "1.8",
+              schema: getSchemasDir(),
+              srcgendir: getSrcGenDir(),
+              classgendir: getClassesDir(),
+              classpath: project.configurations.xmlbeans.asPath,
+              failonerror: true
+      )
+    }
+    else {
+      ant.xmlbean(
+              schema: getSchemasDir(),
+              srcgendir: getSrcGenDir(),
+              classgendir: getClassesDir(),
+              classpath: project.configurations.xmlbeans.asPath,
+              failonerror: true
+      )
+    }
   }
 }

--- a/src/main/groovy/org/labkey/gradle/task/SchemaCompile.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/SchemaCompile.groovy
@@ -62,8 +62,6 @@ class SchemaCompile extends DefaultTask {
     )
     ant.xmlbean(
             schema: getSchemasDir(),
-            // N.B. Later versions of Java not currently supported and introduce warnings like: warning: [dep-ann] deprecated item is not annotated with @Deprecated
-            javasource: "1.8",
             srcgendir: getSrcGenDir(),
             classgendir: getClassesDir(),
             classpath: project.configurations.xmlbeans.asPath,

--- a/src/main/groovy/org/labkey/gradle/util/PropertiesUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/PropertiesUtils.groovy
@@ -79,12 +79,12 @@ class PropertiesUtils
             if (props.containsKey(propName))
                 line = replacePropInLine(line, propName, props.get(propName), xmlEncode)
             // backward compatibility for labkey.xml having new prop name and config.properties having old one
-            // TODO remove these cases once we move to a version that doesn't need to support backward compatibility
+            // TODO remove these cases once we move to a plugin version that doesn't need to support backward compatibility
             else if (propName.equals(ENCRYPTION_KEY_PROP_NAME) && props.containsKey(DEPRECATED_ENCRYPTION_KEY_PROP_NAME))
-                line = replacePropInLine(line, propName, props.get('materEncryptionKey'), xmlEncode)
+                line = replacePropInLine(line, propName, props.get(DEPRECATED_ENCRYPTION_KEY_PROP_NAME), xmlEncode)
             // backward compatibility for labkey.xml having old prop name and config.properties having new one
             else if (propName.equals(DEPRECATED_ENCRYPTION_KEY_PROP_NAME) && props.containsKey(ENCRYPTION_KEY_PROP_NAME))
-                line = replacePropInLine(line, propName, props.get('encryptionKey'), xmlEncode)
+                line = replacePropInLine(line, propName, props.get(ENCRYPTION_KEY_PROP_NAME), xmlEncode)
         }
         return line
     }


### PR DESCRIPTION
#### Rationale
We have deprecated the user of `masterEncryptionKey` in favor of `encryptionKey`.  This PR updates our processing of the `config.properties` files to handle both property names and updates the `labkey.xml` file included in distributions to have the new property name.

As of XMLBeans version 5.0.0, the use of the `javasource` property is not longer supported.  This introduces changes so we can upgrade to that later version when we want to.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/199

#### Changes
* [Issue 44600](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44600) Support new 'EncryptionKey' property name
* Stop specifying `javasource` parameter when invoking XMLBeans build; recent XMLBeans versions fail if this parameter is provided.
* Upgrade to gradle 7.3.3