### PR TITLE
Fix `Distribution.inheritDependencies` so excluded modules work when not building from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### 1.34.4
+*Released*: 24 Aug 2022
+(Earliest compatible LabKey version: 22.3)
+* Fix `Distribution.inheritDependencies` so excluded modules work when not building from source
+
 ### 1.34.3
 *Released*: 10 Aug 2022
 (Earliest compatible LabKey version: 22.3)

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.35.0-excludeDependencies-SNAPSHOT"
+project.version = "1.35.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.35.0-SNAPSHOT"
+project.version = "1.35.0-excludeDependencies-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
@@ -168,10 +168,8 @@ class Distribution implements Plugin<Project>
                     if (!excludedModules.contains(dep.dependencyProject.path))
                         project.dependencies.add("distribution", dep)
                 }
-                else if (dep instanceof ModuleDependency)
+                else if (dep instanceof ModuleDependency && !excludedModules.contains(BuildUtils.getModuleProjectPath(dep)))
                     project.dependencies.add("distribution", dep)
-
-
         }
     }
 

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -18,6 +18,7 @@ package org.labkey.gradle.util
 import org.apache.commons.lang3.StringUtils
 import org.gradle.api.GradleException
 import org.gradle.api.Project
+import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.initialization.Settings
 import org.gradle.api.invocation.Gradle
 import org.labkey.gradle.plugin.extension.LabKeyExtension
@@ -673,6 +674,12 @@ class BuildUtils
         String extensionString = extension == null ? "" : "@$extension"
 
         return "${group}:${moduleName}${versionString}${extensionString}"
+    }
+
+    static String getModuleProjectPath(ModuleDependency dependency)
+    {
+        String name = dependency.getName()
+        return ":server:modules:" + name;
     }
 
     static String getRepositoryKey(Project project)

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -678,8 +678,7 @@ class BuildUtils
 
     static String getModuleProjectPath(ModuleDependency dependency)
     {
-        String name = dependency.getName()
-        return ":server:modules:" + name;
+        return ":server:modules:" + dependency.getName()
     }
 
     static String getRepositoryKey(Project project)


### PR DESCRIPTION
#### Rationale
When not building from source, we were failing to check the excluded modules property (since that is a list of project paths, not dependency coordinates).  This adds a method for getting the path from the dependency and using that to check if the dependency should be excluded.

#### Related Pull Requests
* 

#### Changes
* Do exclusion check for ModuleDependencies as well as ProjectDependencies
