### PR TITLE
Update getRemoteApiProjectPath() to match labkey-api-java layout refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### 1.39.0-refactor-SNAPSHOT
+*Released*: TBD
+(Earliest compatible LabKey version: 22.9)
+* Update getRemoteApiProjectPath() to match `labeky-api-java` layout refactor
+* Upgrade a few dependencies
+
 ### 1.38.0
 *Released*: 9 January 2023
 (Earliest compatible LabKey version: 22.9)
@@ -26,7 +32,7 @@ _Note: 1.28.0 and later require Gradle 7_
 ### 1.37.1
 *Released*: 9 December 2022
 (Earliest compatible LabKey version: 22.9)
-* Update pacakge names for PurgeNpmAlphaVersions task to include @labkey/premium
+* Update package names for PurgeNpmAlphaVersions task to include @labkey/premium
 
 ### 1.37.0
 *Released*: 8 December 2022

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ _Note: 1.28.0 and later require Gradle 7_
 ### 1.39.0-refactor-SNAPSHOT
 *Released*: TBD
 (Earliest compatible LabKey version: 22.9)
-* Update getRemoteApiProjectPath() to match `labeky-api-java` layout refactor
+* Update getRemoteApiProjectPath() to match `labkey-api-java` layout refactor
 * Upgrade a few dependencies
 
 ### 1.38.0

--- a/README.md
+++ b/README.md
@@ -15,8 +15,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
-### 1.39.0-refactor-SNAPSHOT
+### 1.40.0-SNAPSHOT
 *Released*: TBD
+
+### 1.39.0
+*Released*: 10 January 2023
 (Earliest compatible LabKey version: 22.9)
 * Update getRemoteApiProjectPath() to match `labkey-api-java` layout refactor
 * Upgrade a few dependencies

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.39.0-SNAPSHOT"
+project.version = "1.39.0-refactor-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.39.0-refactor-SNAPSHOT"
+project.version = "1.40.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,13 +4,13 @@ artifactoryPluginVersion=4.28.2
 
 commonsIoVersion=2.11.0
 commonsLang3Version=3.12.0
-commonsTextVersion=1.9
+commonsTextVersion=1.10.0
 
 grgitGradleVersion=5.0.0
 graphqlJavaVersion=18.1
 
-httpclientVersion=4.5.13
-httpcoreVersion=4.4.15
+httpclientVersion=4.5.14
+httpcoreVersion=4.4.16
 
 jacksonVersion=2.13.3
 jsonVersion=20220320

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -329,7 +329,7 @@ class BuildUtils
 
     static String getRemoteApiProjectPath(Gradle gradle)
     {
-        return getProjectPath(gradle, "remoteApiProjectPath", ":remoteapi:labkey-api-java:labkey-client-api")
+        return getProjectPath(gradle, "remoteApiProjectPath", ":remoteapi:labkey-api-java")
     }
 
     static String getSasApiProjectPath(Gradle gradle)


### PR DESCRIPTION
#### Rationale
Layout change requires a new plugin version

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-java/pull/45
