### PR TITLE
Update inheritDependencies so logic for excluding modules works and fix encoding of jars.txt file

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
-### TBD
-*Released*: TBD
+### 1.33.1
+*Released*: 9 June 2022
 (Earliest compatible LabKey version: 22.3)
-* Fix `Distribution.inheritDependencies` so the excluded modules parameter works (again0)
+* Fix `Distribution.inheritDependencies` so the excluded modules parameter works (again)
 * [Issue 45622](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45622): Generated `jars.txt` files are encoded as 1252 (ANSI - Latin I) on Windows builds but read using UTF-8
 
 ### 1.33.0

--- a/README.md
+++ b/README.md
@@ -15,9 +15,15 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### TBD
+*Released*: TBD
+(Earliest compatible LabKey version: 22.3)
+* Fix `Distribution.inheritDependencies` so the excluded modules parameter works (again0)
+* [Issue 45622](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45622): Generated `jars.txt` files are encoded as 1252 (ANSI - Latin I) on Windows builds but read using UTF-8
+
 ### 1.33.0
 *Released*: 24 May 2022
-(Earliest compatible LabKey version: 22.TBD)
+(Earliest compatible LabKey version: 22.3)
 
 * Stop specifying `javasource` parameter when invoking XMLBeans build; server XMLBeans dependency has been upgraded to 5.0.3, which fails if this parameter is provided.
 * Add `@labkey/eln` to the packages PurgeNpmAlphaVersions knows about

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.34.0-elnInLKSMDependencies-SNAPSHOT"
+project.version = "1.34.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.34.0-SNAPSHOT"
+project.version = "1.34.0-elnInLKSMDependencies-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
@@ -164,10 +164,13 @@ class Distribution implements Plugin<Project>
         project.evaluationDependsOn(inheritedProjectPath)
         project.project(inheritedProjectPath).configurations.distribution.dependencies.each {
             Dependency dep ->
-                if (dep instanceof ModuleDependency)
+                if (dep instanceof ProjectDependency) {
+                    if (!excludedModules.contains(dep.dependencyProject.path))
+                        project.dependencies.add("distribution", dep)
+                }
+                else if (dep instanceof ModuleDependency)
                     project.dependencies.add("distribution", dep)
-                else if (dep instanceof ProjectDependency && !excludedModules.contains(dep.dependencyProject.path))
-                    project.dependencies.add("distribution", dep)
+
 
         }
     }

--- a/src/main/groovy/org/labkey/gradle/task/WriteDependenciesFile.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/WriteDependenciesFile.groovy
@@ -15,6 +15,7 @@
  */
 package org.labkey.gradle.task
 
+import java.nio.charset.StandardCharsets
 import org.apache.commons.lang3.StringUtils
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
@@ -69,7 +70,7 @@ class WriteDependenciesFile extends DefaultTask
         }
     }
 
-    private void writeDependencies(String configurationName, OutputStream outputStream)
+    private void writeDependencies(String configurationName, OutputStreamWriter writer)
     {
         Configuration configuration = project.configurations.findByName(configurationName)
         if (configuration == null)
@@ -104,7 +105,7 @@ class WriteDependenciesFile extends DefaultTask
                         licenseMissing.add(artifact.moduleVersion.toString())
                     }
                     parts.add(dep.getPurpose() == null ? "" : dep.getPurpose())
-                    outputStream.write("${parts.join("|")}\n".getBytes());
+                    writer.write("${parts.join("|")}\n");
                 } else {
                     missing.add(artifact.moduleVersion.toString())
                 }
@@ -124,19 +125,19 @@ class WriteDependenciesFile extends DefaultTask
         if (extension.getExternalDependencies().isEmpty())
             return;
 
-        FileOutputStream outputStream = null
+        OutputStreamWriter writer = null
         try {
-            outputStream = new FileOutputStream(jarsTxtFile)
-            outputStream.write("{table}\n".getBytes())
-            outputStream.write("Filename|Component|Source|License|Purpose\n".getBytes())
-            writeDependencies("externalsNotTrans", outputStream)
-            writeDependencies("creditable", outputStream)
-            outputStream.write("{table}\n".getBytes())
+            writer = new OutputStreamWriter(new FileOutputStream(jarsTxtFile), StandardCharsets.UTF_8)
+            writer.write("{table}\n")
+            writer.write("Filename|Component|Source|License|Purpose\n")
+            writeDependencies("externalsNotTrans", writer)
+            writeDependencies("creditable", writer)
+            writer.write("{table}\n")
         }
         finally
         {
-            if (outputStream != null)
-                outputStream.close()
+            if (writer != null)
+                writer.close()
         }
     }
 


### PR DESCRIPTION
#### Rationale
The logic for checking if certain dependencies should be excluded when inheriting dependencies relies on the dependency being a `ProjectDependency`.  Apparently, the `DefaultProjectDependency` is both a `ProjectDepenedency` and a `ModuleDependency`, so the logic that existed before would never check the exclusion list.

Also, we want UTF-8 files.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/263

#### Changes
* Fix `Distribution.inheritDependencies` so the excluded modules parameter works (again?)
* [Issue 45622](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45622): Generated `jars.txt` files are encoded as 1252 (ANSI - Latin I) on Windows builds but read using UTF-8
