### PR TITLE
Add `--add-opens` JVM args to test runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ on how to do that, including how to develop and test locally and the versioning 
 _Note: 1.28.0 and later require Gradle 7_
 
 ### 1.34.2
-*Released*: TBD
+*Released*: 28 July 2022
 (Earliest compatible LabKey version: 22.3)
 * Add `--add-opens` JVM args to test runners (removed in [Gradle 7.5](https://docs.gradle.org/7.5/userguide/upgrading_version_7.html#removes_implicit_add_opens_for_test_workers))
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### 1.34.2
+*Released*: TBD
+(Earliest compatible LabKey version: 22.3)
+* Add `--add-opens` JVM args to test runners (removed in [Gradle 7.5](https://docs.gradle.org/7.5/userguide/upgrading_version_7.html#removes_implicit_add_opens_for_test_workers))
+
 ### 1.34.1
 *Released*: 22 June 2022
 (Earliest compatible LabKey version: 22.3)

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.34.2-add-opens-SNAPSHOT"
+project.version = "1.35.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.35.0-SNAPSHOT"
+project.version = "1.34.2-add-opens-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/task/RunUiTest.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/RunUiTest.groovy
@@ -56,7 +56,10 @@ class RunUiTest extends Test
                                     "-Xrunjdwp:transport=dt_socket,server=y," +
                                             "suspend=${testExt.getTestConfig("debugSuspendSelenium")}," +
                                             "address=${testExt.getTestConfig("selenium.debug.port")}",
-                                    "-Dfile.encoding=UTF-8"]
+                                    "-Dfile.encoding=UTF-8",
+                                    "--add-opens=java.base/java.lang=ALL-UNNAMED",
+                                    "--add-opens=java.base/java.util=ALL-UNNAMED"
+        ]
 
         if (project.hasProperty("uiTestJvmOpts"))
             jvmArgsList.add(project.property("uiTestJvmOpts"))


### PR DESCRIPTION
#### Rationale
The Sardine WebDav client uses reflection techniques that are no longer enabled by default as of Gradle 7.5.
https://docs.gradle.org/7.5/userguide/upgrading_version_7.html#removes_implicit_add_opens_for_test_workers

#### Related Pull Requests
* https://github.com/LabKey/server/pull/285

#### Changes
* Add `--add-opens` flags to test JVM args
