### PR TITLE
Add property to limit NPM build task concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### TBD
+*Released*: TBD
+(Earliest compatible LabKey version: 23.3)
+* Add property to limit NPM build task concurrency (`npmRunLimit`)
+
 ### 1.40.6
 *Released*: 15 May 2023
 (Earliest compatible LabKey version: 23.3)

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.41.0-npmRunLimit-SNAPSHOT"
+project.version = "1.41.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.41.0-SNAPSHOT"
+project.version = "1.41.0-npmRunLimit-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/plugin/NpmRun.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/NpmRun.groovy
@@ -115,8 +115,8 @@ class NpmRun implements Plugin<Project>
                     task.dependsOn "yarn_run_${project.npmRun.buildProd}"
                     task.mustRunAfter "yarn_install"
                 }
-        addTaskInputOutput(project.tasks.named('yarnRunBuildProd'))
-        addTaskInputOutput(project.tasks.named("yarn_run_${project.npmRun.buildProd}"))
+        configureBuildTask(project.tasks.named('yarnRunBuildProd'))
+        configureBuildTask(project.tasks.named("yarn_run_${project.npmRun.buildProd}"))
 
         def yarnRunBuild = project.tasks.register("yarnRunBuild")
                 {Task task ->
@@ -126,8 +126,8 @@ class NpmRun implements Plugin<Project>
                     task.dependsOn "yarn_run_${project.npmRun.buildDev}"
                     task.mustRunAfter "yarn_install"
                 }
-        addTaskInputOutput(project.tasks.named('yarnRunBuild'))
-        addTaskInputOutput(project.tasks.named("yarn_run_${project.npmRun.buildDev}"))
+        configureBuildTask(project.tasks.named('yarnRunBuild'))
+        configureBuildTask(project.tasks.named("yarn_run_${project.npmRun.buildDev}"))
 
         def runCommand = LabKeyExtension.isDevMode(project) ? yarnRunBuild : yarnRunBuildProd
         TaskUtils.configureTaskIfPresent(project, "module", { dependsOn(runCommand) })
@@ -161,8 +161,8 @@ class NpmRun implements Plugin<Project>
                     task.mustRunAfter "npmInstall"
 
                 }
-        addTaskInputOutput(project.tasks.named('npmRunBuildProd'))
-        addTaskInputOutput(project.tasks.named("npm_run_${project.npmRun.buildProd}"))
+        configureBuildTask(project.tasks.named('npmRunBuildProd'))
+        configureBuildTask(project.tasks.named("npm_run_${project.npmRun.buildProd}"))
 
         def npmRunBuild = project.tasks.register("npmRunBuild")
                 {Task task ->
@@ -172,8 +172,8 @@ class NpmRun implements Plugin<Project>
                     task.mustRunAfter "npmInstall"
                 }
 
-        addTaskInputOutput(project.tasks.named('npmRunBuild'))
-        addTaskInputOutput(project.tasks.named("npm_run_${project.npmRun.buildDev}"))
+        configureBuildTask(project.tasks.named('npmRunBuild'))
+        configureBuildTask(project.tasks.named("npm_run_${project.npmRun.buildDev}"))
 
         project.tasks.named('npmInstall').configure
                 {Task task ->
@@ -241,7 +241,7 @@ class NpmRun implements Plugin<Project>
 
     }
 
-    private static void addTaskInputOutput(TaskProvider tp)
+    private static void configureBuildTask(TaskProvider tp)
     {
         tp.configure { Task task ->
             if (task.project.file(NPM_PROJECT_FILE).exists())
@@ -266,6 +266,8 @@ class NpmRun implements Plugin<Project>
             }
 
             task.outputs.cacheIf({ true })
+
+            task.usesService(task.project.npmRun.npmRunLimit)
         }
     }
 }

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/NpmRunExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/NpmRunExtension.groovy
@@ -32,7 +32,8 @@ class NpmRunExtension
 
     NpmRunExtension(Project project) {
         npmRunLimit = project.getGradle().getSharedServices().registerIfAbsent("npmRunLimit", NpmRunLimit.class, spec -> {
-            spec.maxParallelUsages project.getProperties().get("npmRunLimit", 2)
+            if (project.hasProperty("npmRunLimit"))
+                spec.getMaxParallelUsages().set(Integer.valueOf(project.property("npmRunLimit")))
         })
     }
 }

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/NpmRunExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/NpmRunExtension.groovy
@@ -15,10 +15,26 @@
  */
 package org.labkey.gradle.plugin.extension
 
+import org.gradle.api.Project
+import org.gradle.api.provider.Provider
+import org.gradle.api.services.BuildService
+
+import static org.gradle.api.services.BuildServiceParameters.None
+
 class NpmRunExtension
 {
     String clean = "clean"
     String setup = "setup"
     String buildProd = "build-prod"
     String buildDev = "build"
+
+    final Provider<BuildService<None>> npmRunLimit
+
+    NpmRunExtension(Project project) {
+        npmRunLimit = project.getGradle().getSharedServices().registerIfAbsent("npmRunLimit", NpmRunLimit.class, spec -> {
+            spec.maxParallelUsages project.getProperties().get("npmRunLimit", 2)
+        })
+    }
 }
+
+abstract class NpmRunLimit implements BuildService<None> { }

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/NpmRunExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/NpmRunExtension.groovy
@@ -28,6 +28,7 @@ class NpmRunExtension
     String buildProd = "build-prod"
     String buildDev = "build"
 
+    // https://docs.gradle.org/current/userguide/build_services.html#concurrent_access_to_the_service
     final Provider<BuildService<None>> npmRunLimit
 
     NpmRunExtension(Project project) {


### PR DESCRIPTION
#### Rationale
When experimenting with different TeamCity instance types, I ran into memory issues with the npm build for some modules. Disabling parallel building was one solution but it would be nice to be able to just prevent npm build tasks from running parallel.
This can be accomplished by configuring the npm build tasks to use a [BuildService with limited parallel usages](https://docs.gradle.org/current/userguide/build_services.html#concurrent_access_to_the_service).

#### Related Pull Requests
* N/A

#### Changes
* Define build service to restrict parallel NPM build tasks
