### PR TITLE
Issue 47465: Check for the presence of the minification project 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ on how to do that, including how to develop and test locally and the versioning 
 _Note: 1.28.0 and later require Gradle 7_
 
 ### 1.40.3
-*Released*: TBD
+*Released*: 15 March 2023
 (Earliest compatible LabKey version: 23.3)
 * [Issue 47465](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=47465): Check for the presence of the minification project before adding tasks related to it
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### 1.40.3
+*Released*: TBD
+(Earliest compatible LabKey version: 23.3)
+* [Issue 47465](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=47465): Check for the presence of the minification project before adding tasks related to it
+
 ### 1.40.2
 *Released*: 6 March 2023
 (Earliest compatible LabKey version: 23.3)

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.41.0-minifyProjectFix-SNAPSHOT"
+project.version = "1.41.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.41.0-SNAPSHOT"
+project.version = "1.41.0-minifyProjectFix-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/plugin/ClientLibraries.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ClientLibraries.groovy
@@ -42,8 +42,8 @@ class ClientLibraries
 
     static void addTasks(Project project)
     {
-        String minProjectPath = BuildUtils.getMinificationProjectPath(project.gradle)
-        if (project.findProject(minProjectPath) != null) {
+        if (BuildUtils.haveMinificationProject(project.gradle)) {
+            String minProjectPath = BuildUtils.getMinificationProjectPath(project.gradle)
             project.tasks.register("compressClientLibs", ClientLibsCompress) {
                 ClientLibsCompress task ->
                     task.group = GroupNames.CLIENT_LIBRARIES

--- a/src/main/groovy/org/labkey/gradle/plugin/ClientLibraries.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ClientLibraries.groovy
@@ -43,27 +43,29 @@ class ClientLibraries
     static void addTasks(Project project)
     {
         String minProjectPath = BuildUtils.getMinificationProjectPath(project.gradle)
-        project.tasks.register("compressClientLibs", ClientLibsCompress) {
-            ClientLibsCompress task ->
-                task.group = GroupNames.CLIENT_LIBRARIES
-                task.description = 'create minified, compressed javascript file using .lib.xml sources'
-                task.dependsOn ( project.tasks.processResources )
-                task.dependsOn(project.project(minProjectPath).tasks.named("npmInstall"))
-                task.xmlFiles = getLibXmlFiles(project)
-        }
+        if (project.findProject(minProjectPath) != null) {
+            project.tasks.register("compressClientLibs", ClientLibsCompress) {
+                ClientLibsCompress task ->
+                    task.group = GroupNames.CLIENT_LIBRARIES
+                    task.description = 'create minified, compressed javascript file using .lib.xml sources'
+                    task.dependsOn(project.tasks.processResources)
+                    task.dependsOn(project.project(minProjectPath).tasks.named("npmInstall"))
+                    task.xmlFiles = getLibXmlFiles(project)
+            }
 
-        project.evaluationDependsOn(minProjectPath)
-        project.tasks.assemble.dependsOn(project.tasks.compressClientLibs)
+            project.evaluationDependsOn(minProjectPath)
+            project.tasks.assemble.dependsOn(project.tasks.compressClientLibs)
 
-        project.tasks.register("cleanClientLibs", Delete) {
-            Delete task ->
-                task.group = GroupNames.CLIENT_LIBRARIES
-                task.description = "Removes ${ClientLibsCompress.getMinificationDir(project)}"
-                task.configure({ DeleteSpec delete ->
-                    if (ClientLibsCompress.getMinificationDir(project).exists())
-                        delete.delete(ClientLibsCompress.getMinificationDir(project))
-                    delete.delete(project.tasks.findByName("compressClientLibs").outputs.files)
-                })
+            project.tasks.register("cleanClientLibs", Delete) {
+                Delete task ->
+                    task.group = GroupNames.CLIENT_LIBRARIES
+                    task.description = "Removes ${ClientLibsCompress.getMinificationDir(project)}"
+                    task.configure({ DeleteSpec delete ->
+                        if (ClientLibsCompress.getMinificationDir(project).exists())
+                            delete.delete(ClientLibsCompress.getMinificationDir(project))
+                        delete.delete(project.tasks.findByName("compressClientLibs").outputs.files)
+                    })
+            }
         }
 
     }

--- a/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
@@ -207,7 +207,7 @@ class FileModule implements Plugin<Project>
 
             Task moduleFile = project.tasks.module
 
-            boolean haveMinifyProject = project.findProject(BuildUtils.getMinificationProjectPath(project.gradle)) != null
+            boolean haveMinifyProject = BuildUtils.haveMinificationProject(project.gradle)
 
             moduleFile.dependsOn(project.tasks.named('processResources'))
             moduleFile.dependsOn(moduleXmlTask)

--- a/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
@@ -214,7 +214,8 @@ class FileModule implements Plugin<Project>
                 moduleFile.dependsOn(project.tasks.named('compressClientLibs'))
             project.tasks.build.dependsOn(moduleFile)
             project.tasks.clean.dependsOn(project.tasks.named('cleanModule'))
-            project.tasks.clean.dependsOn(project.tasks.named('cleanClientLibs'))
+            if (project.findProject(BuildUtils.getMinificationProjectPath(project.gradle)) != null)
+                project.tasks.clean.dependsOn(project.tasks.named('cleanClientLibs'))
 
             project.artifacts
                     {

--- a/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
@@ -207,14 +207,16 @@ class FileModule implements Plugin<Project>
 
             Task moduleFile = project.tasks.module
 
+            boolean haveMinifyProject = project.findProject(BuildUtils.getMinificationProjectPath(project.gradle)) != null
+
             moduleFile.dependsOn(project.tasks.named('processResources'))
             moduleFile.dependsOn(moduleXmlTask)
             setJarManifestAttributes(project, (Manifest) moduleFile.manifest)
-            if (!LabKeyExtension.isDevMode(project))
+            if (!LabKeyExtension.isDevMode(project) && haveMinifyProject)
                 moduleFile.dependsOn(project.tasks.named('compressClientLibs'))
             project.tasks.build.dependsOn(moduleFile)
             project.tasks.clean.dependsOn(project.tasks.named('cleanModule'))
-            if (project.findProject(BuildUtils.getMinificationProjectPath(project.gradle)) != null)
+            if (haveMinifyProject)
                 project.tasks.clean.dependsOn(project.tasks.named('cleanClientLibs'))
 
             project.artifacts

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -102,7 +102,6 @@ class BuildUtils
                 getPlatformModuleProjectPath(gradle, "filecontent"),
                 getPlatformModuleProjectPath(gradle, "pipeline"),
                 getPlatformModuleProjectPath(gradle, "query"),
-                getMinificationProjectPath(gradle) // required for building using npm for lib.xml files compression
         ]
     }
 
@@ -299,6 +298,11 @@ class BuildUtils
     static String getEmbeddedProjectPath(Gradle gradle)
     {
         return getProjectPath(gradle, "embeddedProjectPath", ":server:embedded")
+    }
+
+    static boolean haveMinificationProject(Gradle gradle)
+    {
+        return gradle.rootProject.project(getMinificationProjectPath(gradle)) != null
     }
 
     static String getMinificationProjectPath(Gradle gradle)


### PR DESCRIPTION
#### Rationale
The switch to using npm instead of yui-compressor for our npm and css minification introduced the :server:minification project that is used to do the work of minification. For a standalone build, this project won't exist. It is assumed standalone builds will do their own minification, if necessary, and likely won't have `.lib.xml` files in any case, so we simply won't try to add the tasks related to minification if the required project is not available.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/417
* https://github.com/LabKey/tutorialModules/pull/113

#### Changes
* Add checks for the minification project before adding tasks and dependencies that rely on it.
