### PR TITLE
Add `pickJtds` task

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ _Note: 1.28.0 and later require Gradle 7_
 *Released*: TBD
 (Earliest compatible LabKey version: 22.3)
 * Add `pickJtds` task for configuring LabKey to use the jTDS SQL Server driver
+* Update dependencies (since grgit has gone missing on mavenCentral)
 
 ### 1.33.1
 *Released*: 9 June 2022

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
-### TBD
-*Released*: TBD
+### 1.34.0
+*Released*: 22 June 2022
 (Earliest compatible LabKey version: 22.3)
 * Add `pickJtds` task for configuring LabKey to use the jTDS SQL Server driver
 * Update dependencies (since grgit has gone missing on mavenCentral)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### TBD
+*Released*: TBD
+(Earliest compatible LabKey version: 22.3)
+* Add `pickJtds` task for configuring LabKey to use the jTDS SQL Server driver
+
 ### 1.33.1
 *Released*: 9 June 2022
 (Earliest compatible LabKey version: 22.3)

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.33.2-SNAPSHOT"
+project.version = "1.35.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.34.0-SNAPSHOT"
+project.version = "1.33.2-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,21 +1,21 @@
 artifactory_contextUrl=https://artifactory.labkey.com/artifactory
 
-artifactoryPluginVersion=4.21.0
+artifactoryPluginVersion=4.28.2
 
-commonsIoVersion=2.8.0
+commonsIoVersion=2.11.0
 commonsLang3Version=3.12.0
 commonsTextVersion=1.9
 
-grgitGradleVersion=4.1.0
-graphqlJavaVersion=16.2
+grgitGradleVersion=5.0.0
+graphqlJavaVersion=18.1
 
 httpclientVersion=4.5.13
-httpcoreVersion=4.4.14
+httpcoreVersion=4.4.15
 
-jacksonVersion=2.12.2
-jsonVersion=20210307
+jacksonVersion=2.13.3
+jsonVersion=20220320
 
-# Version 2.4.8a is a custom built version of YUICompressor.
+# Version 2.4.8a is a custom-built version of YUICompressor.
 # Note that 2.4.8 fails with absolute paths on Windows, https://github.com/yui/yuicompressor/issues/78,
 # but the issue is fixed on yuicompressor current master.
 yuiCompressorVersion=2.4.8a

--- a/src/main/groovy/org/labkey/gradle/plugin/Database.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Database.groovy
@@ -54,6 +54,16 @@ class Database implements Plugin<Project>
         }
     }
 
+    private static void addPickJtdsTask(Project project)
+    {
+        project.tasks.register("pickJtds", PickDb) {
+            PickDb task ->
+                task.group = GroupNames.DATABASE
+                task.description = "Switch to SQL Server configuration using jTDS driver"
+                task.dbType = "jtds"
+        }
+    }
+
     private static void addBootstrapTask(Project project)
     {
         project.tasks.register("bootstrap", Bootstrap) {


### PR DESCRIPTION
#### Rationale
Allows developers to choose between the Microsoft and jTDS SQL Server drivers.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/264

#### Changes
* Add `pickJtds` task
