### PR TITLE
Correctly disable `npm` minifier if minification project is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ _Note: 1.28.0 and later require Gradle 7_
 
 ### 1.40.0-SNAPSHOT
 *Released*: TBD
+(Earliest compatible LabKey version: 22.9)
+* Correctly disable `npm` minifier if minification project is missing
 
 ### 1.39.0
 *Released*: 10 January 2023

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
-### 1.40.0-SNAPSHOT
-*Released*: TBD
+### 1.39.1
+*Released*: 11 January 2023
 (Earliest compatible LabKey version: 22.9)
 * Correctly disable `npm` minifier if minification project is missing
 

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.40.0-SNAPSHOT"
+project.version = "1.40.0-standaloneMinify-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.40.0-standaloneMinify-SNAPSHOT"
+project.version = "1.40.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/plugin/ClientLibraries.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ClientLibraries.groovy
@@ -42,7 +42,8 @@ class ClientLibraries
 
     static boolean useNpmMinifier(Project project)
     {
-        return !project.hasProperty("useYuiCompressor") && project.findProject(BuildUtils.getMinificationProjectPath(project.gradle)) != null
+        def minificationProject = project.findProject(BuildUtils.getMinificationProjectPath(project.gradle))
+        return !project.hasProperty("useYuiCompressor") && minificationProject != null && minificationProject.projectDir.exists()
     }
 
     static void addTasks(Project project)

--- a/src/main/groovy/org/labkey/gradle/plugin/ClientLibraries.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ClientLibraries.groovy
@@ -42,7 +42,7 @@ class ClientLibraries
 
     static boolean useNpmMinifier(Project project)
     {
-        return !project.hasProperty("useYuiCompressor") && project.project(BuildUtils.getMinificationProjectPath(project.gradle)).projectDir.exists()
+        return !project.hasProperty("useYuiCompressor") && project.findProject(BuildUtils.getMinificationProjectPath(project.gradle)) != null
     }
 
     static void addTasks(Project project)


### PR DESCRIPTION
#### Rationale
`project.project()` throws an exception if the project isn't defined. Need to check for project definition as well as the directory.

#### Related Pull Requests
* #162 

#### Changes
* Correctly disable `npm` minifier if minification project is missing
