### PR TITLE
Remove custom configurations for jsp compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### TBD
+*Released*: TBD
+(Earliest compatible LabKey version: 23.3)
+* Remove use of reserved configuration name for JSPs
+
 ### 1.40.5
 *Released*: 23 March 2023
 (Earliest compatible LabKey version: 23.3)

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.41.0-jspConfigUpdates-SNAPSHOT"
+project.version = "1.41.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.41.0-SNAPSHOT"
+project.version = "1.41.0-jspConfigUpdates-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/plugin/Jsp.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Jsp.groovy
@@ -60,9 +60,9 @@ class Jsp implements Plugin<Project>
     {
         project.apply plugin: 'java-base'
 
+        addSourceSet(project)
         addConfiguration(project)
         addDependencies(project)
-        addSourceSet(project)
         addJspTasks(project)
     }
 
@@ -82,8 +82,6 @@ class Jsp implements Plugin<Project>
     {
         project.configurations
                 {
-                    jspImplementation
-                    jsp
                     jspTagLibs
                 }
         project.configurations.named('jspImplementation') {
@@ -104,13 +102,10 @@ class Jsp implements Plugin<Project>
                     if (project.hasProperty('apiJar'))
                         jspImplementation project.files(project.tasks.apiJar)
                     BuildUtils.addTomcatBuildDependencies(project, "jspImplementation")
-
-                    jsp ("org.apache.tomcat:tomcat-jasper:${project.apacheTomcatVersion}") { transitive = false }
-                    jsp ("org.apache.tomcat:tomcat-juli:${project.apacheTomcatVersion}") { transitive = false }
                 }
     }
 
-    private void addJspTasks(Project project)
+    private static void addJspTasks(Project project)
     {
         project.tasks.register('listJsps') {
             Task task ->
@@ -191,7 +186,7 @@ class Jsp implements Plugin<Project>
                 task.outputs.cacheIf({true} )
         }
 
-         project.tasks.register('jspJar', Jar) {
+        project.tasks.register('jspJar', Jar) {
              Jar jar ->
                  jar.group = GroupNames.JSP
                  jar.description = "produce jar file of jsps"
@@ -201,13 +196,10 @@ class Jsp implements Plugin<Project>
                  jar.outputs.cacheIf({true})
          }
 
-        project.artifacts {
-            jspImplementation project.tasks.jspJar
-        }
         project.tasks.assemble.dependsOn(project.tasks.jspJar)
     }
 
-    private TaskProvider getCopyTagLibs(Project project)
+    private static TaskProvider getCopyTagLibs(Project project)
     {
         return project.tasks.register("copyTagLibs", Copy) {
             Copy task ->

--- a/src/main/groovy/org/labkey/gradle/task/DeployAppBase.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DeployAppBase.groovy
@@ -26,7 +26,7 @@ class DeployAppBase extends DefaultTask {
         }
         // For TC builds, we deposit the artifacts of the Linux TPP Tools and Windows Proteomics Tools into
         // the external directory, so we want to copy those over as well.
-        // TODO: package the output of these builds into the Artfactory artifact to simplify
+        // TODO: package the output of these builds into the Artifactory artifact to simplify
         if (project.file(_externalDir).exists()) {
             project.logger.info("Copying from ${_externalDir} to ${project.serverDeploy.binDir}")
             if (SystemUtils.IS_OS_MAC)


### PR DESCRIPTION
#### Rationale
The name `jspImplementation` is used by Gradle when there is a `jsp` source set. With Gradle 8.1, they advertise that using this configuration name will not be supported.  We don't need all the different configurations.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/474

#### Changes
* Remove use of reserved configuration name for JSPs and unneeded artifacts declaration (since we no longer publish jsp jar files)
