### PR TITLE
Handle new embedded tomcat properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ on how to do that, including how to develop and test locally and the versioning 
 _Note: 1.28.0 and later require Gradle 7_
 
 ### 1.40.6
-*Released*: TBD
+*Released*: 15 May 2023
 (Earliest compatible LabKey version: 23.3)
 * Remove use of reserved configuration name for JSPs
 * [Issue 47854: Improve audit trail of LabKey install script](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47854)

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ _Note: 1.28.0 and later require Gradle 7_
 (Earliest compatible LabKey version: 23.3)
 * Remove use of reserved configuration name for JSPs
 * [Issue 47854: Improve audit trail of LabKey install script](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47854)
+* Allow more customization of embedded tomcat properties
 
 ### 1.40.5
 *Released*: 23 March 2023

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.40.6-useLocalBuild-SNAPSHOT"
+project.version = "1.41.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.41.0-SNAPSHOT"
+project.version = "1.40.6-useLocalBuild-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
@@ -140,8 +140,16 @@ class DoThenSetup extends DefaultTask
                             line = line.replace("#server.ssl", "server.ssl")
                         }
                         if (project.hasProperty("useLocalBuild")) {
+                            // Let properties file specify which properties require 'useLocalBuild'
+                            line = line.replace("#useLocalBuild#", "");
+
+                            // Old method enables specific properties for 'useLocalBuild' (before 22.6)
                             line = line.replace("#context.webAppLocation=", "context.webAppLocation=")
                             line = line.replace("#spring.devtools.restart.additional-paths=", "spring.devtools.restart.additional-paths=")
+                        }
+                        else {
+                            // Remove placeholder
+                            line = line.replace("#useLocalBuild#", "#");
                         }
                         if (configProperties.containsKey("extraJdbcDataSource"))
                         {


### PR DESCRIPTION
#### Rationale
I'm trying to add a new property to `application.properties`. It includes a replacement for `pathToServer`, so should probably be skipped when `useLocalBuild` isn't set. In order to future-proof this a bit, I'm adding a less specific syntax for such properties (prepending with `#useLocalBuild#`).

#### Related Pull Requests
* https://github.com/LabKey/server/pull/478

#### Changes
* Handle new embedded tomcat properties
