### PR TITLE
Increase complexity of default TeamCity test password

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ _Note: 1.28.0 and later require Gradle 7_
 *Released*: TBD
 (Earliest compatible LabKey version: 23.3)
 * Add RestoreFromTrash task to make it easier to restore artifact version from Artifactory
+* Increase complexity of default TeamCity test password
 
 ### 1.41.2
 *Released*: 24 July 2023

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/TeamCityExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/TeamCityExtension.groovy
@@ -190,6 +190,6 @@ class TeamCityExtension
 
     static String getLabKeyPassword(Project project)
     {
-        return getTeamCityProperty(project, "labkey.server.password", "yekbal1!")
+        return getTeamCityProperty(project, "labkey.server.password", "We'reSo\$tr0ng@yekbal1!")
     }
 }


### PR DESCRIPTION
#### Rationale
We're changing the default password complexity requirement.
I've set the `labkey.server.password` property to something sufficient on TeamCity so this isn't urgent.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4707

#### Changes
* Increase complexity of default TeamCity test password
