### PR TITLE
Conditionally add api module task dependency to 'patchApiModule'

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### 1.36.1
+*Released*: TBD
+(Earliest compatible LabKey version: 22.9)
+* Check for the presence of the API project before adding task dependency to `patchApiModule`. Allows building distributions with a minimal enlistment.
+
 ### 1.36.0
 *Released*: 26 October 2022
 (Earliest compatible LabKey version: 22.9)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ _Note: 1.28.0 and later require Gradle 7_
 *Released*: TBD
 (Earliest compatible LabKey version: 22.9)
 * Check for the presence of the API project before adding task dependency to `patchApiModule`. Allows building distributions with a minimal enlistment.
+* Make `patchApiModule` task more reliable
 
 ### 1.36.0
 *Released*: 26 October 2022

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ on how to do that, including how to develop and test locally and the versioning 
 _Note: 1.28.0 and later require Gradle 7_
 
 ### 1.36.1
-*Released*: TBD
+*Released*: 18 November 2022
 (Earliest compatible LabKey version: 22.9)
 * Check for the presence of the API project before adding task dependency to `patchApiModule`. Allows building distributions with a minimal enlistment.
 * Make `patchApiModule` task more reliable

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.37.0-SNAPSHOT"
+project.version = "1.36.1_patchApiFix-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.36.1_patchApiFix-SNAPSHOT"
+project.version = "1.37.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/plugin/ApplyLicenses.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ApplyLicenses.groovy
@@ -96,11 +96,10 @@ class ApplyLicenses implements Plugin<Project>
             project.tasks.register('verifyLicensePatch') {
                 dependsOn(patchApiTask)
                 doLast {
-                    [project.configurations.extJs3Commercial, project.configurations.extJs3Commercial].forEach {
+                    [project.configurations.extJs3Commercial, project.configurations.extJs4Commercial].forEach {
                         def commercialLicense = project.zipTree(it.singleFile).matching {
                             include '*/license.txt'
                         }.singleFile
-                        project.logger.warn 'parent name ' + commercialLicense.parentFile.name
                         def patchedLicense = project.zipTree(patchApiTask.get().outputs.files.singleFile).matching {
                             include 'web/' + commercialLicense.parentFile.name + '/license.txt'
                         }.singleFile

--- a/src/main/groovy/org/labkey/gradle/plugin/ApplyLicenses.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ApplyLicenses.groovy
@@ -76,7 +76,9 @@ class ApplyLicenses implements Plugin<Project>
                             "Implementation-Title": "Internal API classes",
                             "Implementation-Vendor": "LabKey"
                     )
-                    jar.dependsOn(project.project(BuildUtils.getApiProjectPath(project.gradle)).tasks.findByName("module"))
+                    if (project.findProject(BuildUtils.getApiProjectPath(project.gradle))) {
+                        jar.dependsOn(project.project(BuildUtils.getApiProjectPath(project.gradle)).tasks.findByName("module"))
+                    }
             }
         }
     }


### PR DESCRIPTION
#### Rationale
`patchApiModule` can't run if you don't have the `platform` repository enlisted. Some builds on TeamCity are configured this way, to force building release installers with modules pulled from Artifactory.

#### Related Pull Requests
* #157 

#### Changes
* Check for the presence of the API project before adding task dependency
