### PR TITLE
Issue 44490: Fix WriteDependenciesFile so it works with classifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
-### TBD
-*Released*: TBD
+### 1.33.0
+*Released*: 24 May 2022
 (Earliest compatible LabKey version: 22.TBD)
 
-* Stop specifying `javascource` parameter when invoking XMLBeans build; server XMLBeans dependency has been upgraded to 5.0.3, which fails if this parameter is provided.
+* Stop specifying `javasource` parameter when invoking XMLBeans build; server XMLBeans dependency has been upgraded to 5.0.3, which fails if this parameter is provided.
 * Add `@labkey/eln` to the packages PurgeNpmAlphaVersions knows about
 * Fix NPE-type error when output from `npm view` command is empty
 * [Issue 44490](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44490) Fix WriteDependenciesFile so it works with classifiers

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ _Note: 1.28.0 and later require Gradle 7_
 * Stop specifying `javascource` parameter when invoking XMLBeans build; server XMLBeans dependency has been upgraded to 5.0.3, which fails if this parameter is provided.
 * Add `@labkey/eln` to the packages PurgeNpmAlphaVersions knows about
 * Fix NPE-type error when output from `npm view` command is empty
+* [Issue 44490](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44490) Fix WriteDependenciesFile so it works with classifiers
 
 ### 1.32.2
 *Released*: 11 February 2022

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.33.0-SNAPSHOT"
+project.version = "1.33.0-classifierDependencies-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.33.0-classifierDependencies-SNAPSHOT"
+project.version = "1.34.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/task/WriteDependenciesFile.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/WriteDependenciesFile.groovy
@@ -15,6 +15,7 @@
  */
 package org.labkey.gradle.task
 
+import org.apache.commons.lang3.StringUtils
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.artifacts.Configuration
@@ -79,7 +80,10 @@ class WriteDependenciesFile extends DefaultTask
         List<String> licenseMissing = []
         configuration.resolvedConfiguration.resolvedArtifacts.forEach {
             ResolvedArtifact artifact ->
-                ExternalDependency dep = extension.getExternalDependency(artifact.moduleVersion.toString())
+                String versionString = artifact.moduleVersion.toString();
+                if (!StringUtils.isEmpty(artifact.getClassifier()))
+                    versionString += ":" + artifact.getClassifier()
+                ExternalDependency dep = extension.getExternalDependency(versionString)
                 if (dep) {
                     List<String> parts = new ArrayList<>()
                     parts.add(artifact.file.getName())


### PR DESCRIPTION
#### Rationale
[Issue 44490](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44490): ExternalDependency method doesn't support 'classifier'

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Check for classifier in dependency artifact and add it to the key used for checking external dependencies
