### PR TITLE
Add @labkey/ehr to set of packages to consider for alpha version cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
-### TBD
-*Released*: TBD
+### 1.42.1
+*Released*: 11 October 2023
 (Earliest compatible LabKey version: 23.3)
 * Add `@labkey/ehr` to set of npm packages to purge versions for
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### TBD
+*Released*: TBD
+(Earliest compatible LabKey version: 23.3)
+* Add `@labkey/ehr` to set of npm packages to purge versions for
+
 ### 1.42.0
 *Released*: 5 October 2023
 (Earliest compatible LabKey version: 23.3)

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.43.0-SNAPSHOT"
+project.version = "1.43.0-purgeEhrPackage-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.43.0-purgeEhrPackage-SNAPSHOT"
+project.version = "1.43.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/task/PurgeNpmAlphaVersions.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/PurgeNpmAlphaVersions.groovy
@@ -24,6 +24,7 @@ class PurgeNpmAlphaVersions extends DefaultTask
             '@labkey/assayreport',
             '@labkey/build',
             '@labkey/components',
+            '@labkey/ehr',
             '@labkey/premium',
             '@labkey/test',
             '@labkey/themes'


### PR DESCRIPTION
#### Rationale
We are adding a new `@labkey/ehr` npm package and want to update the `purgeNpmAlphaVersion` task to also consider it for cleanup.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Update list of known packages.
