### PR TITLE
Make `TeamCity.ensureShutdown(..)` less fragile

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ on how to do that, including how to develop and test locally and the versioning 
 _Note: 1.28.0 and later require Gradle 7_
 
 ### 1.34.3
-*Released*: TBD
+*Released*: 10 Aug 2022
 (Earliest compatible LabKey version: 22.3)
-* Make `TeamCity.ensureShutdown(..)` more reliable
+* Ignore harmless exceptions from `TeamCity.ensureShutdown(..)`
 
 ### 1.34.2
 *Released*: 28 July 2022

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### 1.34.3
+*Released*: TBD
+(Earliest compatible LabKey version: 22.3)
+* Make `TeamCity.ensureShutdown(..)` more reliable
+
 ### 1.34.2
 *Released*: 28 July 2022
 (Earliest compatible LabKey version: 22.3)

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.34.3-SNAPSHOT"
+project.version = "1.35.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.35.0-SNAPSHOT"
+project.version = "1.34.3-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins


### PR DESCRIPTION
#### Rationale
Seems like tomcat shutdown is hovering around our default timeout in `TeamCity.threadDumpAndKill` and throws an uncaught `VMDisconnectedException`.
```
Execution failed for task ':server:testAutomation:stopTomcat'.
> com.sun.jdi.VMDisconnectedException (no error message)
[...]
Caused by: com.sun.jdi.VMDisconnectedException
       at jdk.jdi/com.sun.tools.jdi.TargetVM.waitForReply(TargetVM.java:310)
       at jdk.jdi/com.sun.tools.jdi.VirtualMachineImpl.waitForTargetReply(VirtualMachineImpl.java:1173)
       at jdk.jdi/com.sun.tools.jdi.PacketStream.waitForReply(PacketStream.java:87)
       at jdk.jdi/com.sun.tools.jdi.JDWP$VirtualMachine$Suspend.waitForReply(JDWP.java:571)
       at jdk.jdi/com.sun.tools.jdi.JDWP$VirtualMachine$Suspend.process(JDWP.java:557)
       at jdk.jdi/com.sun.tools.jdi.VirtualMachineImpl.suspend(VirtualMachineImpl.java:487)
       at com.sun.jdi.VirtualMachine$suspend$0.call(Unknown Source)
       at org.labkey.gradle.plugin.TeamCity.threadDumpAndKill(TeamCity.groovy:345)
```

No rush on this. The failure is mostly cosmetic but does cause some confusing noise on TeamCity.

#### Related Pull Requests
* N/A

#### Changes
* Treat any `VMDisconnectedException` as a successful shutdown
