### PR TITLE
Remove internal module, yuicompressor and other obsolete references

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ _Note: 1.28.0 and later require Gradle 7_
 (Earliest compatible LabKey version: 23.3)
 * Remove packages that are no longer published from `PurgeNpmAlphaVeresions` consideration
 * Remove references to internal module and adjust dependency declarations accordingly
+* Remove obsolete reference to labkey-api-sas project
 * Remove option for using yui compressor
 
 ### 1.39.1

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
-### TBD
-*Released*: TBD
+### 1.40.0
+*Released*: 8 February 2023
 (Earliest compatible LabKey version: 23.3)
 * Remove packages that are no longer published from `PurgeNpmAlphaVeresions` consideration
 * Remove references to internal module and adjust dependency declarations accordingly

--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### TBD
+*Released*: TBD
+(Earliest compatible LabKey version: 23.3)
+* Remove packages that are no longer published from `PurgeNpmAlphaVeresions` consideration
+* Remove references to internal module and adjust dependency declarations accordingly
+* Remove option for using yui compressor
+
 ### 1.39.1
 *Released*: 11 January 2023
 (Earliest compatible LabKey version: 22.9)

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.40.0-removeInternal-SNAPSHOT"
+project.version = "1.41.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,6 @@ dependencies {
     api "org.apache.commons:commons-lang3:${commonsLang3Version}"
     api "org.apache.commons:commons-text:${commonsTextVersion}"
     api "commons-io:commons-io:${commonsIoVersion}"
-    api "com.yahoo.platform.yui:yuicompressor:${yuiCompressorVersion}"
     api "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
     implementation "org.apache.httpcomponents:httpcore:${httpcoreVersion}"
     api "org.apache.httpcomponents:httpclient:${httpclientVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.40.0-SNAPSHOT"
+project.version = "1.40.0-removeInternal-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,8 +14,3 @@ httpcoreVersion=4.4.16
 
 jacksonVersion=2.13.3
 jsonVersion=20220320
-
-# Version 2.4.8a is a custom-built version of YUICompressor.
-# Note that 2.4.8 fails with absolute paths on Windows, https://github.com/yui/yuicompressor/issues/78,
-# but the issue is fixed on yuicompressor current master.
-yuiCompressorVersion=2.4.8a

--- a/src/main/groovy/org/labkey/gradle/plugin/Api.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Api.groovy
@@ -74,7 +74,6 @@ class Api implements Plugin<Project>
         project.dependencies
                 {
                     BuildUtils.addLabKeyDependency(project: project, config: 'apiImplementation', depProjectPath: BuildUtils.getApiProjectPath(project.gradle), depVersion: project.labkeyVersion)
-                    BuildUtils.addLabKeyDependency(project: project, config: 'apiImplementation', depProjectPath: BuildUtils.getInternalProjectPath(project.gradle), depVersion: project.labkeyVersion)
                     BuildUtils.addLabKeyDependency(project: project, config: "apiImplementation", depProjectPath: BuildUtils.getRemoteApiProjectPath(project.gradle), depVersion: BuildUtils.getLabKeyClientApiVersion(project))
                 }
     }

--- a/src/main/groovy/org/labkey/gradle/plugin/ClientLibraries.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ClientLibraries.groovy
@@ -40,12 +40,6 @@ class ClientLibraries
         )
     }
 
-    static boolean useNpmMinifier(Project project)
-    {
-        def minificationProject = project.findProject(BuildUtils.getMinificationProjectPath(project.gradle))
-        return !project.hasProperty("useYuiCompressor") && minificationProject != null && minificationProject.projectDir.exists()
-    }
-
     static void addTasks(Project project)
     {
         String minProjectPath = BuildUtils.getMinificationProjectPath(project.gradle)
@@ -54,26 +48,24 @@ class ClientLibraries
                 task.group = GroupNames.CLIENT_LIBRARIES
                 task.description = 'create minified, compressed javascript file using .lib.xml sources'
                 task.dependsOn ( project.tasks.processResources )
-                if (useNpmMinifier(project))
-                    task.dependsOn(project.project(minProjectPath).tasks.findByName("npmInstall"))
+                task.dependsOn(project.project(minProjectPath).tasks.findByName("npmInstall"))
                 task.xmlFiles = getLibXmlFiles(project)
         }
-        if (useNpmMinifier(project))
-            project.evaluationDependsOn(minProjectPath)
+
+        project.evaluationDependsOn(minProjectPath)
         project.tasks.assemble.dependsOn(project.tasks.compressClientLibs)
 
-        if (useNpmMinifier(project)) {
-            project.tasks.register("cleanClientLibs", Delete) {
-                Delete task ->
-                    task.group = GroupNames.CLIENT_LIBRARIES
-                    task.description = "Removes ${ClientLibsCompress.getMinificationDir(project)}"
-                    task.configure({ DeleteSpec delete ->
-                        if (ClientLibsCompress.getMinificationDir(project).exists())
-                            delete.delete(ClientLibsCompress.getMinificationDir(project))
-                        delete.delete(project.tasks.findByName("compressClientLibs").outputs.files)
-                    })
-            }
+        project.tasks.register("cleanClientLibs", Delete) {
+            Delete task ->
+                task.group = GroupNames.CLIENT_LIBRARIES
+                task.description = "Removes ${ClientLibsCompress.getMinificationDir(project)}"
+                task.configure({ DeleteSpec delete ->
+                    if (ClientLibsCompress.getMinificationDir(project).exists())
+                        delete.delete(ClientLibsCompress.getMinificationDir(project))
+                    delete.delete(project.tasks.findByName("compressClientLibs").outputs.files)
+                })
         }
+
     }
 }
 

--- a/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
@@ -214,8 +214,7 @@ class FileModule implements Plugin<Project>
                 moduleFile.dependsOn(project.tasks.named('compressClientLibs'))
             project.tasks.build.dependsOn(moduleFile)
             project.tasks.clean.dependsOn(project.tasks.named('cleanModule'))
-            if (ClientLibraries.useNpmMinifier(project))
-                project.tasks.clean.dependsOn(project.tasks.named('cleanClientLibs'))
+            project.tasks.clean.dependsOn(project.tasks.named('cleanClientLibs'))
 
             project.artifacts
                     {

--- a/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
@@ -427,8 +427,7 @@ class FileModule implements Plugin<Project>
 
                             }
                         }
-                        else if (project.path.equals(BuildUtils.getApiProjectPath(project.gradle))
-                                || project.path.equals(BuildUtils.getInternalProjectPath(project.gradle)))
+                        else if (project.path.equals(BuildUtils.getApiProjectPath(project.gradle)))
                         {
                             Properties pomProperties = LabKeyExtension.getApiPomProperties(project)
 
@@ -468,8 +467,7 @@ class FileModule implements Plugin<Project>
                             {
                                 dependsOn project.tasks.apiJar
                             }
-                            else if (project.path.equals(BuildUtils.getApiProjectPath(project.gradle))
-                                    || project.path.equals(BuildUtils.getInternalProjectPath(project.gradle)))
+                            else if (project.path.equals(BuildUtils.getApiProjectPath(project.gradle)))
                             {
                                 dependsOn project.tasks.jar
                             }

--- a/src/main/groovy/org/labkey/gradle/plugin/Jsp.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Jsp.groovy
@@ -98,7 +98,7 @@ class Jsp implements Plugin<Project>
         project.dependencies
                 {
                     BuildUtils.addLabKeyDependency(project: project, config: "jspImplementation", depProjectPath: BuildUtils.getApiProjectPath(project.gradle), depVersion: project.labkeyVersion)
-                    BuildUtils.addLabKeyDependency(project: project, config: "jspImplementation", depProjectPath: BuildUtils.getInternalProjectPath(project.gradle), depVersion: project.labkeyVersion)
+                    BuildUtils.addLabKeyDependency(project: project, config: "jspImplementation", depProjectPath: BuildUtils.getRemoteApiProjectPath(project.gradle), depVersion: BuildUtils.getLabKeyClientApiVersion(project))
                     BuildUtils.addLabKeyDependency(project: project, config: "jspTagLibs", depProjectPath: BuildUtils.getApiProjectPath(project.gradle), depVersion: project.labkeyVersion, depExtension: 'module', transitive: false)
                     jspImplementation project.files(project.tasks.jar)
                     if (project.hasProperty('apiJar'))

--- a/src/main/groovy/org/labkey/gradle/plugin/Module.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Module.groovy
@@ -44,7 +44,7 @@ class Module implements Plugin<Project> {
                 {
                     BuildUtils.addTomcatBuildDependencies(project, 'implementation')
 
-                    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: BuildUtils.getInternalProjectPath(project.gradle), depVersion: project.labkeyVersion)
+                    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: BuildUtils.getApiProjectPath(project.gradle), depVersion: project.labkeyVersion)
                     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: BuildUtils.getRemoteApiProjectPath(project.gradle), depVersion: BuildUtils.getLabKeyClientApiVersion(project))
                     if (BuildUtils.isBaseModule(project) && !BuildUtils.isApi(project) && project.findProject(BuildUtils.getApiProjectPath(project.gradle)))
                     {

--- a/src/main/groovy/org/labkey/gradle/task/PurgeNpmAlphaVersions.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/PurgeNpmAlphaVersions.groovy
@@ -24,12 +24,9 @@ class PurgeNpmAlphaVersions extends DefaultTask
             '@labkey/assayreport',
             '@labkey/build',
             '@labkey/components',
-            '@labkey/eln',
-            '@labkey/freezermanager',
             '@labkey/premium',
             '@labkey/test',
-            '@labkey/themes',
-            '@labkey/workflow'
+            '@labkey/themes'
     ]
 
     @TaskAction

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -326,11 +326,6 @@ class BuildUtils
         return getProjectPath(gradle, "remoteApiProjectPath", ":remoteapi:labkey-api-java")
     }
 
-    static String getSasApiProjectPath(Gradle gradle)
-    {
-        return getProjectPath(gradle, "sasApiProjectPath", ":remoteapi:labkey-api-java:labkey-api-sas")
-    }
-
     static String getJdbcApiProjectPath(Gradle gradle)
     {
         return getProjectPath(gradle, "jdbcApiProjectPath", ":remoteapi:labkey-api-jdbc");

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -96,7 +96,6 @@ class BuildUtils
         return [
                 getApiProjectPath(gradle),
                 getBootstrapProjectPath(gradle),
-                getInternalProjectPath(gradle),
                 getPlatformModuleProjectPath(gradle, "audit"),
                 getPlatformModuleProjectPath(gradle, "core"),
                 getPlatformModuleProjectPath(gradle, "experiment"),
@@ -315,11 +314,6 @@ class BuildUtils
     static String getBootstrapProjectPath(Gradle gradle)
     {
         return getProjectPath(gradle, "bootstrapProjectPath", ":server:bootstrap")
-    }
-
-    static String getInternalProjectPath(Gradle gradle)
-    {
-        return getProjectPath(gradle, "internalProjectPath", ":server:modules:platform:internal")
     }
 
     static String getNodeBinProjectPath(Gradle gradle)


### PR DESCRIPTION
#### Rationale
The guts of the internal module were moved elsewhere with [platform PR #4015](https://github.com/LabKey/platform/pull/4015). Here we adjust our dependency declarations so we no longer rely on its build file to bring in either the api module or the labkey-client-api jar.   We also remove references to the internal project path, making this change not backward compatible with earlier versions of LabKey.

There are also some other cleanup changes included here, such as removing the option to use the outdated yuiCompressor.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/398
* https://github.com/LabKey/commonAssays/pull/576
* https://github.com/LabKey/cds/pull/557
* https://github.com/LabKey/platform/pull/4099
* https://github.com/LabKey/distributions/pull/364
* https://github.com/LabKey/wnprc-modules/pull/248

#### Changes
* Remove packages that are no longer published from `PurgeNpmAlphaVeresions` consideration
* Remove references to internal module and adjust dependency declarations accordingly
* Remove obsolete reference to labkey-api-sas project
* Remove option for using yui compressor