### PR TITLE
Add tasks to generate startup properties files on TeamCity

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ _Note: 1.28.0 and later require Gradle 7_
 ### 1.36.2
 *Released*: TBD
 (Earliest compatible LabKey version: 22.9)
-* Add tasks to generate startup properties files on TeamCity
+* Add `createStartupPropertyFile` task to define arbitrary LabKey startup properties
+  * Controlled by `labkey.startup.properties` TeamCity property
+* Add `includeDistModules` task to populate `ModuleLoader.include` startup property
+  * Controlled by `labkey.startup.includeDistModules` TeamCity property
 
 ### 1.36.1
 *Released*: 18 November 2022

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
-### 1.36.2
-*Released*: TBD
+### 1.37.0
+*Released*: 8 December 2022
 (Earliest compatible LabKey version: 22.9)
 * Add `createStartupPropertyFile` task to define arbitrary LabKey startup properties
   * Controlled by `labkey.startup.properties` TeamCity property

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### 1.36.2
+*Released*: TBD
+(Earliest compatible LabKey version: 22.9)
+* Add tasks to generate startup properties files on TeamCity
+
 ### 1.36.1
 *Released*: 18 November 2022
 (Earliest compatible LabKey version: 22.9)

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.37.0-SNAPSHOT"
+project.version = "1.36.2-tomcatStartupProps-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.36.2-tomcatStartupProps-SNAPSHOT"
+project.version = "1.38.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
@@ -136,7 +136,7 @@ class TeamCity extends Tomcat
 
         project.tasks.register("createStartupPropertyFile") {
             doLast {
-                String properties = extension.getTeamCityProperty('', '')
+                String properties = extension.getTeamCityProperty('labkey.startup.properties')
 
                 extension.writeStartupProperties('99_teamcity_startup.properties', properties)
             }
@@ -250,9 +250,9 @@ class TeamCity extends Tomcat
 
         }
 
-        if (project.hasProperty('includeModulesFromDist') && !project.property('includeModulesFromDist').isBlank())
+        if (!extension.getTeamCityProperty('labkey.startup.includeDistModules').isBlank())
         {
-            String inheritedDistPath = project.property('includeModulesFromDist')
+            String inheritedDistPath = extension.getTeamCityProperty('labkey.startup.includeDistModules')
             project.logger.info("inheriting from distribution ${includeModulesFromDist}")
             project.evaluationDependsOn(inheritedDistPath)
             def distListModulesTask = project.tasks.register("distListModules", Task) {

--- a/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
@@ -142,6 +142,10 @@ class TeamCity extends Tomcat
             }
         }
 
+        project.tasks.named("startTomcat").configure {
+            dependsOn(project.tasks.createStartupPropertyFile)
+        }
+
         project.tasks.register("createNlpConfig", Copy) {
             Copy task ->
                 task.group = GroupNames.TEST_SERVER

--- a/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
@@ -268,10 +268,7 @@ class TeamCity extends Tomcat
                     task.doLast {
                         List<String> includeModules = new ArrayList<>();
                         project.project(inheritedDistPath).configurations.distribution.dependencies.each {
-                            Dependency dep ->
-                                if (dep instanceof ProjectDependency || dep instanceof ModuleDependency) {
-                                    includeModules.add(dep.getName())
-                                }
+                            includeModules.add(it.getName())
                         }
                         extension.writeStartupProperties('00_modulesInclude.properties',
                                 'ModuleLoader.include;startup=' + String.join(',', includeModules))

--- a/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
@@ -235,7 +235,9 @@ class TeamCity extends Tomcat
                 }
             }
             TaskProvider undeployTaskProvider = project.tasks.named(undeployTaskName)
-            project.tasks.startTomcat.mustRunAfter(undeployTaskProvider)
+            project.tasks.named("startTomcat").configure {
+                mustRunAfter(undeployTaskProvider)
+            }
 
             project.project(BuildUtils.getTestProjectPath(project.gradle)).tasks.startTomcat.mustRunAfter(setUpDbTask)
             String ciTestTaskName = "ciTests" + properties.dbTypeAndVersion.capitalize()

--- a/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
@@ -253,7 +253,7 @@ class TeamCity extends Tomcat
         if (!extension.getTeamCityProperty('labkey.startup.includeDistModules').isBlank())
         {
             String inheritedDistPath = extension.getTeamCityProperty('labkey.startup.includeDistModules')
-            project.logger.info("inheriting from distribution ${includeModulesFromDist}")
+            project.logger.info("inheriting from distribution ${inheritedDistPath}")
             project.evaluationDependsOn(inheritedDistPath)
             def distListModulesTask = project.tasks.register("distListModules", Task) {
                 Task task ->

--- a/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
@@ -261,7 +261,7 @@ class TeamCity extends Tomcat
             String inheritedDistPath = extension.getTeamCityProperty('labkey.startup.includeDistModules')
             project.logger.info("inheriting from distribution ${inheritedDistPath}")
             project.evaluationDependsOn(inheritedDistPath)
-            def distListModulesTask = project.tasks.register("distListModules", Task) {
+            def includeDistModulesTask = project.tasks.register("includeDistModules", Task) {
                 Task task ->
                     task.group = GroupNames.TEST_SERVER
                     task.description = "Generate server properties file to run with modules from a specified distribution"
@@ -279,7 +279,7 @@ class TeamCity extends Tomcat
             }
 
             project.tasks.named("startTomcat").configure {
-                dependsOn(distListModulesTask)
+                dependsOn(includeDistModulesTask)
             }
         }
 

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/TeamCityExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/TeamCityExtension.groovy
@@ -15,8 +15,11 @@
  */
 package org.labkey.gradle.plugin.extension
 
+import org.apache.commons.io.FileUtils
 import org.gradle.api.Project
 import org.labkey.gradle.util.DatabaseProperties
+
+import java.nio.charset.StandardCharsets
 
 class TeamCityExtension
 {
@@ -104,6 +107,18 @@ class TeamCityExtension
             props.setJdbcPassword(getTeamCityProperty("database.${typeAndVersion}.password"))
 
         this.databaseTypes.add(props)
+    }
+
+    File startupPropertiesDir() {
+        File startupDir = new File(new File(ServerDeployExtension.getServerDeployDirectory(project)), 'startup')
+        FileUtils.forceMkdir(startupDir)
+        return startupDir
+    }
+
+    void writeStartupProperties(String fileName, String properties) {
+        File propFile = new File(startupPropertiesDir(), fileName)
+
+        FileUtils.write(propFile, properties, StandardCharsets.UTF_8)
     }
 
     String getBuildBranch()


### PR DESCRIPTION
#### Rationale
In order to efficiently test different distributions or product tiers, we need a way to customize Tomcat startup more easily on TeamCity.

#### Related Pull Requests
* N/A

#### Changes
* Add `createStartupPropertyFile` task to define arbitrary LabKey startup properties
  * Controlled by `labkey.startup.properties` TeamCity property
* Add `includeDistModules` task to populate `ModuleLoader.include` startup property
  * Controlled by `labkey.startup.includeDistModules` TeamCity property