### PR TITLE
Remove unneeded local repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,12 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
-### TBD
-*Released*: TBD
+### 1.41.0
+*Released*: TDB June 2023
 (Earliest compatible LabKey version: 23.3)
-* Add plugin for purging artifact versions from Artfactory
+* Add plugin for purging artifact versions from Artifactory
 * Add property to limit NPM build task concurrency (`npmRunLimit`)
+* Remove use of local repository for dependencies
 
 ### 1.40.6
 *Released*: 15 May 2023

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ on how to do that, including how to develop and test locally and the versioning 
 _Note: 1.28.0 and later require Gradle 7_
 
 ### 1.41.0
-*Released*: TDB June 2023
+*Released*: 8 June 2023
 (Earliest compatible LabKey version: 23.3)
 * Add plugin for purging artifact versions from Artifactory
 * Add property to limit NPM build task concurrency (`npmRunLimit`)

--- a/build.gradle
+++ b/build.gradle
@@ -25,9 +25,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven {
-        url "${artifactory_contextUrl}/libs-release"
-    }
 }
 
 dependencies {
@@ -45,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.41.0-SNAPSHOT"
+project.version = "1.41.0-repoOptimizations-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.41.0-repoOptimizations-SNAPSHOT"
+project.version = "1.42.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins


### PR DESCRIPTION
#### Rationale
Since we no longer use `yuiCompressor` and our special build for that library, we no longer need to get any dependencies from our Artifactory repository.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/497

#### Changes
* Remove use of `libs-release` repo
