### PR TITLE
Fix check for minification project

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### 1.40.4
+*Released*: TBD
+(Earliest compatible LabKey version: 23.3)
+* Fix check for minification project
+
 ### 1.40.3
 *Released*: 15 March 2023
 (Earliest compatible LabKey version: 23.3)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ on how to do that, including how to develop and test locally and the versioning 
 _Note: 1.28.0 and later require Gradle 7_
 
 ### 1.40.4
-*Released*: TBD
+*Released*: 21 March 2023
 (Earliest compatible LabKey version: 23.3)
 * Fix check for minification project
 

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.40.4-findMinification-SNAPSHOT"
+project.version = "1.41.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.41.0-SNAPSHOT"
+project.version = "1.40.3-findMinification-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.40.3-findMinification-SNAPSHOT"
+project.version = "1.40.4-findMinification-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -302,7 +302,7 @@ class BuildUtils
 
     static boolean haveMinificationProject(Gradle gradle)
     {
-        return gradle.rootProject.project(getMinificationProjectPath(gradle)) != null
+        return gradle.rootProject.findProject(getMinificationProjectPath(gradle)) != null
     }
 
     static String getMinificationProjectPath(Gradle gradle)


### PR DESCRIPTION
#### Rationale
Need to use `findProject` to check whether a project exists; `project` will throw an exception if it doesn't.
```
org.gradle.api.UnknownProjectException: Project with path ':server:minification' could not be found in root project 'Response'.
       at org.gradle.api.internal.project.DefaultProject.project(DefaultProject.java:664)
       at org.gradle.api.internal.project.DefaultProject.project(DefaultProject.java:657)
       at org.gradle.api.internal.project.ProjectInternal$project$2.call(Unknown Source)
       at org.labkey.gradle.util.BuildUtils.haveMinificationProject(BuildUtils.groovy:305)
       at org.labkey.gradle.util.BuildUtils$haveMinificationProject$7.call(Unknown Source)
       at org.labkey.gradle.plugin.ClientLibraries.addTasks(ClientLibraries.groovy:45)
       at org.labkey.gradle.plugin.ClientLibraries$addTasks.call(Unknown Source)
       at org.labkey.gradle.plugin.FileModule.applyPlugins(FileModule.groovy:116)
```

#### Related Pull Requests
* #169 

#### Changes
* use `findProject` to check for minification project
