### PR TITLE
Don't apply module version to LabKey dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### 1.41.1
+*Released*: TBD
+(Earliest compatible LabKey version: 23.3)
+* Don't apply module version to LabKey dependencies
+  * Allows correct dependency resolution when using `versioning` plugin
+
 ### 1.41.0
 *Released*: 8 June 2023
 (Earliest compatible LabKey version: 23.3)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ on how to do that, including how to develop and test locally and the versioning 
 _Note: 1.28.0 and later require Gradle 7_
 
 ### 1.41.1
-*Released*: TBD
+*Released*: 28 June 2023
 (Earliest compatible LabKey version: 23.3)
 * Don't apply module version to LabKey dependencies
   * Allows correct dependency resolution when using `versioning` plugin

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.42.0-SNAPSHOT"
+project.version = "1.41.1-dependencyVersion-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.41.1-dependencyVersion-SNAPSHOT"
+project.version = "1.42.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -649,14 +649,14 @@ class BuildUtils
             {
                 parentProject.logger.debug("${depProjectPath} project not found; assumed to be external.")
                 if (depVersion == null)
-                    depVersion = parentProject.version
+                    depVersion = parentProject.labkeyVersion
             }
             else
             {
                 parentProject.logger.debug("${depProjectPath} project found but not building from source because: "
                         + whyNotBuildFromSource(parentProject, BUILD_FROM_SOURCE_PROP).join("; "))
                 if (depVersion == null)
-                    depVersion = depProject.version
+                    depVersion = depProject.labkeyVersion
             }
 
             // TODO I don't think this combinedClosure works. Change to just pass transitive through in the add


### PR DESCRIPTION
#### Rationale
`BuildUtils.addLabKeyDependency` applies the depending module's version to the dependency. When building with `-PincludeVcs`, a module's version includes the feature branch name (e.g. `23.3-myBranch-SNAPSHOT`). If you attempt to build without enlisting all dependent modules, the plugin will attempt to pull dependencies with the same version (e.g. `dataintegration-23.3-myBranch-SNAPSHOT.pom`).
Since we never publish feature branches to Artifactory, we should just use `labkeyVersion` for dependencies not being built locally.

#### Related Pull Requests
* N/A

#### Changes
* Don't apply module version to LabKey dependencies
