### PR TITLE
Issue 43245: Update `ClientLibsCompress` task to use npm packages instead of the ancient YuiCompressor

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
-### TBD
-*Released*: TBD
+### 1.38.0
+*Released*: 9 January 2023
 (Earliest compatible LabKey version: 22.9)
-* Update `ClientLibsCompress` task to use npm packages instead of the ancient YuiCompressor
+* Update `ClientLibsCompress` task to use npm packages instead of the ancient YuiCompressor by default
   * Use [terser](https://github.com/terser/terser) for javascript minification 
   * Use [cssnano](https://cssnano.co/) via [postcss](https://github.com/postcss/postcss) for css minification
+  * Add check for `useYuiCompressor` property on projects to enable deprecated functionality
 
 ### 1.37.1
 *Released*: 9 December 2022

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ _Note: 1.28.0 and later require Gradle 7_
 (Earliest compatible LabKey version: 22.9)
 * Update `ClientLibsCompress` task to use npm packages instead of the ancient YuiCompressor
   * Use [terser](https://github.com/terser/terser) for javascript minification 
-  * Use [cssnano[(https://cssnano.co/)] via [postcss](https://github.com/postcss/postcss) for css minification
+  * Use [cssnano](https://cssnano.co/) via [postcss](https://github.com/postcss/postcss) for css minification
 
 ### 1.37.1
 *Released*: 9 December 2022

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ _Note: 1.28.0 and later require Gradle 7_
 ### TBD
 *Released*: TBD
 (Earliest compatible LabKey version: 22.9)
-* Update `ClientLibsCompress` task to add option for not using ancient YuiCompressor
+* Update `ClientLibsCompress` task to use npm packages instead of the ancient YuiCompressor
+  * Use [terser](https://github.com/terser/terser) for javascript minification 
+  * Use [cssnano[(https://cssnano.co/)] via [postcss](https://github.com/postcss/postcss) for css minification
 
 ### 1.37.1
 *Released*: 9 December 2022

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### TBD
+*Released*: TBD
+(Earliest compatible LabKey version: 22.9)
+* Update `ClientLibsCompress` task to add option for not using ancient YuiCompressor
+
 ### 1.37.1
 *Released*: 9 December 2022
 (Earliest compatible LabKey version: 22.9)

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.38.0-byeYui-SNAPSHOT"
+project.version = "1.39.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.38.0-SNAPSHOT"
+project.version = "1.38.0-byeYui-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/plugin/ClientLibraries.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ClientLibraries.groovy
@@ -17,7 +17,9 @@ package org.labkey.gradle.plugin
 
 
 import org.gradle.api.Project
+import org.gradle.api.file.DeleteSpec
 import org.gradle.api.file.FileTree
+import org.gradle.api.tasks.Delete
 import org.labkey.gradle.task.ClientLibsCompress
 import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.GroupNames
@@ -51,6 +53,16 @@ class ClientLibraries
         }
         project.evaluationDependsOn(minProjectPath)
         project.tasks.assemble.dependsOn(project.tasks.compressClientLibs)
+
+        project.tasks.register("cleanClientLibs", Delete) {
+            Delete task ->
+                task.group = GroupNames.CLIENT_LIBRARIES
+                task.description = "Removes ${ClientLibsCompress.getMinificationDir(project)}"
+                task.configure({ DeleteSpec delete ->
+                    if (ClientLibsCompress.getMinificationDir(project).exists())
+                        delete.delete(ClientLibsCompress.getMinificationDir(project))
+                })
+        }
     }
 }
 

--- a/src/main/groovy/org/labkey/gradle/plugin/ClientLibraries.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ClientLibraries.groovy
@@ -42,7 +42,7 @@ class ClientLibraries
 
     static boolean useNpmMinifier(Project project)
     {
-        return project.hasProperty("useNpmMinifier") && project.project(BuildUtils.getMinificationProjectPath(project.gradle)).projectDir.exists()
+        return !project.hasProperty("useYuiCompressor") && project.project(BuildUtils.getMinificationProjectPath(project.gradle)).projectDir.exists()
     }
 
     static void addTasks(Project project)

--- a/src/main/groovy/org/labkey/gradle/plugin/ClientLibraries.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ClientLibraries.groovy
@@ -42,7 +42,7 @@ class ClientLibraries
 
     static boolean useNpmMinifier(Project project)
     {
-        return project.hasProperty("useNpmMinifier")
+        return project.hasProperty("useNpmMinifier") && project.project(BuildUtils.getMinificationProjectPath(project.gradle)).projectDir.exists()
     }
 
     static void addTasks(Project project)

--- a/src/main/groovy/org/labkey/gradle/plugin/ClientLibraries.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ClientLibraries.groovy
@@ -69,6 +69,7 @@ class ClientLibraries
                     task.configure({ DeleteSpec delete ->
                         if (ClientLibsCompress.getMinificationDir(project).exists())
                             delete.delete(ClientLibsCompress.getMinificationDir(project))
+                        delete.delete(project.tasks.findByName("compressClientLibs").outputs.files)
                     })
             }
         }

--- a/src/main/groovy/org/labkey/gradle/plugin/ClientLibraries.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ClientLibraries.groovy
@@ -19,6 +19,7 @@ package org.labkey.gradle.plugin
 import org.gradle.api.Project
 import org.gradle.api.file.FileTree
 import org.labkey.gradle.task.ClientLibsCompress
+import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.GroupNames
 
 /**
@@ -39,14 +40,16 @@ class ClientLibraries
 
     static void addTasks(Project project)
     {
+        String minProjectPath = BuildUtils.getMinificationProjectPath(project.gradle)
         project.tasks.register("compressClientLibs", ClientLibsCompress) {
             ClientLibsCompress task ->
                 task.group = GroupNames.CLIENT_LIBRARIES
                 task.description = 'create minified, compressed javascript file using .lib.xml sources'
                 task.dependsOn ( project.tasks.processResources )
+                task.dependsOn(project.project(minProjectPath).tasks.findByName("npmInstall"))
                 task.xmlFiles = getLibXmlFiles(project)
         }
-
+        project.evaluationDependsOn(minProjectPath)
         project.tasks.assemble.dependsOn(project.tasks.compressClientLibs)
     }
 }

--- a/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
@@ -214,6 +214,7 @@ class FileModule implements Plugin<Project>
                 moduleFile.dependsOn(project.tasks.named('compressClientLibs'))
             project.tasks.build.dependsOn(moduleFile)
             project.tasks.clean.dependsOn(project.tasks.named('cleanModule'))
+            project.tasks.clean.dependsOn(project.tasks.named('cleanClientLibs'))
 
             project.artifacts
                     {

--- a/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
@@ -203,7 +203,6 @@ class FileModule implements Plugin<Project>
                     jar.archiveExtension.set('module')
                     jar.destinationDirectory = project.buildDir
                     jar.outputs.cacheIf({true})
-                    jar.doFirst({project.logger.quiet("STARTING module jar construction")})
             }
 
             Task moduleFile = project.tasks.module

--- a/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
@@ -214,7 +214,8 @@ class FileModule implements Plugin<Project>
                 moduleFile.dependsOn(project.tasks.named('compressClientLibs'))
             project.tasks.build.dependsOn(moduleFile)
             project.tasks.clean.dependsOn(project.tasks.named('cleanModule'))
-            project.tasks.clean.dependsOn(project.tasks.named('cleanClientLibs'))
+            if (ClientLibraries.useNpmMinifier(project))
+                project.tasks.clean.dependsOn(project.tasks.named('cleanClientLibs'))
 
             project.artifacts
                     {

--- a/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
@@ -203,6 +203,7 @@ class FileModule implements Plugin<Project>
                     jar.archiveExtension.set('module')
                     jar.destinationDirectory = project.buildDir
                     jar.outputs.cacheIf({true})
+                    jar.doFirst({project.logger.quiet("STARTING module jar construction")})
             }
 
             Task moduleFile = project.tasks.module

--- a/src/main/groovy/org/labkey/gradle/plugin/NpmRun.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/NpmRun.groovy
@@ -15,6 +15,7 @@
  */
 package org.labkey.gradle.plugin
 
+import org.apache.commons.lang3.SystemUtils
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -45,6 +46,11 @@ class NpmRun implements Plugin<Project>
     static boolean isApplicable(Project project)
     {
         return project.file(NPM_PROJECT_FILE).exists()
+    }
+
+    static String getNpmCommand()
+    {
+        return SystemUtils.IS_OS_WINDOWS ? "npm.cmd" : "npm"
     }
 
     @Override

--- a/src/main/groovy/org/labkey/gradle/task/ClientLibsCompress.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ClientLibsCompress.groovy
@@ -24,10 +24,10 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.file.FileTree
 import org.gradle.api.tasks.InputFiles
-import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectories
 import org.gradle.api.tasks.OutputFiles
 import org.gradle.api.tasks.TaskAction
+import org.labkey.gradle.plugin.ClientLibraries
 import org.labkey.gradle.plugin.NpmRun
 import org.labkey.gradle.plugin.extension.LabKeyExtension
 import org.labkey.gradle.util.BuildUtils
@@ -161,10 +161,12 @@ class ClientLibsCompress extends DefaultTask
         if (outputDirs == null) {
             outputDirs = new ArrayList<>()
 
-            getImporterMap().entrySet().each { Map.Entry<File, XmlImporter> entry ->
-                {
-                    if (entry.value.doCompile && entry.value.hasFilesToCompress())
-                        outputDirs.add(getMinificationWorkingDir(entry.key))
+            if (ClientLibraries.useNpmMinifier(project)) {
+                getImporterMap().entrySet().each { Map.Entry<File, XmlImporter> entry ->
+                    {
+                        if (entry.value.doCompile && entry.value.hasFilesToCompress())
+                            outputDirs.add(getMinificationWorkingDir(entry.key))
+                    }
                 }
             }
         }
@@ -191,7 +193,7 @@ class ClientLibsCompress extends DefaultTask
         {
             try
             {
-                if (project.hasProperty("useNpmMinifier"))
+                if (ClientLibraries.useNpmMinifier(project))
                 {
                     minifyViaNpm(xmlFile, importer)
                 }

--- a/src/main/groovy/org/labkey/gradle/task/ClientLibsCompress.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ClientLibsCompress.groovy
@@ -140,15 +140,19 @@ class ClientLibsCompress extends DefaultTask
                 // The output file will be in the working directory not in the source directory used when parsing the file.
                 String fileName = entry.key.getAbsolutePath()
                 fileName = fileName.replace(entry.value.sourceDir.getAbsolutePath(), workingDir.getAbsolutePath())
-                File workingFile = new File(fileName)
+                File workingFile = project.file(fileName)
                 if (entry.value.getCssFiles().size() > 0)
                 {
                     outputFiles.add(getOutputFile(workingFile, "min", "css"))
+                    if (LabKeyExtension.isDevMode(project))
+                        outputFiles.add(getOutputFile(workingFile, "min", "css.gz"))
                     outputFiles.add(getOutputFile(workingFile, "combined", "css"))
                 }
                 if (entry.value.getJavascriptFiles().size() > 0)
                 {
                     outputFiles.add(getOutputFile(workingFile, "min", "js"))
+                    if (LabKeyExtension.isDevMode(project))
+                        outputFiles.add(getOutputFile(workingFile, "min", "js.gz"))
                     outputFiles.add(getOutputFile(workingFile, "combined", "js"))
                 }
             }
@@ -250,7 +254,7 @@ class ClientLibsCompress extends DefaultTask
             File cssFile = concatenateCssFiles(xmlFile, importer.cssFiles)
             Pair<File, File> minFiles = createPackageJson(xmlFile, importer.javascriptFiles, cssFile)
             if (importer.hasJavascriptFiles()) {
-                project.logger.info("Compressing Javascript files for ${xmlFile}")
+                project.logger.quiet("Compressing Javascript files for ${xmlFile}")
                 project.ant.exec(
                     executable: getNpmCommand(),
                     dir: getMinificationWorkingDir(xmlFile)
@@ -258,10 +262,11 @@ class ClientLibsCompress extends DefaultTask
                     {
                         arg(line: "run minify-js")
                     }
+                project.logger.quiet("DONE Compressing Javascript files as ${minFiles.left}")
                 compressFile(minFiles.left)
             }
             if (importer.hasCssFiles()) {
-                project.logger.info("Compressing css files for ${xmlFile}")
+                project.logger.quiet("Compressing css files for ${xmlFile}")
                 project.ant.exec(
                     executable: getNpmCommand(),
                     dir: getMinificationWorkingDir(xmlFile)
@@ -269,6 +274,7 @@ class ClientLibsCompress extends DefaultTask
                     {
                         arg(line: "run minify-css")
                     }
+                project.logger.quiet("DONE Compressing css files as ${minFiles.right}")
                 compressFile(minFiles.right)
             }
         }

--- a/src/main/groovy/org/labkey/gradle/task/ClientLibsCompress.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ClientLibsCompress.groovy
@@ -234,8 +234,8 @@ class ClientLibsCompress extends DefaultTask
         }
     }
 
-    @Internal
-    String getNpmCommand()
+
+    private String getNpmCommand()
     {
         Project minProject = project.project(BuildUtils.getMinificationProjectPath(project.gradle))
         return "${minProject.projectDir}/.gradle/npm/npm-v${minProject.npmVersion}/bin/${NpmRun.getNpmCommand()}"

--- a/src/main/groovy/org/labkey/gradle/task/ClientLibsCompress.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ClientLibsCompress.groovy
@@ -259,7 +259,7 @@ class ClientLibsCompress extends DefaultTask
             if (importer.hasJavascriptFiles()) {
                 if (executableDir == null)
                     throw new GradleException("Could not find expected files in ${BuildUtils.getMinificationProjectPath(project.gradle)} project")
-                project.logger.quiet("Compressing Javascript files for ${xmlFile} with ${executableDir} in ${getMinificationWorkingDir(xmlFile)}")
+                project.logger.info("Compressing Javascript files for ${xmlFile} with ${executableDir} in ${getMinificationWorkingDir(xmlFile)}")
                 project.ant.exec(
                     outputproperty:"${propPrefix}JsText",
                     errorproperty: "${propPrefix}JsError",
@@ -274,17 +274,17 @@ class ClientLibsCompress extends DefaultTask
                                 value: "${executableDir}${File.pathSeparator}${System.getenv("PATH")}"
                         )
                     }
-                project.logger.quiet("${project.path} ${xmlFile} ant text ${project.ant.project.properties.get(propPrefix + 'JsText')}")
-                project.logger.quiet("${project.path} ${xmlFile} ant error ${project.ant.project.properties.get(propPrefix + 'JsError')}")
-                project.logger.quiet("${project.path} ${xmlFile} ant exitValue ${project.ant.project.properties.get(propPrefix + 'JsExitValue')}")
+                project.logger.debug("${project.path} ${xmlFile} ant text ${project.ant.project.properties.get(propPrefix + 'JsText')}")
+                project.logger.debug("${project.path} ${xmlFile} ant error ${project.ant.project.properties.get(propPrefix + 'JsError')}")
+                project.logger.debug("${project.path} ${xmlFile} ant exitValue ${project.ant.project.properties.get(propPrefix + 'JsExitValue')}")
                 if (project.ant.project.properties.get(propPrefix + 'JsExitValue') != '0')
                     throw new GradleException("Error compressing Javascript files for ${xmlFile}. Exit code ${project.ant.project.properties.get(propPrefix + 'JsExitValue')}.\n Output: ${project.ant.project.properties.get(propPrefix + 'JsText')}.\n Error: ${project.ant.project.properties.get(propPrefix + 'JsError')} ")
 
-                project.logger.quiet("DONE Compressing Javascript files as ${minFiles.left}")
+                project.logger.debug("DONE Compressing Javascript files as ${minFiles.left}")
                 compressFile(minFiles.left)
             }
             if (importer.hasCssFiles()) {
-                project.logger.quiet("Compressing css files for ${xmlFile}")
+                project.logger.info("Compressing css files for ${xmlFile}")
                 project.ant.exec(
                     outputproperty:"${propPrefix}CssText",
                     errorproperty: "${propPrefix}CssError",
@@ -299,12 +299,12 @@ class ClientLibsCompress extends DefaultTask
                                 value: "${executableDir}${File.pathSeparator}${System.getenv("PATH")}"
                         )
                     }
-                project.logger.quiet("${project.path} ${xmlFile} ant text ${project.ant.project.properties.get(propPrefix + 'CssText')}")
-                project.logger.quiet("${project.path} ${xmlFile} ant error ${project.ant.project.properties.get(propPrefix + 'CssError')}")
-                project.logger.quiet("${project.path} ${xmlFile} ant exitValue ${project.ant.project.properties.get(propPrefix + 'CssExitValue')}")
+                project.logger.debug("${project.path} ${xmlFile} ant text ${project.ant.project.properties.get(propPrefix + 'CssText')}")
+                project.logger.debug("${project.path} ${xmlFile} ant error ${project.ant.project.properties.get(propPrefix + 'CssError')}")
+                project.logger.debug("${project.path} ${xmlFile} ant exitValue ${project.ant.project.properties.get(propPrefix + 'CssExitValue')}")
                 if (project.ant.project.properties.get(propPrefix + 'CssExitValue') != '0')
                     throw new GradleException("Error compressing css files for ${xmlFile}. Exit code ${project.ant.project.properties.get(propPrefix + 'CssExitValue')}.\n Output: ${project.ant.project.properties.get(propPrefix + 'CssText')}.\n Error: ${project.ant.project.properties.get(propPrefix + 'CssError')} ")
-                project.logger.quiet("DONE Compressing css files as ${minFiles.right}")
+                project.logger.debug("DONE Compressing css files as ${minFiles.right}")
                 compressFile(minFiles.right)
             }
         }

--- a/src/main/groovy/org/labkey/gradle/task/ClientLibsCompress.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ClientLibsCompress.groovy
@@ -267,9 +267,9 @@ class ClientLibsCompress extends DefaultTask
                     throw new GradleException("Could not find expected files in ${BuildUtils.getMinificationProjectPath(project.gradle)} project")
                 project.logger.quiet("Compressing Javascript files for ${xmlFile} with ${executableDir} in ${getMinificationWorkingDir(xmlFile)}")
                 project.ant.exec(
-                    outputproperty:"text",
-                    errorproperty: "error",
-                    resultproperty: "exitValue",
+                    outputproperty:"minifyJsText",
+                    errorproperty: "minifyJsError",
+                    resultproperty: "minifyJsExitValue",
                     executable: "${executableDir}/${NpmRun.getNpmCommand()}",
                     dir: getMinificationWorkingDir(xmlFile)
                 )
@@ -280,11 +280,11 @@ class ClientLibsCompress extends DefaultTask
                                 value: "${executableDir}${File.pathSeparator}${System.getenv("PATH")}"
                         )
                     }
-                project.logger.quiet("${project.path} ${xmlFile} ant text ${project.ant.project.properties.text}")
-                project.logger.quiet("${project.path} ${xmlFile} ant error ${project.ant.project.properties.error}")
-                project.logger.quiet("${project.path} ${xmlFile} ant exitValue ${project.ant.project.properties.exitValue}")
-                if (project.ant.project.properties.exitValue != '0')
-                    throw new GradleException("Error compressing Javascript files for ${xmlFile}.\n Output: ${project.ant.project.properties.text}.\n Error: ${project.ant.project.properties.text} ")
+                project.logger.quiet("${project.path} ${xmlFile} ant text ${project.ant.project.properties.minifyJsText}")
+                project.logger.quiet("${project.path} ${xmlFile} ant error ${project.ant.project.properties.minifyJsError}")
+                project.logger.quiet("${project.path} ${xmlFile} ant exitValue ${project.ant.project.properties.minifyJsExitValue}")
+//                if (project.ant.project.properties.minifyJsExitValue != '0')
+//                    throw new GradleException("Error compressing Javascript files for ${xmlFile}.\n Output: ${project.ant.project.properties.minifyJsText}.\n Error: ${project.ant.project.properties.minifyJsError} ")
 
                 project.logger.quiet("DONE Compressing Javascript files as ${minFiles.left}")
                 compressFile(minFiles.left)
@@ -292,9 +292,9 @@ class ClientLibsCompress extends DefaultTask
             if (importer.hasCssFiles()) {
                 project.logger.quiet("Compressing css files for ${xmlFile}")
                 project.ant.exec(
-                    outputproperty:"text",
-                    errorproperty: "error",
-                    resultproperty: "exitValue",
+                    outputproperty:"minifyCssText",
+                    errorproperty: "minifyCssError",
+                    resultproperty: "minifyCssExitValue",
                     executable: "${executableDir}/${NpmRun.getNpmCommand()}",
                     dir: getMinificationWorkingDir(xmlFile)
                 )
@@ -306,11 +306,11 @@ class ClientLibsCompress extends DefaultTask
                         )
                     }
 
-                project.logger.quiet("${project.path} ${xmlFile} ant text ${project.ant.project.properties.text}")
-                project.logger.quiet("${project.path} ${xmlFile} ant error ${project.ant.project.properties.error}")
-                project.logger.quiet("${project.path} ${xmlFile} ant exitValue ${project.ant.project.properties.exitValue}")
-                if (project.ant.project.properties.exitValue != '0')
-                    throw new GradleException("Error compressing css files for ${xmlFile}.\n Output: ${project.ant.project.properties.text}.\n Error: ${project.ant.project.properties.text} ")
+                project.logger.quiet("${project.path} ${xmlFile} ant text ${project.ant.project.properties.minifyCssText}")
+                project.logger.quiet("${project.path} ${xmlFile} ant error ${project.ant.project.properties.minifyCssError}")
+                project.logger.quiet("${project.path} ${xmlFile} ant exitValue ${project.ant.project.properties.minifyCssExitValue}")
+//                if (project.ant.project.properties.exitValue != '0')
+//                    throw new GradleException("Error compressing css files for ${xmlFile}.\n Output: ${project.ant.project.properties.minifyCssText}.\n Error: ${project.ant.project.properties.minifyCssError} ")
                 project.logger.quiet("DONE Compressing css files as ${minFiles.right}")
                 compressFile(minFiles.right)
             }

--- a/src/main/groovy/org/labkey/gradle/task/ClientLibsCompress.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ClientLibsCompress.groovy
@@ -18,6 +18,7 @@ package org.labkey.gradle.task
 import com.yahoo.platform.yui.compressor.CssCompressor
 import com.yahoo.platform.yui.compressor.JavaScriptCompressor
 import org.apache.commons.io.IOUtils
+import org.apache.commons.lang3.SystemUtils
 import org.apache.commons.lang3.tuple.Pair
 import org.apache.tools.ant.util.FileUtils
 import org.gradle.api.DefaultTask
@@ -240,7 +241,7 @@ class ClientLibsCompress extends DefaultTask
     private String getNpmCommand()
     {
         Project minProject = project.project(BuildUtils.getMinificationProjectPath(project.gradle))
-        return "${minProject.projectDir}/.gradle/npm/npm-v${minProject.npmVersion}/bin/${NpmRun.getNpmCommand()}"
+        return "${minProject.projectDir}/.gradle/npm/npm-v${minProject.npmVersion}${SystemUtils.IS_OS_WINDOWS ? '' : '/bin'}/${NpmRun.getNpmCommand()}"
     }
 
     void minifyViaNpm(File xmlFile, XmlImporter importer)

--- a/src/main/groovy/org/labkey/gradle/task/ClientLibsCompress.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ClientLibsCompress.groovy
@@ -259,10 +259,10 @@ class ClientLibsCompress extends DefaultTask
     void minifyViaNpm(File xmlFile, XmlImporter importer)
     {
         if (importer.hasFilesToCompress()) {
+            String executableDir = getNodeExecutableDir()
             File cssFile = concatenateCssFiles(xmlFile, importer.cssFiles)
             Pair<File, File> minFiles = createPackageJson(xmlFile, importer.javascriptFiles, cssFile)
             if (importer.hasJavascriptFiles()) {
-                String executableDir = getNodeExecutableDir()
                 if (executableDir == null)
                     throw new GradleException("Could not find expected files in ${BuildUtils.getMinificationProjectPath(project.gradle)} project")
                 project.logger.quiet("Compressing Javascript files for ${xmlFile} with ${executableDir} in ${getMinificationWorkingDir(xmlFile)}")

--- a/src/main/groovy/org/labkey/gradle/task/ClientLibsCompress.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ClientLibsCompress.groovy
@@ -283,6 +283,9 @@ class ClientLibsCompress extends DefaultTask
             if (importer.hasCssFiles()) {
                 project.logger.quiet("Compressing css files for ${xmlFile}")
                 project.ant.exec(
+                    outputproperty:"text",
+                    errorproperty: "error",
+                    resultproperty: "exitValue",
                     executable: "${executableDir}/${NpmRun.getNpmCommand()}",
                     dir: getMinificationWorkingDir(xmlFile)
                 )
@@ -293,6 +296,9 @@ class ClientLibsCompress extends DefaultTask
                                 value: "${executableDir}${File.pathSeparator}${System.getenv("PATH")}"
                         )
                     }
+                project.logger.quiet("${project.path} ${xmlFile} ant text ${project.ant.project.properties.text}")
+                project.logger.quiet("${project.path} ${xmlFile} ant error ${project.ant.project.properties.error}")
+                project.logger.quiet("${project.path} ${xmlFile} ant exitValue ${project.ant.project.properties.exitValue}")
                 project.logger.quiet("DONE Compressing css files as ${minFiles.right}")
                 compressFile(minFiles.right)
             }

--- a/src/main/groovy/org/labkey/gradle/task/ClientLibsCompress.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ClientLibsCompress.groovy
@@ -279,14 +279,8 @@ class ClientLibsCompress extends DefaultTask
                     "    \"minify-css\": \"postcss ${allCssFile.getAbsolutePath()} --ext min.css --dir ${workingDir.getAbsolutePath()}\""
             )
         }
-        buffer.append("\n")
         buffer.append(
-                "  },\n" +
-                "  \"devDependencies\": {\n" +
-                "    \"cssnano\": \"^${project.cssnanoVersion}\",\n" +
-                "    \"postcss\": \"^${project.postcssVersion}\",\n" +
-                "    \"postcss-cli\": \"^${project.postcssCliVersion}\",\n" +
-                "    \"terser\": \"^${project.terserVersion}\"\n" +
+                "\n" +
                 "  }\n" +
                 "}")
         PrintWriter writer = null

--- a/src/main/groovy/org/labkey/gradle/task/ClientLibsCompress.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ClientLibsCompress.groovy
@@ -310,6 +310,11 @@ class ClientLibsCompress extends DefaultTask
         }
     }
 
+    static String escapeBackslashPaths(String path)
+    {
+        return path.replaceAll("\\\\", "\\\\\\\\")
+    }
+
     Pair<File, File> createPackageJson(File xmlFile, Set<File> jsFiles, File allCssFile)
     {
         File jsMinFile = null
@@ -318,7 +323,9 @@ class ClientLibsCompress extends DefaultTask
         File sourceDir = getSourceDir(xmlFile)
         File workingFile = new File(xmlFile.getAbsolutePath().replace(sourceDir.getAbsolutePath(), workingDir.getAbsolutePath()))
 
-        String jsFileNames = jsFiles.stream().map(jsFile -> jsFile.getAbsolutePath()).collect(Collectors.joining(" "))
+        String jsFileNames = jsFiles.stream().map(jsFile ->
+                escapeBackslashPaths(jsFile.getAbsolutePath()))
+                .collect(Collectors.joining(" "))
         File packageJson = new File(getMinificationWorkingDir(xmlFile), "package.json")
         project.logger.info("Creating ${packageJson} for ${xmlFile.getAbsolutePath()}")
         String sanitizedName = xmlFile.name.substring(0, xmlFile.name.length()-LIB_XML_EXTENSION.length())
@@ -334,7 +341,7 @@ class ClientLibsCompress extends DefaultTask
         if (!jsFiles.isEmpty()) {
             jsMinFile = getOutputFile(workingFile, "min", "js")
             buffer.append(
-                    "    \"minify-js\": \"terser ${jsFileNames} -o ${jsMinFile.getAbsolutePath()}\""
+                    "    \"minify-js\": \"terser ${jsFileNames} -o ${escapeBackslashPaths(jsMinFile.getAbsolutePath())}\""
             )
             comma = ",\n"
         }
@@ -342,7 +349,7 @@ class ClientLibsCompress extends DefaultTask
             cssMinFile = getOutputFile(workingFile, "min", "css")
             buffer.append(comma)
             buffer.append(
-                    "    \"minify-css\": \"postcss ${allCssFile.getAbsolutePath()} --ext min.css --dir ${cssMinFile.parentFile.getAbsolutePath()}\""
+                    "    \"minify-css\": \"postcss ${escapeBackslashPaths(allCssFile.getAbsolutePath())} --ext min.css --dir ${escapeBackslashPaths(cssMinFile.parentFile.getAbsolutePath())}\""
             )
         }
         buffer.append(

--- a/src/main/groovy/org/labkey/gradle/task/ClientLibsCompress.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ClientLibsCompress.groovy
@@ -213,7 +213,7 @@ class ClientLibsCompress extends DefaultTask
         }
         else
         {
-            this.logger.info("No compile necessary");
+            this.logger.info("No compile necessary for ${xmlFile}");
         }
     }
 
@@ -250,6 +250,7 @@ class ClientLibsCompress extends DefaultTask
             File cssFile = concatenateCssFiles(xmlFile, importer.cssFiles)
             Pair<File, File> minFiles = createPackageJson(xmlFile, importer.javascriptFiles, cssFile)
             if (importer.hasJavascriptFiles()) {
+                project.logger.info("Compressing Javascript files for ${xmlFile}")
                 project.ant.exec(
                     executable: getNpmCommand(),
                     dir: getMinificationWorkingDir(xmlFile)
@@ -260,6 +261,7 @@ class ClientLibsCompress extends DefaultTask
                 compressFile(minFiles.left)
             }
             if (importer.hasCssFiles()) {
+                project.logger.info("Compressing css files for ${xmlFile}")
                 project.ant.exec(
                     executable: getNpmCommand(),
                     dir: getMinificationWorkingDir(xmlFile)
@@ -274,7 +276,6 @@ class ClientLibsCompress extends DefaultTask
 
     Pair<File, File> createPackageJson(File xmlFile, Set<File> jsFiles, File allCssFile)
     {
-        project.logger.quiet("Creating package.json file for ${xmlFile.getAbsolutePath()}")
         File jsMinFile = null
         File cssMinFile = null
 
@@ -283,6 +284,7 @@ class ClientLibsCompress extends DefaultTask
 
         String jsFileNames = jsFiles.stream().map(jsFile -> jsFile.getAbsolutePath()).collect(Collectors.joining(" "))
         File packageJson = new File(getMinificationWorkingDir(xmlFile), "package.json")
+        project.logger.info("Creating ${packageJson} for ${xmlFile.getAbsolutePath()}")
         String sanitizedName = xmlFile.name.substring(0, xmlFile.name.length()-LIB_XML_EXTENSION.length())
         packageJson.createNewFile()
         StringBuffer buffer = new StringBuffer("")

--- a/src/main/groovy/org/labkey/gradle/task/ClientLibsCompress.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ClientLibsCompress.groovy
@@ -267,6 +267,9 @@ class ClientLibsCompress extends DefaultTask
                     throw new GradleException("Could not find expected files in ${BuildUtils.getMinificationProjectPath(project.gradle)} project")
                 project.logger.quiet("Compressing Javascript files for ${xmlFile} with ${executableDir} in ${getMinificationWorkingDir(xmlFile)}")
                 project.ant.exec(
+                    outputproperty:"text",
+                    errorproperty: "error",
+                    resultproperty: "exitValue",
                     executable: "${executableDir}/${NpmRun.getNpmCommand()}",
                     dir: getMinificationWorkingDir(xmlFile)
                 )
@@ -277,6 +280,12 @@ class ClientLibsCompress extends DefaultTask
                                 value: "${executableDir}${File.pathSeparator}${System.getenv("PATH")}"
                         )
                     }
+                project.logger.quiet("${project.path} ${xmlFile} ant text ${project.ant.project.properties.text}")
+                project.logger.quiet("${project.path} ${xmlFile} ant error ${project.ant.project.properties.error}")
+                project.logger.quiet("${project.path} ${xmlFile} ant exitValue ${project.ant.project.properties.exitValue}")
+                if (project.ant.project.properties.exitValue != '0')
+                    throw new GradleException("Error compressing Javascript files for ${xmlFile}.\n Output: ${project.ant.project.properties.text}.\n Error: ${project.ant.project.properties.text} ")
+
                 project.logger.quiet("DONE Compressing Javascript files as ${minFiles.left}")
                 compressFile(minFiles.left)
             }
@@ -296,9 +305,12 @@ class ClientLibsCompress extends DefaultTask
                                 value: "${executableDir}${File.pathSeparator}${System.getenv("PATH")}"
                         )
                     }
+
                 project.logger.quiet("${project.path} ${xmlFile} ant text ${project.ant.project.properties.text}")
                 project.logger.quiet("${project.path} ${xmlFile} ant error ${project.ant.project.properties.error}")
                 project.logger.quiet("${project.path} ${xmlFile} ant exitValue ${project.ant.project.properties.exitValue}")
+                if (project.ant.project.properties.exitValue != '0')
+                    throw new GradleException("Error compressing css files for ${xmlFile}.\n Output: ${project.ant.project.properties.text}.\n Error: ${project.ant.project.properties.text} ")
                 project.logger.quiet("DONE Compressing css files as ${minFiles.right}")
                 compressFile(minFiles.right)
             }

--- a/src/main/groovy/org/labkey/gradle/task/ClientLibsCompress.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ClientLibsCompress.groovy
@@ -248,7 +248,7 @@ class ClientLibsCompress extends DefaultTask
         if (importer.hasFilesToCompress()) {
             File cssFile = concatenateCssFiles(xmlFile, importer.cssFiles)
             Pair<File, File> minFiles = createPackageJson(xmlFile, importer.javascriptFiles, cssFile)
-            if (!importer.hasJavascriptFiles()) {
+            if (importer.hasJavascriptFiles()) {
                 project.ant.exec(
                     executable: getNpmCommand(),
                     dir: getMinificationWorkingDir(xmlFile)

--- a/src/main/groovy/org/labkey/gradle/task/PurgeNpmAlphaVersions.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/PurgeNpmAlphaVersions.groovy
@@ -11,6 +11,7 @@ import org.apache.http.impl.client.HttpClients
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.tasks.TaskAction
+import org.labkey.gradle.plugin.NpmRun
 
 import java.util.stream.Collectors
 
@@ -65,8 +66,7 @@ class PurgeNpmAlphaVersions extends DefaultTask
 
     private static List<String> getNpmAlphaVersions(String packageName, String alphaPrefix)
     {
-        String npmCmd = SystemUtils.IS_OS_WINDOWS ? "npm.cmd" : "npm"
-        String output = (npmCmd + " view ${packageName} versions --json").execute().text
+        String output = (NpmRun.getNpmCommand() + " view ${packageName} versions --json").execute().text
         if (!StringUtils.isEmpty(output)) {
             def parsedJson = new JsonSlurper().parseText(output)
             if (parsedJson instanceof ArrayList) {

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -301,6 +301,11 @@ class BuildUtils
         return getProjectPath(gradle, "embeddedProjectPath", ":server:embedded")
     }
 
+    static String getMinificationProjectPath(Gradle gradle)
+    {
+        return getProjectPath(gradle, "minificationProjectPath", ":server:minification")
+    }
+
     static String getApiProjectPath(Gradle gradle)
     {
         return getProjectPath(gradle, "apiProjectPath", ":server:modules:platform:api")

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -103,7 +103,7 @@ class BuildUtils
                 getPlatformModuleProjectPath(gradle, "filecontent"),
                 getPlatformModuleProjectPath(gradle, "pipeline"),
                 getPlatformModuleProjectPath(gradle, "query"),
-                getMinificationProjectPath(gradle) // required for building
+                getMinificationProjectPath(gradle) // required for building using npm for lib.xml files compression
         ]
     }
 

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -102,7 +102,8 @@ class BuildUtils
                 getPlatformModuleProjectPath(gradle, "experiment"),
                 getPlatformModuleProjectPath(gradle, "filecontent"),
                 getPlatformModuleProjectPath(gradle, "pipeline"),
-                getPlatformModuleProjectPath(gradle, "query")
+                getPlatformModuleProjectPath(gradle, "query"),
+                getMinificationProjectPath(gradle) // required for building
         ]
     }
 


### PR DESCRIPTION
#### Rationale
From [Issue 43245](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43245): For a long time now we've used YUI Compressor v2.4.8 (released 7/2/2013) to minify our JS and stylesheet assets declared in any LabKey `lib.xml` files. Over time this package has really started to show its age as it is falling further and further behind what modern browsers support. Often times this comes up as errors in our production build as a difficult to track down error when someone uses a valid browser supported JS/CSS syntax that YUI does not support.

The modern options for minification are available from client-side build technologies. One approach we might take is to simply require that modules with lib.xml files create package.json files that do the desired compression. I think this is not unreasonable as these files are generally not very volatile, but by continuing to do this automatically we can save some build time (installing the required `node_modules` only once) and not require that folks remember to update their package.json files when the lib.xml files are updated. 

The approach taken is as follows:
- There is a new Gradle project directory in the server build (`:server:minification`). This project contains a `package.json` file configured with the `devDependencies` required for doing the minification and the required `postcss.config.js` file that applies the `cssnano` plugin.  We could also locate a config file for `terser` here if the default doesn't do all we want it to.
- We apply the NpmRun plugin in`:server:minification` so we can use the npm executable that is installed by that plugin for executing the build scripts and we can install the node modules in this one directory for use in all subdirectories.  
- For each `lib.xml` file we find that references css or javascript files to be minified we create a directory under `server/minification/modules/<moduleName>` using the base name of the `lib.xml` file (e.g., `server/minification/modules/study/progress-report`). In this directory, we generate a `package.json` file with `minify-js` and/or `minify-css` scripts. The scripts reference the absolute paths of the input files and deposit the output files in the same directories we use for YuiCompression 
- The npm scripts are run for each directory

At the moment, you turn on the use of the minification via npm by adding the `useNpmMinifier` property to a project. It remains to be determined whether we need to retain the ability to fall back on the YuiCompressor, but before release of this version I will likely at least make the npm minifier the default and require a property such as `useYuiCompessor` to activate the other path. If we need to support the use of `lib.xml` files in standalone module builds, it will probably be easiest to retain the ability to use the YuiCompressor. However, my preference would be to guide people making standalone modules to set up a `package.json` file that does the require minification and doesn't rely on this special logic at all.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/379

#### Changes
* Update `ClientLibsCompress` task with option to use npm packages instead of the ancient YuiCompressor
  * Use [terser](https://github.com/terser/terser) for javascript minification 
  * Use [cssnano](https://cssnano.co/) via [postcss](https://github.com/postcss/postcss) for css minification
