### PR TITLE
Allow customizing database name on TeamCity

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### 1.40.0
+*Released*: TBD
+(Earliest compatible LabKey version: 22.9)
+* Allow customizing database name on TeamCity
+
 ### 1.39.1
 *Released*: 11 January 2023
 (Earliest compatible LabKey version: 22.9)

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.40.0-SNAPSHOT"
+project.version = "1.40.0-dockerPG-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.40.0-dockerPG-SNAPSHOT"
+project.version = "1.40.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/TeamCityExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/TeamCityExtension.groovy
@@ -61,7 +61,12 @@ class TeamCityExtension
 
     private void setDatabaseProperties()
     {
-        if ((Boolean) getTeamCityProperty("build.is.personal", false))
+        if (!getTeamCityProperty('database.name').isEmpty())
+        {
+            this.databaseName = getTeamCityProperty('database.name')
+            this.dropDatabase = getTeamCityProperty('drop.database', true)
+        }
+        else if ((Boolean) getTeamCityProperty("build.is.personal", false))
         {
             this.databaseName = "LabKey_PersonalBuild"
             this.dropDatabase = true


### PR DESCRIPTION
#### Rationale
It will be useful to be able to specify a database name on TeamCity.

#### Related Pull Requests
* N/A

#### Changes
* Allow customizing the database name via `system.database.name` on TeamCity
