### PR TITLE
Add RestoreFromTrash task to make it easier to restore artifact version from Artifactory

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -7,5 +7,5 @@
   <component name="JavaScriptSettings">
     <option name="languageLevel" value="ES6" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_15" default="true" project-jdk-name="15" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK" />
 </project>

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### TBD
+*Released*: TBD
+(Earliest compatible LabKey version: 23.3)
+* Add RestoreFromTrash task to make it easier to restore artifact version from Artifactory
+
 ### 1.41.2
 *Released*: 24 July 2023
 (Earliest compatible LabKey version: 23.3)

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.42.0-restoreArtifacts-SNAPSHOT"
+project.version = "1.42.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.42.0-SNAPSHOT"
+project.version = "1.42.0-restoreArtifacts-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/task/PurgeArtifacts.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/PurgeArtifacts.groovy
@@ -18,8 +18,8 @@ import org.labkey.gradle.util.BuildUtils
 
 class PurgeArtifacts extends DefaultTask
 {
-    private static final String SNAPSHOT_REPOSITORY_NAME = 'libs-snapshot-local'
-    private static final String RELEASE_REPOSITORY_NAME = 'libs-release-local'
+    public static final String SNAPSHOT_REPOSITORY_NAME = 'libs-snapshot-local'
+    public static final String RELEASE_REPOSITORY_NAME = 'libs-release-local'
     public static final String VERSION_PROPERTY = 'purgeVersion'
 
     static boolean isPreSplitVersion(String version)
@@ -56,7 +56,7 @@ class PurgeArtifacts extends DefaultTask
                 }
                 else
                     numDeleted++
-                if (!isPreSplitVersion && plugins.hasPlugin(Api.class)) {
+                if (!isPreSplitVersion && (plugins.hasPlugin(Api.class) || project.path == BuildUtils.getApiProjectPath(project.gradle))) {
                     response = makeDeleteRequest(p.name, purgeVersion, "api")
                     if (response == Response.NOT_FOUND)
                         numNotFound++

--- a/src/main/groovy/org/labkey/gradle/task/RestoreFromTrash.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/RestoreFromTrash.groovy
@@ -1,0 +1,120 @@
+package org.labkey.gradle.task
+
+import org.apache.commons.lang3.StringUtils
+import org.apache.http.HttpStatus
+import org.apache.http.client.methods.CloseableHttpResponse
+import org.apache.http.client.methods.HttpPost
+import org.apache.http.impl.client.CloseableHttpClient
+import org.apache.http.impl.client.HttpClients
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.api.tasks.TaskAction
+import org.labkey.gradle.plugin.Api
+import org.labkey.gradle.plugin.FileModule
+import org.labkey.gradle.plugin.JavaModule
+import org.labkey.gradle.plugin.Module
+import org.labkey.gradle.util.BuildUtils
+
+import static org.labkey.gradle.task.PurgeArtifacts.Response
+
+class RestoreFromTrash extends DefaultTask
+{
+    public static final String VERSION_PROPERTY = "restoreVersion"
+
+    @TaskAction
+    void restoreVersions()
+    {
+        String restoreVersion
+        if (!project.hasProperty(VERSION_PROPERTY))
+            throw new GradleException("No value provided for ${VERSION_PROPERTY}.")
+        restoreVersion = project.property(VERSION_PROPERTY);
+        String[] unrestoredVersions = []
+        int numRestored = 0
+        int numNotFound = 0
+        project.allprojects({ Project p ->
+            def plugins = p.getPlugins()
+            if (plugins.hasPlugin(Module.class) || plugins.hasPlugin(JavaModule.class) || plugins.hasPlugin(FileModule.class)) {
+                logger.quiet("Considering ${p.path}...")
+                Response response = makeRestoreRequest(p.name, restoreVersion, "module")
+                if (response == Response.NOT_FOUND)
+                    numNotFound++
+                else if (response == Response.ERROR) {
+                    unrestoredVersions += "${p.path} - module: ${restoreVersion}"
+                } else
+                    numRestored++
+            }
+            if (plugins.hasPlugin(Api.class) || project.path == BuildUtils.getApiProjectPath(project.gradle)) {
+                Response response = makeRestoreRequest(p.name, restoreVersion, "api")
+                if (response == Response.NOT_FOUND)
+                    numNotFound++
+                else if (response == Response.ERROR) {
+                    unrestoredVersions += "${p.path} - api: ${restoreVersion}"
+                } else
+                    numRestored++
+            }
+        })
+
+        logger.quiet("Restored ${numRestored} artifacts; ${numNotFound} artifacts not found.")
+        if (unrestoredVersions.size() > 0 && !project.hasProperty("dryRun"))
+            throw new GradleException("The following ${unrestoredVersions.size()} versions were not restored.\n${StringUtils.join(unrestoredVersions, "\n")}\nCheck the log for more information.")
+
+    }
+
+    /**
+     * This uses the Artifactory REST Api to request a restoration of a particular "item" (https://jfrog.com/help/r/jfrog-rest-apis/restore-item-from-trash-can)
+     *
+     * @param artifactName the artifact whose version is to be deleted
+     * @param version the version of the artifact to delete (e.g., 21.11-SNAPSHOT)
+     * @param type either "api" or "module"
+     * @return Response summarizing http status from request
+     * @throws GradleException if the restoration request throws an exception
+     */
+    Response makeRestoreRequest(String artifactName, String version, String type)
+    {
+        if (project.hasProperty("dryRun")) {
+            logger.quiet("\tRestoring version ${version} of ${artifactName} ${type} -- Skipped for dry run")
+            return
+        }
+
+        CloseableHttpClient httpClient = HttpClients.createDefault();
+        String endpoint = project.property('artifactory_contextUrl')
+        Response responseStatus = Response.SUCCESS
+        if (!endpoint.endsWith("/"))
+            endpoint += "/"
+        endpoint += "api/trash/restore/"
+
+        String repo = version.contains("SNAPSHOT") ? PurgeArtifacts.SNAPSHOT_REPOSITORY_NAME : PurgeArtifacts.RELEASE_REPOSITORY_NAME
+        String path = "${repo}/org/labkey/${type}/${artifactName}/${version}"
+        endpoint += "${path}?to=${path}"
+        logger.quiet("\tMaking restore request for ${type} artifact ${artifactName} and version ${version} via endpoint ${endpoint}")
+
+        try
+        {
+            HttpPost httpPost = new HttpPost(endpoint)
+            // N.B. Using Authorization Bearer with an API token does not currently work
+            httpPost.setHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString("${project.property('artifactory_user')}:${project.property('artifactory_password')}".getBytes()))
+            CloseableHttpResponse response = httpClient.execute(httpPost)
+            int statusCode = response.getStatusLine().getStatusCode()
+
+            if (statusCode == HttpStatus.SC_NOT_FOUND) {
+                logger.info("No such file or directory: ${endpoint}")
+                responseStatus = Response.NOT_FOUND
+            }
+            else if (statusCode != HttpStatus.SC_OK && statusCode != HttpStatus.SC_NO_CONTENT && statusCode != HttpStatus.SC_ACCEPTED) {
+                logger.error("Unable to restore using ${endpoint}: ${response.getStatusLine()}")
+                responseStatus = Response.ERROR
+            }
+            response.close()
+            return responseStatus
+        }
+        catch (Exception e)
+        {
+            throw new GradleException("Problem executing restore request with url ${endpoint}", e)
+        }
+        finally
+        {
+            httpClient.close()
+        }
+    }
+}


### PR DESCRIPTION
#### Rationale
When we need to restore artifacts from the Trash Can in Artifactory, doing this through the UI requires a LOT of pointing and clicking. Fortunately, they have API support for this operation (https://jfrog.com/help/r/jfrog-rest-apis/restore-item-from-trash-can).

#### Changes
* Add new task
* Fix purgeTask so it will purge the api api jar artifacts

