### PR TITLE
Avoid more unnecessary task configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ on how to do that, including how to develop and test locally and the versioning 
 _Note: 1.28.0 and later require Gradle 7_
 
 ### 1.40.5
-*Released*: TBD
+*Released*: 23 March 2023
 (Earliest compatible LabKey version: 23.3)
 * Improve performance of Gradle task configuration
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### 1.40.5
+*Released*: TBD
+(Earliest compatible LabKey version: 23.3)
+* Improve performance of Gradle task configuration
+
 ### 1.40.4
 *Released*: 21 March 2023
 (Earliest compatible LabKey version: 23.3)

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.41.0-SNAPSHOT"
+project.version = "1.41.0-moreAvoidance-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.41.0-moreAvoidance-SNAPSHOT"
+project.version = "1.41.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/plugin/ClientLibraries.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ClientLibraries.groovy
@@ -54,7 +54,7 @@ class ClientLibraries
             }
 
             project.evaluationDependsOn(minProjectPath)
-            project.tasks.assemble.dependsOn(project.tasks.compressClientLibs)
+            project.tasks.named("assemble").configure {dependsOn(project.tasks.compressClientLibs)}
 
             project.tasks.register("cleanClientLibs", Delete) {
                 Delete task ->

--- a/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
@@ -136,9 +136,7 @@ class Distribution implements Plugin<Project>
     {
         // This block sets up the task dependencies for each configuration dependency.
         project.afterEvaluate {
-            if (project.hasProperty("distribution"))
-            {
-                Task distTask = project.tasks.distribution
+            TaskUtils.configureTaskIfPresent(project, 'distribution') { Task distTask ->
                 project.configurations.distribution.dependencies.each {
                     if (it instanceof DefaultProjectDependency)
                     {

--- a/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
@@ -166,13 +166,13 @@ class FileModule implements Plugin<Project>
                 }
 
                 if (project.file(ModuleExtension.MODULE_PROPERTIES_FILE).exists())
-                    tadk.inputs.file(project.file(ModuleExtension.MODULE_PROPERTIES_FILE))
+                    task.inputs.file(project.file(ModuleExtension.MODULE_PROPERTIES_FILE))
                 else
                     project.logger.info("${project.path} - ${ModuleExtension.MODULE_PROPERTIES_FILE} not found so not added as input to 'moduleXml'")
-                tadk.outputs.file(moduleXmlFile)
+                task.outputs.file(moduleXmlFile)
                 if (project.file("build.gradle").exists())
-                    tadk.inputs.file(project.file("build.gradle"))
-                tadk.outputs.cacheIf { false } // disable build caching. Has too many undeclared inputs.
+                    task.inputs.file(project.file("build.gradle"))
+                task.outputs.cacheIf { false } // disable build caching. Has too many undeclared inputs.
         }
 
         // This is added because Intellij started creating this "out" directory when you build through IntelliJ.

--- a/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
@@ -66,7 +66,7 @@ class FileModule implements Plugin<Project>
             project.apply plugin: 'org.labkey.build.base'
 
             project.extensions.create("lkModule", ModuleExtension, project)
-            addSourceSet()
+            addSourceSet(project)
             applyPlugins(project)
             addConfigurations(project)
             addTasks(project)
@@ -91,7 +91,7 @@ class FileModule implements Plugin<Project>
     }
 
 
-    private void addSourceSet()
+    private void addSourceSet(Project project)
     {
         ModuleResources.addSourceSet(project)
     }

--- a/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
@@ -66,7 +66,7 @@ class FileModule implements Plugin<Project>
             project.apply plugin: 'org.labkey.build.base'
 
             project.extensions.create("lkModule", ModuleExtension, project)
-            addSourceSet(project)
+            addSourceSet()
             applyPlugins(project)
             addConfigurations(project)
             addTasks(project)
@@ -91,7 +91,7 @@ class FileModule implements Plugin<Project>
     }
 
 
-    private void addSourceSet(Project project)
+    private void addSourceSet()
     {
         ModuleResources.addSourceSet(project)
     }
@@ -178,7 +178,7 @@ class FileModule implements Plugin<Project>
         // This is added because Intellij started creating this "out" directory when you build through IntelliJ.
         // It copies files there that are actually input files to the build, which causes some problems when later
         // builds attempt to find their input files.
-        project.tasks.create("cleanOut", Delete) {
+        project.tasks.register("cleanOut", Delete) {
             Delete task ->
                 task.group = GroupNames.BUILD
                 task.description = "removes the ${project.file('out')} directory created by Intellij builds"

--- a/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
@@ -221,7 +221,7 @@ class FileModule implements Plugin<Project>
 
             project.artifacts
                     {
-                        // TODO: Figure out how to
+                        // TODO: Figure out how to add this artifact without resolving 'module' task
                         published moduleTask.get()
                     }
 

--- a/src/main/groovy/org/labkey/gradle/plugin/Gwt.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Gwt.groovy
@@ -167,7 +167,7 @@ class Gwt implements Plugin<Project>
                 copy.group = GroupNames.GWT
         }
 
-        project.tasks.classes.dependsOn(project.tasks.compileGwt)
+        project.tasks.named("classes").configure {dependsOn(project.tasks.compileGwt)}
     }
 
     private static Map<String, String> getGwtModuleClasses(Project project)

--- a/src/main/groovy/org/labkey/gradle/plugin/Jsp.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Jsp.groovy
@@ -86,7 +86,7 @@ class Jsp implements Plugin<Project>
                     jsp
                     jspTagLibs
                 }
-        project.configurations.getByName('jspImplementation') {
+        project.configurations.named('jspImplementation') {
             resolutionStrategy {
                 force "javax.servlet:javax.servlet-api:${project.servletApiVersion}"
             }

--- a/src/main/groovy/org/labkey/gradle/plugin/Jsp.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Jsp.groovy
@@ -185,7 +185,7 @@ class Jsp implements Plugin<Project>
                task.dependsOn('jar')
         }
 
-        project.tasks.compileJspJava {
+        project.tasks.named('compileJspJava').configure {
             Task task ->
                 task.dependsOn project.tasks.jsp2Java
                 task.outputs.cacheIf({true} )

--- a/src/main/groovy/org/labkey/gradle/plugin/ModuleResources.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ModuleResources.groovy
@@ -34,9 +34,9 @@ class ModuleResources
                 task.description = "write a list of direct external dependencies that should be checked on the credits page"
         }
 
-        project.tasks.processModuleResources.dependsOn(project.tasks.writeDependenciesList)
-        project.tasks.processResources.dependsOn(project.tasks.processModuleResources)
-        project.tasks.clean.dependsOn(project.tasks.cleanWriteDependenciesList)
+        project.tasks.named("processModuleResources").configure {dependsOn(project.tasks.named('writeDependenciesList'))}
+        project.tasks.named("processResources").configure {dependsOn(project.tasks.named('processModuleResources'))}
+        project.tasks.clean {dependsOn(project.tasks.named('cleanWriteDependenciesList'))}
     }
 
     static void addSourceSet(Project project)
@@ -53,9 +53,9 @@ class ModuleResources
                 }
         if (!LabKeyExtension.isDevMode(project))
         {
-            GzipAction zipAction = new GzipAction();
-            zipAction.extraExcludes = ["views/**"];
-            project.tasks.processModuleResources.doLast(zipAction);
+            GzipAction zipAction = new GzipAction()
+            zipAction.extraExcludes = ["views/**"]
+            project.tasks.named("processModuleResources").configure {doLast(zipAction)}
         }
     }
 }

--- a/src/main/groovy/org/labkey/gradle/plugin/TestRunner.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/TestRunner.groovy
@@ -208,7 +208,7 @@ class TestRunner extends UiTest
 
     private void addAspectJ(Project project)
     {
-        project.tasks.compileUiTestJava.doLast {
+        project.tasks.named('compileUiTestJava').configure {doLast {
             ant.taskdef(
                 resource: "org/aspectj/tools/ant/taskdefs/aspectjTaskdefs.properties",
                 classpath: project.configurations.aspectj.asPath
@@ -224,6 +224,6 @@ class TestRunner extends UiTest
                     }
                 }
             )
-        }
+        }}
     }
 }

--- a/src/main/groovy/org/labkey/gradle/plugin/Webapp.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Webapp.groovy
@@ -72,7 +72,7 @@ class Webapp implements Plugin<Project>
                     }
                 }
         if (!LabKeyExtension.isDevMode(project))
-            project.tasks.processWebappResources.doLast(new GzipAction())
-        project.tasks.processResources.dependsOn('processWebappResources')
+            project.tasks.named('processWebappResources').configure {doLast(new GzipAction())}
+        project.tasks.named('processResources').configure {dependsOn('processWebappResources')}
     }
 }

--- a/src/main/groovy/org/labkey/gradle/task/RunUiTest.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/RunUiTest.groovy
@@ -62,7 +62,7 @@ class RunUiTest extends Test
         ]
 
         if (project.hasProperty("uiTestJvmOpts"))
-            jvmArgsList.add(project.property("uiTestJvmOpts"))
+            jvmArgsList.add((String) project.property("uiTestJvmOpts"))
 
         TomcatExtension tomcat = project.extensions.findByType(TomcatExtension.class)
 

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -125,7 +125,7 @@ class BuildUtils
      */
     static void addBaseModuleDependencies(Project project)
     {
-        for (String path : BuildUtils.getBaseModules(project.gradle))
+        for (String path : getBaseModules(project.gradle))
         {
             if (path != getBootstrapProjectPath(project.gradle) && path != getRemoteApiProjectPath(project.gradle))
             {

--- a/src/main/groovy/org/labkey/gradle/util/ModuleFinder.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/ModuleFinder.groovy
@@ -76,7 +76,7 @@ class ModuleFinder extends SimpleFileVisitor<Path>
 
     static boolean isModuleContainer(Project p)
     {
-        return (p.findProperty("moduleContainer") && p.path.equalsIgnoreCase(p.property("moduleContainer")))
+        return (p.findProperty("moduleContainer") && p.path.equalsIgnoreCase((String) p.property("moduleContainer")))
     }
 
     static boolean isPotentialModule(Project p)


### PR DESCRIPTION
#### Rationale
Making the build a bit snappier with more task configuration avoidance.
Before | After:
![image](https://user-images.githubusercontent.com/5263798/226705530-795c8eea-5587-4685-8ace-be96009ff22a.png)

For future reference, `tasks.named('clean')` doesn't work for whatever reason.

#### Related Pull Requests
* N/A

#### Changes
* Replace `tasks.taskName` references with `tasks.named('taskName')`
