### PR TITLE
Update `PurgeNpmAlphaVersions` task to handle a single version returned as a string instead of an array

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### TBD
+*Released*: TBD
+(Earliest compatible LabKey version: 23.3)
+* Update `PurgeNpmAlphaVersions` task to handle a single version returned as a string instead of an array
+
 ### 1.42.1
 *Released*: 11 October 2023
 (Earliest compatible LabKey version: 23.3)

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
-### TBD
-*Released*: TBD
+### 1.42.2
+*Released*: 26 October 2023
 (Earliest compatible LabKey version: 23.3)
 * Update `PurgeNpmAlphaVersions` task to handle a single version returned as a string instead of an array
 

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.43.0-purgeWithOneVersion-SNAPSHOT"
+project.version = "1.43.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.43.0-SNAPSHOT"
+project.version = "1.43.0-purgeWithOneVersion-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins


### PR DESCRIPTION
#### Rationale
When there is a single version of an npm package, the request to get the versions in JSON format returns the single version as a simple string instead of as an array of that single string. We need to handle that when parsing.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/608

#### Changes
* Update parsing of return value from npm call.
