### PR TITLE
Include feature branch name in `patchApiModule` output

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### 1.40.1
+*Released*: TBD
+(Earliest compatible LabKey version: 23.3)
+* Include feature branch name in `patchApiModule` output
+  * [Issue 47370: Patched API module doesn't get named correctly on feature branches](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=47370)
+
 ### 1.40.0
 *Released*: 8 February 2023
 (Earliest compatible LabKey version: 23.3)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ on how to do that, including how to develop and test locally and the versioning 
 _Note: 1.28.0 and later require Gradle 7_
 
 ### 1.40.1
-*Released*: TBD
+*Released*: 27 March 2023
 (Earliest compatible LabKey version: 23.3)
 * Include feature branch name in `patchApiModule` output
   * [Issue 47370: Patched API module doesn't get named correctly on feature branches](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=47370)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ on how to do that, including how to develop and test locally and the versioning 
 _Note: 1.28.0 and later require Gradle 7_
 
 ### 1.40.1
-*Released*: 27 March 2023
+*Released*: 27 February 2023
 (Earliest compatible LabKey version: 23.3)
 * Include feature branch name in `patchApiModule` output
   * [Issue 47370: Patched API module doesn't get named correctly on feature branches](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=47370)

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.40.1-patchApiModuleName-SNAPSHOT"
+project.version = "1.41.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.41.0-SNAPSHOT"
+project.version = "1.40.1-patchApiModuleName-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/plugin/ApplyLicenses.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ApplyLicenses.groovy
@@ -89,7 +89,9 @@ class ApplyLicenses implements Plugin<Project>
                             "Implementation-Vendor": "LabKey"
                     )
                     if (project.findProject(BuildUtils.getApiProjectPath(project.gradle))) {
-                        jar.dependsOn(project.project(BuildUtils.getApiProjectPath(project.gradle)).tasks.findByName("module"))
+                        var apiProj = project.project(BuildUtils.getApiProjectPath(project.gradle))
+                        jar.dependsOn(apiProj.tasks.findByName("module"))
+                        jar.archiveVersion.set(apiProj.getVersion().toString())
                     }
             }
 


### PR DESCRIPTION
#### Rationale
[Secure Issue 47370: Patched API module doesn't get named correctly on feature branches](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=47370)

Installers built on a feature branch could include two copies of the API module; need to make sure the file names match to avoid this.

#### Related Pull Requests
* N/A

#### Changes
* Include feature branch name in `patchApiModule` output
