### PR TITLE
Refine dependencies for SchemaCompile and other misc changes to avoid warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
-### TBD
-*Released*: TBD
+### 1.32.2
+*Released*: 11 February 2022
 (Earliest compatible LabKey version: 22.2)
-* Update inputs of `SchemaCompile` task so it will defeat the cache when the xmlBeans version changes
+* Update inputs of `SchemaCompile` task, so it will defeat the cache when the xmlBeans version changes
 * Update `RunUiTest` reports to non-deprecated properties
 * Change `copyJspResources` to use `project.copy` instead of a `Copy` task to avoid warnings about cache optimizations that are not interesting
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ _Note: 1.28.0 and later require Gradle 7_
 ### TBD
 *Released*: TBD
 (Earliest compatible LabKey version: 22.2)
-* Update input annotations of `SchemaCompile` task so it will defeat the cache when the xmlBeans version changes
-* Update RunUiTest reports to non-deprecated properties
-* Change `copyJspResources` to user `project.copy` instead of a `Copy` task to avoid warnings about cache optimizations that are not possible
+* Update inputs of `SchemaCompile` task so it will defeat the cache when the xmlBeans version changes
+* Update `RunUiTest` reports to non-deprecated properties
+* Change `copyJspResources` to use `project.copy` instead of a `Copy` task to avoid warnings about cache optimizations that are not interesting
 
 ### 1.32.1
 *Released*: 24 January 2022

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ _Note: 1.28.0 and later require Gradle 7_
 *Released*: TBD
 (Earliest compatible LabKey version: 22.2)
 * Update input annotations of `SchemaCompile` task so it will defeat the cache when the xmlBeans version changes
+* Update RunUiTest reports to non-deprecated properties
+* Change `copyJspResources` to user `project.copy` instead of a `Copy` task to avoid warnings about cache optimizations that are not possible
 
 ### 1.32.1
 *Released*: 24 January 2022

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### TBD
+*Released*: TBD
+(Earliest compatible LabKey version: 22.2)
+* Update input annotations of `SchemaCompile` task so it will defeat the cache when the xmlBeans version changes
+
 ### 1.32.1
 *Released*: 24 January 2022
 (Earliest compatible LabKey version: 22.2)

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.33.0-refineDependencies-SNAPSHOT"
+project.version = "1.33.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.33.0-SNAPSHOT"
+project.version = "1.33.0-refineDependencies-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/groovy/org/labkey/gradle/task/RunUiTest.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/RunUiTest.groovy
@@ -37,10 +37,10 @@ class RunUiTest extends Test
         setJvmArgs()
 
         reports { TestTaskReports -> reports
-            reports.junitXml.enabled = false
-            reports.junitXml.setDestination( new File("${project.buildDir}/${LOG_DIR}/reports/xml"))
-            reports.html.enabled = true
-            reports.html.setDestination(new File( "${project.buildDir}/${LOG_DIR}/reports/html"))
+            reports.junitXml.required = false
+            reports.junitXml.outputLocation =  new File("${project.buildDir}/${LOG_DIR}/reports/xml")
+            reports.html.required = true
+            reports.html.outputLocation = new File( "${project.buildDir}/${LOG_DIR}/reports/html")
         }
         setClasspath (project.sourceSets.uiTest.runtimeClasspath)
         setTestClassesDirs (project.sourceSets.uiTest.output.classesDirs)

--- a/src/main/groovy/org/labkey/gradle/task/SchemaCompile.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/SchemaCompile.groovy
@@ -17,6 +17,7 @@ package org.labkey.gradle.task
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
@@ -31,6 +32,14 @@ import org.labkey.gradle.util.BuildUtils
 @CacheableTask
 class SchemaCompile extends DefaultTask {
 
+  // This input declaration is used to defeat the gradle build cache when the xmlbeansVersion changes and should
+  // remain even if there are no usages of this method. I don't know why the cache key doesn't change as a result of the
+  // new jar file version, but it doesn't (perhaps an artifact of having to use the ant builder).
+  @Input
+  String getXmlBeansVersion()
+  {
+    return project.property('xmlbeansVersion');
+  }
 
   @InputDirectory
   @PathSensitive(PathSensitivity.RELATIVE)
@@ -62,7 +71,7 @@ class SchemaCompile extends DefaultTask {
             classpath: project.configurations.xmlbeans.asPath
     )
     // TODO get rid of this once we have updated to the later xmlbeans version please
-    if (BuildUtils.compareVersions(project.property('xmlbeansVersion'), '5.0.0') == -1) {
+    if (BuildUtils.compareVersions(getXmlBeansVersion(), '5.0.0') == -1) {
       ant.xmlbean(
               javasource: "1.8",
               schema: getSchemasDir(),


### PR DESCRIPTION
#### Rationale
For some reason, perhaps because of the use of the ant builder, the build cache key for the `SchemaCompile` task does not change when the version of xmlBeans changes.  We add an input property for that version property to make it behave better.

We also take this opportunity to get rid of some warnings that show up  with Gradle 7.4 about deprecated properties and overlapping build directories.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Update inputs of `SchemaCompile` task so it will defeat the cache when the xmlBeans version changes
* Update `RunUiTest` reports to non-deprecated properties
* Change `copyJspResources` to use `project.copy` instead of a `Copy` task to avoid warnings about cache optimizations that are not interesting
