### PR TITLE
Replace `buildDir` with `layout.buildDirectory` and do some other housekeeping

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ _Note: 1.28.0 and later require Gradle 7_
 (Earliest compatible LabKey version: 23.3)
 * [Issue 49045](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49045) - make copying to the modules-api directory a proper task, so it can run even if apiJar does not
 * Eliminate usages of deprecated `project.buildDir`
+* Update `BuildUtils.includeModules` to be able to specify full module paths for exclusion, not just directory names
 
 ### 1.42.2
 *Released*: 26 October 2023

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ _Note: 1.28.0 and later require Gradle 7_
 *Released*: TBD
 (Earliest compatible LabKey version: 23.3)
 * [Issue 49045](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49045) - make copying to the modules-api directory a proper task, so it can run even if apiJar does not
+* Eliminate usages of deprecated `project.buildDir`
 
 ### 1.42.2
 *Released*: 26 October 2023

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### TBD
+*Released*: TBD
+(Earliest compatible LabKey version: 23.3)
+* [Issue 49045](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49045) - make copying to the modules-api directory a proper task, so it can run even if apiJar does not
+
 ### 1.42.2
 *Released*: 26 October 2023
 (Earliest compatible LabKey version: 23.3)

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
-### TBD
-*Released*: TBD
+### 1.43.0
+*Released*: 16 November 2023
 (Earliest compatible LabKey version: 23.3)
 * [Issue 49045](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49045) - make copying to the modules-api directory a proper task, so it can run even if apiJar does not
 * Eliminate usages of deprecated `project.buildDir`

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.43.0-buildDirBeGone-SNAPSHOT"
+project.version = "1.44.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.43.0-SNAPSHOT"
+project.version = "1.43.0-buildDirBeGone-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -167,7 +167,7 @@ if (project.file("moduleTemplate").exists())
         Zip zip ->
             zip.archiveFileName = "moduleTemplate.zip"
             zip.from project.file("moduleTemplate")
-            zip.destinationDirectory = new File(project.projectDir, "src/main/resources")
+            zip.destinationDirectory.set(new File(project.projectDir, "src/main/resources"))
     }
     project.tasks.processResources.dependsOn(project.tasks.zipModuleTemplate)
 }
@@ -176,7 +176,7 @@ project.tasks.register("zipDistributionResources", Zip) {
     Zip zip ->
         zip.archiveFileName = "distributionResources.zip"
         zip.from project.file("distributionResources")
-        zip.destinationDirectory = new File(project.projectDir, "src/main/resources")
+        zip.destinationDirectory.set(new File(project.projectDir, "src/main/resources"))
 }
 project.tasks.processResources.dependsOn(project.tasks.zipDistributionResources)
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -2,7 +2,7 @@
 <!-- Rationale describing why this pull request is needed, what behavior it's adding/changing/removing, etc. (replace this comment) -->
 
 #### Related Pull Requests
-* <!-- list of links to related pull requests (replace this comment) -->
+- <!-- list of links to related pull requests (replace this comment) -->
 
 #### Changes
-* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
+- <!-- list of descriptions of changes that are worth noting (replace this comment) -->

--- a/src/main/groovy/org/labkey/gradle/plugin/AntBuild.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/AntBuild.groovy
@@ -61,8 +61,8 @@ class AntBuild implements Plugin<Project>
     {
         project.ant.setProperty('basedir', BuildUtils.getServerProject(project).projectDir)
         project.ant.setProperty('modules.dir', project.projectDir.parent)
-        project.ant.setProperty('build.modules.dir', project.layout.buildDirectory.getAsFile().get().parent)
-        project.ant.setProperty('build.dir', project.rootProject.layout.buildDirectory.getAsFile().path)
+        project.ant.setProperty('build.modules.dir', BuildUtils.getBuildDir(project).parent)
+        project.ant.setProperty('build.dir', BuildUtils.getBuildDirPath(project))
         project.ant.setProperty('explodedModuleDir', project.labkey.explodedModuleDir)
         project.ant.setProperty('java.source.and.target', project.sourceCompatibility)
     }

--- a/src/main/groovy/org/labkey/gradle/plugin/AntBuild.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/AntBuild.groovy
@@ -61,8 +61,8 @@ class AntBuild implements Plugin<Project>
     {
         project.ant.setProperty('basedir', BuildUtils.getServerProject(project).projectDir)
         project.ant.setProperty('modules.dir', project.projectDir.parent)
-        project.ant.setProperty('build.modules.dir', project.buildDir.parent)
-        project.ant.setProperty('build.dir', project.rootProject.buildDir)
+        project.ant.setProperty('build.modules.dir', project.layout.buildDirectory.getAsFile().get().parent)
+        project.ant.setProperty('build.dir', project.rootProject.layout.buildDirectory.getAsFile().path)
         project.ant.setProperty('explodedModuleDir', project.labkey.explodedModuleDir)
         project.ant.setProperty('java.source.and.target', project.sourceCompatibility)
     }

--- a/src/main/groovy/org/labkey/gradle/plugin/AntBuild.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/AntBuild.groovy
@@ -62,7 +62,7 @@ class AntBuild implements Plugin<Project>
         project.ant.setProperty('basedir', BuildUtils.getServerProject(project).projectDir)
         project.ant.setProperty('modules.dir', project.projectDir.parent)
         project.ant.setProperty('build.modules.dir', BuildUtils.getBuildDir(project).parent)
-        project.ant.setProperty('build.dir', BuildUtils.getBuildDirPath(project))
+        project.ant.setProperty('build.dir', BuildUtils.getBuildDirPath(project.rootProject))
         project.ant.setProperty('explodedModuleDir', project.labkey.explodedModuleDir)
         project.ant.setProperty('java.source.and.target', project.sourceCompatibility)
     }

--- a/src/main/groovy/org/labkey/gradle/plugin/Antlr.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Antlr.groovy
@@ -50,7 +50,7 @@ class Antlr implements Plugin<Project>
         }
     }
 
-    void addTasks(Project project)
+    static void addTasks(Project project)
     {
         FileTree antlrInput = project.fileTree(dir: project.projectDir, includes: ["**/*${EXTENSION}"], excludes: ["out/**/*${EXTENSION}"])
 

--- a/src/main/groovy/org/labkey/gradle/plugin/Api.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Api.groovy
@@ -17,9 +17,8 @@ package org.labkey.gradle.plugin
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.Task
-import org.gradle.api.file.CopySpec
 import org.gradle.api.file.DuplicatesStrategy
+import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.bundling.Jar
 import org.labkey.gradle.plugin.extension.LabKeyExtension
 import org.labkey.gradle.util.BuildUtils
@@ -102,11 +101,12 @@ class Api implements Plugin<Project>
 
         if (LabKeyExtension.isDevMode(project))
         {
-            // we put all API jar files into a special directory for the RecompilingJspClassLoader's classpath
-            project.tasks.apiJar.doLast {
-                project.copy { CopySpec copy ->
+            project.tasks.register("copyToModulesApi", Copy) {
+                Copy copy -> {
+                    copy.group = GroupNames.API
+                    copy.description = "Copies api jar files to the ${MODULES_API_DIR} for use with RecompilingJspClassLoader"
                     copy.from project.tasks.apiJar.outputs
-                    copy.into "${project.rootProject.buildDir}/${MODULES_API_DIR}"
+                    copy.into project.rootProject.layout.buildDirectory.file(MODULES_API_DIR)
                     copy.include "${project.name}_api*.jar"
                     copy.setDuplicatesStrategy(DuplicatesStrategy.INCLUDE)
                 }
@@ -120,7 +120,7 @@ class Api implements Plugin<Project>
     // deletion a step for the 'undeployModule' task instead
     static void deleteModulesApiJar(Project project)
     {
-        project.delete project.fileTree("${project.rootProject.buildDir}/${MODULES_API_DIR}") {include "**/${project.name}_api*.jar"}
+        project.delete project.fileTree(project.rootProject.layout.buildDirectory.file(MODULES_API_DIR)) {include "**/${project.name}_api*.jar"}
     }
 
     private void addArtifacts(Project project)

--- a/src/main/groovy/org/labkey/gradle/plugin/ApplyLicenses.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ApplyLicenses.groovy
@@ -11,7 +11,7 @@ import org.labkey.gradle.util.GroupNames
 class ApplyLicenses implements Plugin<Project>
 {
     @Override
-    public void apply(Project project)
+    void apply(Project project)
     {
         if (project.findProject(BuildUtils.getApiProjectPath(project.gradle)))
             project.evaluationDependsOn(BuildUtils.getApiProjectPath(project.gradle))

--- a/src/main/groovy/org/labkey/gradle/plugin/ApplyLicenses.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ApplyLicenses.groovy
@@ -61,7 +61,7 @@ class ApplyLicenses implements Plugin<Project>
                     jar.archiveVersion.set(project.getVersion().toString())
                     jar.archiveClassifier.set("extJsCommercial")
                     jar.archiveExtension.set('module')
-                    jar.destinationDirectory = project.file("${project.buildDir}/patchApiModule")
+                    jar.destinationDirectory.set(project.layout.buildDirectory.dir("patchApiModule"))
                     jar.outputs.cacheIf({ true })
                     // first include the ext-3.4.1 and ext-4.2.1 directories from the extjs configuration artifacts
                     jar.into('web') {

--- a/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
@@ -18,7 +18,6 @@ package org.labkey.gradle.plugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.api.UnknownTaskException
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.ProjectDependency
@@ -142,9 +141,7 @@ class Distribution implements Plugin<Project>
                     if (it instanceof DefaultProjectDependency)
                     {
                         DefaultProjectDependency dep = (DefaultProjectDependency) it
-                        try {
-                            distTask.dependsOn(dep.dependencyProject.tasks.named("module"))
-                        } catch (UnknownTaskException ignore) {}
+                        TaskUtils.addOptionalTaskDependency(dep.dependencyProject, distTask, "module")
                     }
                 }
             }
@@ -237,12 +234,10 @@ class Distribution implements Plugin<Project>
             return project.dist.artifactId
         else
         {
-            try
-            {
-                def task = project.tasks.named("distribution")
-                if (task.get() instanceof ModuleDistribution)
-                    return ((ModuleDistribution) project.tasks.distribution).getArtifactId()
-            } catch (UnknownTaskException ignore) {}
+            TaskUtils.doIfTaskPresent(project, "distribution", (distTask) -> {
+                if (distTask.get() instanceof ModuleDistribution)
+                    return ((ModuleDistribution) distTask).getArtifactId()
+            })
         }
         return project.name
     }

--- a/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
@@ -18,6 +18,7 @@ package org.labkey.gradle.plugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.UnknownTaskException
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.ProjectDependency
@@ -141,8 +142,9 @@ class Distribution implements Plugin<Project>
                     if (it instanceof DefaultProjectDependency)
                     {
                         DefaultProjectDependency dep = (DefaultProjectDependency) it
-                        if (dep.dependencyProject.tasks.findByName("module") != null)
-                            distTask.dependsOn(dep.dependencyProject.tasks.module)
+                        try {
+                            distTask.dependsOn(dep.dependencyProject.tasks.named("module"))
+                        } catch (UnknownTaskException ignore) {}
                     }
                 }
             }
@@ -233,10 +235,16 @@ class Distribution implements Plugin<Project>
     {
         if (project.dist.artifactId != null)
             return project.dist.artifactId
-        else if (project.tasks.findByName("distribution") != null)
+        else
         {
-            if (project.tasks.distribution instanceof ModuleDistribution)
-                return ((ModuleDistribution) project.tasks.distribution).getArtifactId()
+            try
+            {
+                def task = project.tasks.named("distribution")
+                if (task.get() instanceof ModuleDistribution)
+                    return ((ModuleDistribution) project.tasks.distribution).getArtifactId()
+            } catch (UnknownTaskException ignore) {}
+//            if (project.tasks.distribution instanceof ModuleDistribution)
+//                return ((ModuleDistribution) project.tasks.distribution).getArtifactId()
         }
         return project.name
     }

--- a/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
@@ -243,8 +243,6 @@ class Distribution implements Plugin<Project>
                 if (task.get() instanceof ModuleDistribution)
                     return ((ModuleDistribution) project.tasks.distribution).getArtifactId()
             } catch (UnknownTaskException ignore) {}
-//            if (project.tasks.distribution instanceof ModuleDistribution)
-//                return ((ModuleDistribution) project.tasks.distribution).getArtifactId()
         }
         return project.name
     }

--- a/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
@@ -123,10 +123,10 @@ class Distribution implements Plugin<Project>
         project.tasks.register('clean', Delete) {
             Delete task ->
                 task.group = GroupNames.BUILD
-                task.description = "Removes the distribution build directory ${project.buildDir} and distribution directory ${project.dist.dir}/${project.name}"
+                task.description = "Removes the distribution build directory ${project.layout.buildDirectory.asFile.get()} and distribution directory ${project.dist.dir}/${project.name}"
                 task.configure ({
                     DeleteSpec spec ->
-                        spec.delete project.buildDir
+                        spec.delete project.layout.buildDirectory
                         spec.delete "${project.dist.dir}/${project.name}"
                 })
         }

--- a/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
@@ -234,12 +234,11 @@ class Distribution implements Plugin<Project>
             return project.dist.artifactId
         else
         {
-            TaskUtils.doIfTaskPresent(project, "distribution", (distTask) -> {
-                if (distTask.get() instanceof ModuleDistribution)
-                    return ((ModuleDistribution) distTask).getArtifactId()
-            })
+            return TaskUtils.getOptionalTask(project, "distribution")
+                    .filter(task -> task.get() instanceof ModuleDistribution)
+                    .map(task -> ((ModuleDistribution)task.get()).getArtifactId())
+                    .orElse(project.name)
         }
-        return project.name
     }
 
 }

--- a/src/main/groovy/org/labkey/gradle/plugin/Gwt.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Gwt.groovy
@@ -18,7 +18,6 @@ package org.labkey.gradle.plugin
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.api.file.FileTree
 import org.gradle.api.specs.AndSpec
 import org.gradle.api.tasks.Copy
@@ -102,8 +101,8 @@ class Gwt implements Plugin<Project>
                         java.group = GroupNames.GWT
                         java.description = "compile GWT source files for " + gwtModuleClass.getKey() + " into JS"
 
-                        File extrasDir = project.layout.buildDirectory.file(project.gwt.extrasDir).get().asFile
-                        File outputDir = project.layout.buildDirectory.file(project.gwt.outputDir).get().asFile
+                        File extrasDir = BuildUtils.getBuildDirFile(project, project.gwt.extrasDir)
+                        File outputDir = BuildUtils.getBuildDirFile(project, project.gwt.outputDir)
 
                         java.inputs.files(project.sourceSets.gwt.java.srcDirs)
                         String extrasDirPath = extrasDir.getPath()

--- a/src/main/groovy/org/labkey/gradle/plugin/Gwt.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Gwt.groovy
@@ -102,10 +102,12 @@ class Gwt implements Plugin<Project>
                         java.group = GroupNames.GWT
                         java.description = "compile GWT source files for " + gwtModuleClass.getKey() + " into JS"
 
-                        GString extrasDir = "${project.buildDir}/${project.gwt.extrasDir}"
-                        String outputDir = "${project.buildDir}/${project.gwt.outputDir}"
+                        File extrasDir = project.layout.buildDirectory.file(project.gwt.extrasDir).get().asFile
+                        File outputDir = project.layout.buildDirectory.file(project.gwt.outputDir).get().asFile
 
                         java.inputs.files(project.sourceSets.gwt.java.srcDirs)
+                        String extrasDirPath = extrasDir.getPath()
+                        String outputDirPath = outputDir.getPath()
 
                         java.outputs.dir extrasDir
                         java.outputs.dir outputDir
@@ -114,8 +116,8 @@ class Gwt implements Plugin<Project>
                         java.outputs.upToDateSpec = new AndSpec()
 
                         java.doFirst {
-                            project.file(extrasDir).mkdirs()
-                            project.file(outputDir).mkdirs()
+                            extrasDir.mkdirs()
+                            outputDir.mkdirs()
                         }
 
                         if (!LabKeyExtension.isDevMode(project))
@@ -138,11 +140,11 @@ class Gwt implements Plugin<Project>
 
                         java.args =
                                 [
-                                        '-war', outputDir,
+                                        '-war', outputDirPath,
                                         '-style', project.gwt.style,
                                         '-logLevel', project.gwt.logLevel,
-                                        '-extra', extrasDir,
-                                        '-deploy', extrasDir,
+                                        '-extra', extrasDirPath,
+                                        '-deploy', extrasDirPath,
                                         '-localWorkers', 4,
                                         gwtModuleClass.getValue()
                                 ]

--- a/src/main/groovy/org/labkey/gradle/plugin/Gwt.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Gwt.groovy
@@ -36,7 +36,7 @@ class Gwt implements Plugin<Project>
 {
     public static final String SOURCE_DIR = "gwtsrc"
 
-    private Project project;
+    private Project project
     private static final String GWT_EXTENSION = ".gwt.xml"
 
     static boolean isApplicable(Project project)
@@ -90,7 +90,7 @@ class Gwt implements Plugin<Project>
     private void addTasks()
     {
         Map<String, String> gwtModuleClasses = getGwtModuleClasses(project)
-        List<TaskProvider> gwtTasks = new ArrayList<>(gwtModuleClasses.size());
+        List<TaskProvider> gwtTasks = new ArrayList<>(gwtModuleClasses.size())
         gwtModuleClasses.entrySet().each {
              gwtModuleClass ->
 
@@ -174,18 +174,18 @@ class Gwt implements Plugin<Project>
     private static Map<String, String> getGwtModuleClasses(Project project)
     {
         File gwtSrc = project.file(project.gwt.srcDir)
-        FileTree tree = project.fileTree(dir: gwtSrc, includes: ["**/*${GWT_EXTENSION}"]);
-        Map<String, String> nameToClass = new HashMap<>();
-        String separator = System.getProperty("file.separator").equals("\\") ? "\\\\" : System.getProperty("file.separator");
+        FileTree tree = project.fileTree(dir: gwtSrc, includes: ["**/*${GWT_EXTENSION}"])
+        Map<String, String> nameToClass = new HashMap<>()
+        String separator = System.getProperty("file.separator").equals("\\") ? "\\\\" : System.getProperty("file.separator")
         for (File file : tree.getFiles())
         {
             String className = file.getPath()
-            className = className.substring(gwtSrc.getPath().length() + 1); // lop off the part of the path before the package structure
-            className = className.replaceAll(separator, "."); // convert from path to class package
-            className = className.substring(0, className.indexOf(GWT_EXTENSION)); // remove suffix
-            nameToClass.put(file.getName().substring(0, file.getName().indexOf(GWT_EXTENSION)),className);
+            className = className.substring(gwtSrc.getPath().length() + 1) // lop off the part of the path before the package structure
+            className = className.replaceAll(separator, ".") // convert from path to class package
+            className = className.substring(0, className.indexOf(GWT_EXTENSION)) // remove suffix
+            nameToClass.put(file.getName().substring(0, file.getName().indexOf(GWT_EXTENSION)),className)
         }
-        return nameToClass;
+        return nameToClass
     }
 
 }

--- a/src/main/groovy/org/labkey/gradle/plugin/JavaModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/JavaModule.groovy
@@ -130,7 +130,7 @@ class JavaModule implements Plugin<Project>
         project.sourceSets {
             main {
                 java {
-                    srcDirs = XmlBeans.isApplicable(project) ? ['src', project.layout.buildDirectory.file(XmlBeans.CLASS_DIR).get().asFile.getPath()] : ['src']
+                    srcDirs = XmlBeans.isApplicable(project) ? ['src', BuildUtils.getBuildDirFile(project, XmlBeans.CLASS_DIR).getPath()] : ['src']
                 }
             }
         }
@@ -173,7 +173,7 @@ class JavaModule implements Plugin<Project>
 
             project.tasks.register("copyExternalLibs", Copy) {
                 Copy task ->
-                    File destination = project.layout.buildDirectory.file("libsExternal").get().asFile;
+                    File destination = BuildUtils.getBuildDirFile(project, "libsExternal")
                     task.group = GroupNames.MODULE
                     task.description = "copy the dependencies declared in the 'external' configuration into the lib directory of the built module"
                     task.setDuplicatesStrategy(DuplicatesStrategy.EXCLUDE)

--- a/src/main/groovy/org/labkey/gradle/plugin/JavaModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/JavaModule.groovy
@@ -17,7 +17,6 @@ package org.labkey.gradle.plugin
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.UnknownTaskException
 import org.gradle.api.file.CopySpec
 import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.file.FileCollection

--- a/src/main/groovy/org/labkey/gradle/plugin/JavaModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/JavaModule.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.bundling.Jar
+import org.labkey.gradle.plugin.extension.LabKeyExtension
 import org.labkey.gradle.plugin.extension.ModuleExtension
 import org.labkey.gradle.task.CheckForVersionConflicts
 import org.labkey.gradle.util.BuildUtils
@@ -129,7 +130,7 @@ class JavaModule implements Plugin<Project>
         project.sourceSets {
             main {
                 java {
-                    srcDirs = XmlBeans.isApplicable(project) ? ['src', "$project.buildDir/$XmlBeans.CLASS_DIR"] : ['src']
+                    srcDirs = XmlBeans.isApplicable(project) ? ['src', project.layout.buildDirectory.file(XmlBeans.CLASS_DIR).get().asFile.getPath()] : ['src']
                 }
             }
         }
@@ -172,7 +173,7 @@ class JavaModule implements Plugin<Project>
 
             project.tasks.register("copyExternalLibs", Copy) {
                 Copy task ->
-                    File destination = new File(project.buildDir, "libsExternal");
+                    File destination = project.layout.buildDirectory.file("libsExternal").get().asFile;
                     task.group = GroupNames.MODULE
                     task.description = "copy the dependencies declared in the 'external' configuration into the lib directory of the built module"
                     task.setDuplicatesStrategy(DuplicatesStrategy.EXCLUDE)
@@ -198,6 +199,8 @@ class JavaModule implements Plugin<Project>
                 if (project.tasks.findByName('apiJar') != null)
                 {
                     dependsOn(project.tasks.apiJar)
+                    if (LabKeyExtension.isDevMode(project))
+                        dependsOn(project.tasks.copyToModulesApi)
                 }
                 if (project.tasks.findByName('jspJar') != null)
                 {

--- a/src/main/groovy/org/labkey/gradle/plugin/JsDoc.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/JsDoc.groovy
@@ -86,7 +86,7 @@ class JsDoc implements Plugin<Project>
                 task.archiveVersion.set(project.getVersion().toString())
                 task.archiveExtension.set("zip")
                 task.from project.tasks.jsdoc
-                task.destinationDirectory = getJsDocDirectory(project)
+                task.destinationDirectory.set(getJsDocDirectory(project))
         }
 
         project.tasks.register('cleanJsDoc', DefaultTask) {

--- a/src/main/groovy/org/labkey/gradle/plugin/JsDoc.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/JsDoc.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.CopySpec
+import org.gradle.api.file.Directory
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.bundling.Zip
 import org.labkey.gradle.plugin.extension.JsDocExtension
@@ -38,13 +39,13 @@ class JsDoc implements Plugin<Project>
     {
         project.extensions.create("jsDoc", JsDocExtension)
         project.jsDoc.root = "${project.rootDir}/tools/jsdoc-toolkit/"
-        project.jsDoc.outputDir =new File(getJsDocDirectory(project), "docs")
+        project.jsDoc.outputDir = getJsDocDirectory(project).file( "docs").asFile
         addTasks(project)
     }
 
-    static File getJsDocDirectory(Project project)
+    static Directory getJsDocDirectory(Project project)
     {
-        return new File(XsdDoc.getClientDocsBuildDir(project),"javascript")
+        return XsdDoc.getClientDocsBuildDir(project).get().dir("javascript")
     }
 
     private static void addTasks(Project project)

--- a/src/main/groovy/org/labkey/gradle/plugin/JsDoc.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/JsDoc.groovy
@@ -57,7 +57,7 @@ class JsDoc implements Plugin<Project>
                         { CopySpec copy ->
                             copy.from project.file("${project.jsDoc.root}/templates/jsdoc")
                             copy.filter( { String line ->
-                                Matcher matcher = PropertiesUtils.PROPERTY_PATTERN.matcher(line);
+                                Matcher matcher = PropertiesUtils.PROPERTY_PATTERN.matcher(line)
                                 String newLine = line;
                                 while (matcher.find())
                                 {

--- a/src/main/groovy/org/labkey/gradle/plugin/Jsp.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Jsp.groovy
@@ -73,7 +73,7 @@ class Jsp implements Plugin<Project>
                 {
                     jsp {
                         java {
-                            srcDirs = [project.layout.buildDirectory.dir(JspCompile2Java.CLASSES_DIR).get().asFile.getPath()]
+                            srcDirs = [BuildUtils.getBuildDirFile(project, JspCompile2Java.CLASSES_DIR).getPath()]
                         }
                     }
                 }
@@ -167,7 +167,7 @@ class Jsp implements Plugin<Project>
 
         project.tasks.register('jsp2Java', JspCompile2Java) {
            JspCompile2Java task ->
-               task.webappDirectory = project.layout.buildDirectory.dir(WEBAPP_DIR).get().asFile
+               task.webappDirectory = BuildUtils.getBuildDirFile(project, WEBAPP_DIR)
                task.group = GroupNames.JSP
                task.description = "compile jsp files into Java classes"
 

--- a/src/main/groovy/org/labkey/gradle/plugin/Jsp.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Jsp.groovy
@@ -73,7 +73,7 @@ class Jsp implements Plugin<Project>
                 {
                     jsp {
                         java {
-                            srcDirs = ["${project.buildDir}/${JspCompile2Java.CLASSES_DIR}"]
+                            srcDirs = [project.layout.buildDirectory.dir(JspCompile2Java.CLASSES_DIR).get().asFile.getPath()]
                         }
                     }
                 }
@@ -125,11 +125,11 @@ class Jsp implements Plugin<Project>
                         task.description = "Copy jsp files to jsp compile directory"
                         task.configure({ CopySpec copy ->
                             copy.from 'src'
-                            copy.into "${project.buildDir}/${WEBAPP_DIR}"
+                            copy.into project.layout.buildDirectory.file(WEBAPP_DIR)
                             copy.include '**/*.jsp'
                         })
                         task.doFirst {
-                            project.delete "${project.buildDir}/${WEBAPP_DIR}/org"
+                            project.delete project.layout.buildDirectory.file("${WEBAPP_DIR}/org")
                         }
                 }
 
@@ -149,7 +149,7 @@ class Jsp implements Plugin<Project>
                         task.doLast {
                             project.copySpec({ CopySpec copy ->
                                 copy.from 'resources'
-                                copy.into "${project.buildDir}/${WEBAPP_DIR}/org/labkey/${project.name}"
+                                copy.into project.layout.buildDirectory.file("${WEBAPP_DIR}/org/labkey/${project.name}")
                                 copy.include '**/*.jsp'
                                 copy.setDuplicatesStrategy(DuplicatesStrategy.INCLUDE)
                             })
@@ -167,7 +167,7 @@ class Jsp implements Plugin<Project>
 
         project.tasks.register('jsp2Java', JspCompile2Java) {
            JspCompile2Java task ->
-               task.webappDirectory = new File("${project.buildDir}/${WEBAPP_DIR}")
+               task.webappDirectory = project.layout.buildDirectory.dir(WEBAPP_DIR).get().asFile
                task.group = GroupNames.JSP
                task.description = "compile jsp files into Java classes"
 
@@ -221,7 +221,7 @@ class Jsp implements Plugin<Project>
                         // 'path.replace' leaves some empty directories
                         copy.setIncludeEmptyDirs false
                     }
-                    copy.into "${project.buildDir}/${WEBAPP_DIR}"
+                    copy.into project.layout.buildDirectory.dir(WEBAPP_DIR)
                     copy.include "${prefix}WEB-INF/web.xml"
                     copy.include "${prefix}WEB-INF/*.tld"
                     copy.include "${prefix}WEB-INF/*.jspf"

--- a/src/main/groovy/org/labkey/gradle/plugin/LabKey.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/LabKey.groovy
@@ -45,9 +45,9 @@ class LabKey implements Plugin<Project>
         project.version = BuildUtils.getVersionNumber(project)
         project.subprojects { Project subproject ->
             if (ModuleFinder.isDistributionProject(subproject))
-                subproject.buildDir = "${project.rootProject.buildDir}/installer/${subproject.name}"
+                subproject.layout.buildDirectory = project.rootProject.layout.buildDirectory.file("installer/${subproject.name}")
             else
-                subproject.buildDir = "${project.rootProject.buildDir}/modules/${subproject.name}"
+                subproject.layout.buildDirectory = project.rootProject.layout.buildDirectory.file("modules/${subproject.name}")
         }
 
         addConfigurations(project)

--- a/src/main/groovy/org/labkey/gradle/plugin/MultiGit.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/MultiGit.groovy
@@ -171,7 +171,7 @@ class MultiGit implements Plugin<Project>
 
             private Type(topic, enlistmentProject)
             {
-                this.topic = topic;
+                this.topic = topic
                 this.enlistmentProject = enlistmentProject
             }
         }
@@ -368,7 +368,7 @@ class MultiGit implements Plugin<Project>
 
         private Grgit getGit()
         {
-            File enlistmentDir = getEnlistmentDir();
+            File enlistmentDir = getEnlistmentDir()
 
             if (enlistmentDir.exists())
             {
@@ -489,7 +489,7 @@ class MultiGit implements Plugin<Project>
                 })
             }
 
-            return moduleNames;
+            return moduleNames
         }
 
         Project getProject()
@@ -524,8 +524,8 @@ class MultiGit implements Plugin<Project>
 
         Branch getCurrentBranch()
         {
-            Grgit git = getGit();
-            return git != null ?  git.branch.current : null
+            Grgit git = getGit()
+            return git != null ?  git.branch.current() : null
         }
 
         String toString()
@@ -663,7 +663,7 @@ class MultiGit implements Plugin<Project>
 
         private static String getAuthorizationToken()
         {
-            return System.getenv('GIT_ACCESS_TOKEN');
+            return System.getenv('GIT_ACCESS_TOKEN')
         }
 
         private String getQueryString(String filterString = "")
@@ -763,7 +763,7 @@ class MultiGit implements Plugin<Project>
                     names.push(((String) topicMap.get('name')).toLowerCase())
                 }
             }
-            return names;
+            return names
         }
 
         private void setLicenseInfo(Repository repository, Map<String, Object> node)
@@ -825,12 +825,12 @@ class MultiGit implements Plugin<Project>
             {
                 project.logger.info("getAllRepositories - includeArchived: ${includeArchived}, filterString: '${filterString}'")
                 Map<String, Object> rawData = makeRequest(project, getSearchString(filterString, endCursor))
-                Map<String, Object> pageInfo = getMap(rawData, ['data', 'search', 'pageInfo']);
+                Map<String, Object> pageInfo = getMap(rawData, ['data', 'search', 'pageInfo'])
                 hasNextPage = (Boolean) pageInfo.get('hasNextPage')
                 endCursor = (String) pageInfo.get('endCursor')
                 project.logger.info("hasNextPage ${hasNextPage} endCursor ${endCursor}")
 
-                List<Map<String, Object>> searchResults = getMapList(rawData, ['data', 'search'], "edges");
+                List<Map<String, Object>> searchResults = getMapList(rawData, ['data', 'search'], "edges")
                 for (Map<String, Object> nodeMap: searchResults)
                 {
                     Map<String, Object> node = (Map<String, Object>) nodeMap.get('node')
@@ -850,7 +850,7 @@ class MultiGit implements Plugin<Project>
                     repositories.put(repository.getName(), repository)
                 }
             }
-            return repositories;
+            return repositories
         }
 
         Map<String, Repository> execute() throws IOException
@@ -875,12 +875,12 @@ class MultiGit implements Plugin<Project>
 
         private static Map<String, Object> makeRequest(Project project, String queryString) throws IOException
         {
-            CloseableHttpClient httpClient = HttpClients.createDefault();
+            CloseableHttpClient httpClient = HttpClients.createDefault()
             Map<String, Object> rawData
             project.logger.info("Making request with queryString '${queryString}'")
             try
             {
-                HttpPost httpPost = new HttpPost(GITHUB_GRAPHQL_ENDPOINT);
+                HttpPost httpPost = new HttpPost(GITHUB_GRAPHQL_ENDPOINT)
                 httpPost.setHeader("Authorization", "Bearer " + getAuthorizationToken())
 
                 Map<String, String> requestObject = new HashMap<>()
@@ -898,11 +898,11 @@ class MultiGit implements Plugin<Project>
                 }
                 catch (Exception re)
                 {
-                    throw new GradleException("Problem retrieving response from query '${queryString}'", re);
+                    throw new GradleException("Problem retrieving response from query '${queryString}'", re)
                 }
                 finally
                 {
-                    response.close();
+                    response.close()
                 }
             }
             catch (Exception e)
@@ -922,13 +922,13 @@ class MultiGit implements Plugin<Project>
         }
     }
 
-    private Project project;
+    private Project project
 
     @Override
     void apply(Project project)
     {
         this.project = project
-        addTasks(project);
+        addTasks(project)
     }
 
     private static Map<String, Object> getMap(Map<String, Object> data, List<String> path)
@@ -937,9 +937,9 @@ class MultiGit implements Plugin<Project>
 
         for (String step: path)
         {
-            current = (Map<String, Object>) current.get(step);
+            current = (Map<String, Object>) current.get(step)
         }
-        return current;
+        return current
     }
 
     private static List<Map<String, Object>> getMapList(Map<String, Object> response, List<String> path, String finalKey)
@@ -974,7 +974,7 @@ class MultiGit implements Plugin<Project>
                 }
         })
 
-        return baseRepos;
+        return baseRepos
     }
 
     void addTasks(Project project)
@@ -1165,7 +1165,7 @@ class MultiGit implements Plugin<Project>
                             if (repository.enlistmentDir.exists() && (project.hasProperty(RepositoryQuery.TOPICS_PROPERTY) || repository.project != null))
                             {
                                 project.logger.quiet("Pulling for ${repository.enlistmentDir} ")
-                                Grgit grgit = repository.getGit();
+                                Grgit grgit = repository.getGit()
                                 try
                                 {
                                     grgit.pull(rebase: project.hasProperty('gitRebase'))

--- a/src/main/groovy/org/labkey/gradle/plugin/NpmRun.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/NpmRun.groovy
@@ -231,7 +231,7 @@ class NpmRun implements Plugin<Project>
                         if (p.getPlugins().hasPlugin(NpmRun.class))
                             nodeProjects.add("${p.path} (${useYarn(p) ? 'yarn' : 'npm'})")
                     })
-                    if (nodeProjects.size == 0)
+                    if (nodeProjects.size() == 0)
                         println("No projects found containing ${NPM_PROJECT_FILE}")
                     else {
                         println("The following projects use Node in their builds:\n\t${nodeProjects.join("\n\t")}\n")

--- a/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
@@ -513,7 +513,7 @@ class ServerDeploy implements Plugin<Project>
 
         Path pmLinkPath = Paths.get("${linkContainer.getPath()}/${packageMgr}")
         String pmDirName = "${packageMgr}-v${version}"
-        Path pmTargetPath = Paths.get(pmLinkProject.layout.buildDirectory.file("${workDirectory}/${pmDirName}").get().asFile.getPath())
+        Path pmTargetPath = Paths.get(BuildUtils.getBuildDirFile(pmLinkProject, "${workDirectory}/${pmDirName}").getPath())
 
         if (!Files.isSymbolicLink(pmLinkPath) || !Files.readSymbolicLink(pmLinkPath).getFileName().toString().equals(pmDirName))
         {
@@ -528,7 +528,7 @@ class ServerDeploy implements Plugin<Project>
         Path nodeLinkPath = Paths.get("${linkContainer.getPath()}/node")
         if (!Files.isSymbolicLink(nodeLinkPath) || !Files.readSymbolicLink(nodeLinkPath).getFileName().toString().startsWith(nodeFilePrefix))
         {
-            File nodeDir = project.layout.buildDirectory.file(project.nodeWorkDirectory).get().asFile
+            File nodeDir = BuildUtils.getBuildDirFile(project, project.nodeWorkDirectory)
             File[] nodeFiles = nodeDir.listFiles({ File file -> file.name.startsWith(nodeFilePrefix) } as FileFilter)
             if (nodeFiles != null && nodeFiles.length > 0)
             {

--- a/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
@@ -16,6 +16,7 @@
 package org.labkey.gradle.plugin
 
 import org.apache.commons.lang3.SystemUtils
+import org.gradle.api.UnknownTaskException
 import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.DefaultTask
 import org.gradle.api.Plugin
@@ -390,8 +391,13 @@ class ServerDeploy implements Plugin<Project>
                     String[] projectsMissingTasks = []
                     project.subprojects({
                         Project sub ->
-                            if (sub.file("module.properties").exists() && sub.tasks.findByName("module") == null)
-                                projectsMissingTasks += sub.path
+                            if (sub.file("module.properties").exists()) {
+                                try {
+                                    sub.tasks.named("module")
+                                } catch (UnknownTaskException ignore) {
+                                    projectsMissingTasks += sub.path
+                                }
+                            }
                     })
                     if (projectsMissingTasks.length > 0)
                         project.logger.quiet("Each of the following projects has a 'module.properties' file but no 'module' task. " +
@@ -502,7 +508,7 @@ class ServerDeploy implements Plugin<Project>
                 }
     }
 
-    private linkBinaries(Project project, String packageMgr, String version, workDirectory) {
+    private static linkBinaries(Project project, String packageMgr, String version, workDirectory) {
 
         Project pmLinkProject = project.findProject(BuildUtils.getNodeBinProjectPath(project.gradle))
         if (pmLinkProject == null)

--- a/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
@@ -252,7 +252,7 @@ class ServerDeploy implements Plugin<Project>
                 doLast {
                     project.copy {
                         CopySpec copy ->
-                            copy.from new File(embeddedProject.buildDir, "libs")
+                            copy.from embeddedProject.layout.buildDirectory.file( "libs")
                             copy.into project.serverDeploy.embeddedDir
                             copy.setDuplicatesStrategy(DuplicatesStrategy.INCLUDE)
                     }
@@ -348,9 +348,9 @@ class ServerDeploy implements Plugin<Project>
         project.tasks.register("cleanBuild", Delete) {
             Delete task ->
                 task.group = GroupNames.DEPLOY
-                task.description = "Remove the build directory ${project.rootProject.buildDir}"
+                task.description = "Remove the build directory ${project.rootProject.layout.buildDirectory}"
                 task.configure({ DeleteSpec spec ->
-                    spec.delete project.rootProject.buildDir
+                    spec.delete project.rootProject.layout.buildDirectory
                 })
         }
         project.tasks.named('deployApp').configure {mustRunAfter(project.tasks.cleanBuild)}
@@ -513,7 +513,7 @@ class ServerDeploy implements Plugin<Project>
 
         Path pmLinkPath = Paths.get("${linkContainer.getPath()}/${packageMgr}")
         String pmDirName = "${packageMgr}-v${version}"
-        Path pmTargetPath = Paths.get("${pmLinkProject.buildDir}/${workDirectory}/${pmDirName}")
+        Path pmTargetPath = Paths.get(pmLinkProject.layout.buildDirectory.file("${workDirectory}/${pmDirName}").get().asFile.getPath())
 
         if (!Files.isSymbolicLink(pmLinkPath) || !Files.readSymbolicLink(pmLinkPath).getFileName().toString().equals(pmDirName))
         {
@@ -528,7 +528,7 @@ class ServerDeploy implements Plugin<Project>
         Path nodeLinkPath = Paths.get("${linkContainer.getPath()}/node")
         if (!Files.isSymbolicLink(nodeLinkPath) || !Files.readSymbolicLink(nodeLinkPath).getFileName().toString().startsWith(nodeFilePrefix))
         {
-            File nodeDir = new File("${pmLinkProject.buildDir}/${project.nodeWorkDirectory}")
+            File nodeDir = project.layout.buildDirectory.file(project.nodeWorkDirectory).get().asFile
             File[] nodeFiles = nodeDir.listFiles({ File file -> file.name.startsWith(nodeFilePrefix) } as FileFilter)
             if (nodeFiles != null && nodeFiles.length > 0)
             {

--- a/src/main/groovy/org/labkey/gradle/plugin/SpringConfig.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/SpringConfig.groovy
@@ -17,6 +17,9 @@ package org.labkey.gradle.plugin
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.UnknownTaskException
+import org.gradle.api.provider.Provider
 import org.labkey.gradle.util.BuildUtils
 
 /**
@@ -69,10 +72,14 @@ class SpringConfig implements Plugin<Project>
                     depProjectConfig: 'apiJarFile',
                     transitive: false
             )
-            if (project.tasks.findByName("jar") != null)
-                project.dependencies.add("springImplementation", project.tasks.jar.outputs.files)
-            if (project.tasks.findByName("apiJar") != null)
-                project.dependencies.add("springImplementation", project.tasks.apiJar.outputs.files)
+            try {
+                Provider<Task> jarTask = project.tasks.named("jar")
+                project.dependencies.add("springImplementation", jarTask.get().outputs.files)
+            } catch (UnknownTaskException ignore) {}
+            try {
+                Provider<Task> jarTask = project.tasks.named("apiJar")
+                project.dependencies.add("springImplementation", jarTask.get().outputs.files)
+            } catch (UnknownTaskException ignore) {}
         }
     }
 }

--- a/src/main/groovy/org/labkey/gradle/plugin/SpringConfig.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/SpringConfig.groovy
@@ -17,10 +17,8 @@ package org.labkey.gradle.plugin
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.Task
-import org.gradle.api.UnknownTaskException
-import org.gradle.api.provider.Provider
 import org.labkey.gradle.util.BuildUtils
+import org.labkey.gradle.util.TaskUtils
 
 /**
  * Used for copying the Spring config files to the module's build directory.
@@ -72,14 +70,12 @@ class SpringConfig implements Plugin<Project>
                     depProjectConfig: 'apiJarFile',
                     transitive: false
             )
-            try {
-                Provider<Task> jarTask = project.tasks.named("jar")
+            TaskUtils.doIfTaskPresent(project, "jar", (jarTask) -> {
                 project.dependencies.add("springImplementation", jarTask.get().outputs.files)
-            } catch (UnknownTaskException ignore) {}
-            try {
-                Provider<Task> jarTask = project.tasks.named("apiJar")
-                project.dependencies.add("springImplementation", jarTask.get().outputs.files)
-            } catch (UnknownTaskException ignore) {}
+            })
+            TaskUtils.doIfTaskPresent(project, "apiJar", (apiJarTask) -> {
+                project.dependencies.add("springImplementation", apiJarTask.get().outputs.files)
+            })
         }
     }
 }

--- a/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
@@ -23,6 +23,8 @@ import org.apache.commons.lang3.SystemUtils
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.UnknownTaskException
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.process.JavaExecSpec
@@ -186,10 +188,11 @@ class TeamCity extends Tomcat
             String shortType = properties.shortType
             if (shortType == null || shortType.isEmpty())
                 continue
+            Provider<Task> pickDbTask
             String pickDbTaskName = "pick${shortType.capitalize()}"
-            Task pickDbTask = project.tasks.findByName(pickDbTaskName)
-            if (pickDbTask == null)
-            {
+            try {
+                pickDbTask = project.tasks.named(pickDbTaskName)
+            } catch (UnknownTaskException ignore) {
                 project.tasks.register(pickDbTaskName, PickDb) {
                     PickDb task ->
                         task.group = GroupNames.TEST_SERVER
@@ -197,7 +200,7 @@ class TeamCity extends Tomcat
                         task.dbType = "${shortType}"
                         task.dbPropertiesChanged = true
                 }
-                pickDbTask = project.tasks.getByName(pickDbTaskName)
+                pickDbTask = project.tasks.named(pickDbTaskName)
             }
 
             String suffix = properties.dbTypeAndVersion.capitalize()
@@ -219,9 +222,10 @@ class TeamCity extends Tomcat
             // ones that are not supported.  But, undeployModule currently knows nothing about the build/deploy/embedded
             // directory, so that needs to be updated as well.
             String undeployTaskName = "undeployModulesNotFor${properties.shortType.capitalize()}"
-            Task undeployTask = project.tasks.findByName(undeployTaskName)
-            if (undeployTask == null)
-            {
+            Provider<Task> undeployTask
+            try {
+                undeployTask = project.tasks.named(undeployTaskName)
+            } catch (UnknownTaskException ignore) {
                 project.tasks.register(undeployTaskName, UndeployModules) {
                     UndeployModules task ->
                         task.group = GroupNames.DEPLOY
@@ -231,9 +235,9 @@ class TeamCity extends Tomcat
                         task.mustRunAfter(BuildUtils.getServerProject(project).tasks.pickPg)
                 }
             }
-            TaskProvider undeployTaskProvider = project.tasks.named(undeployTaskName)
+            undeployTask = project.tasks.named(undeployTaskName)
             project.tasks.named("startTomcat").configure {
-                mustRunAfter(undeployTaskProvider)
+                mustRunAfter(undeployTask)
             }
 
             project.project(BuildUtils.getTestProjectPath(project.gradle)).tasks.startTomcat.mustRunAfter(setUpDbTask)
@@ -263,7 +267,7 @@ class TeamCity extends Tomcat
                     task.description = "Generate server properties file to run with modules from a specified distribution"
                     task.doLast {
                         project.logger.info("inheriting from distribution ${inheritedDistPath}")
-                        Set<String> includeModules = new HashSet<>();
+                        Set<String> includeModules = new HashSet<>()
                         project.project(inheritedDistPath).configurations.distribution.dependencies.each {
                             includeModules.add(it.getName())
                         }

--- a/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
@@ -246,7 +246,7 @@ class TeamCity extends Tomcat
                 RunTestSuite task ->
                     task.group = GroupNames.TEST_SERVER
                     task.description = "Run a test suite for ${properties.dbTypeAndVersion} on the TeamCity server"
-                    task.dependsOn(setUpDbTask, undeployTaskProvider)
+                    task.dependsOn(setUpDbTask, undeployTask)
                     task.dbProperties = properties
                     task.mustRunAfter(project.tasks.validateConfiguration)
                     task.mustRunAfter(project.tasks.cleanTestLogs)

--- a/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
@@ -50,7 +50,7 @@ class TeamCity extends Tomcat
     private static final String TEST_CONFIGS_DIR = "configs/config-test"
     private static final String NLP_CONFIG_FILE = "nlpConfig.xml"
     private static final String PIPELINE_CONFIG_FILE =  "pipelineConfig.xml"
-    private static final Duration TOMCAT_SHUTDOWN_TIMEOUT = Duration.ofSeconds(15);
+    private static final Duration TOMCAT_SHUTDOWN_TIMEOUT = Duration.ofSeconds(15)
 
     private TeamCityExtension extension
 

--- a/src/main/groovy/org/labkey/gradle/plugin/TestRunner.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/TestRunner.groovy
@@ -119,7 +119,7 @@ class TestRunner extends UiTest
         }
     }
 
-    private void addDataFileTasks(Project project)
+    private static void addDataFileTasks(Project project)
     {
         List<File> directories = new ArrayList<>()
 

--- a/src/main/groovy/org/labkey/gradle/plugin/TestRunner.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/TestRunner.groovy
@@ -131,7 +131,7 @@ class TestRunner extends UiTest
             }
         })
 
-        File sampleDataFile = new File("${project.buildDir}/sampledata.dirs")
+        File sampleDataFile = project.layout.buildDirectory.file("sampledata.dirs").get().asFile
 
         project.tasks.register("writeSampleDataFile") {
             Task task ->
@@ -180,7 +180,7 @@ class TestRunner extends UiTest
                             task.archiveBaseName.set(dir.getName())
                             task.archiveExtension.set("zip")
                             task.from dir
-                            task.destinationDirectory = new File("${project.buildDir}/chromextensions")
+                            task.destinationDirectory.set(project.layout.buildDirectory.dir("chromextensions"))
                     }
 
                     extensionsZipTasks.add(project.tasks.named(extensionTaskName))
@@ -214,7 +214,7 @@ class TestRunner extends UiTest
                 classpath: project.configurations.aspectj.asPath
             )
             ant.iajc(
-                destdir: "${project.buildDir}/classes/java/uiTest/",
+                destdir: project.layout.buildDirectory.dir("classes/java/uiTest/").get().asFile.getPath(),
                 source: project.sourceCompatibility,
                 target: project.targetCompatibility,
                 classpath: project.configurations.uiTestRuntimeClasspath.asPath,

--- a/src/main/groovy/org/labkey/gradle/plugin/TestRunner.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/TestRunner.groovy
@@ -131,7 +131,7 @@ class TestRunner extends UiTest
             }
         })
 
-        File sampleDataFile = project.layout.buildDirectory.file("sampledata.dirs").get().asFile
+        File sampleDataFile = BuildUtils.getBuildDirFile(project,"sampledata.dirs")
 
         project.tasks.register("writeSampleDataFile") {
             Task task ->
@@ -214,7 +214,7 @@ class TestRunner extends UiTest
                 classpath: project.configurations.aspectj.asPath
             )
             ant.iajc(
-                destdir: project.layout.buildDirectory.dir("classes/java/uiTest/").get().asFile.getPath(),
+                destdir: BuildUtils.getBuildDirFile(project,"classes/java/uiTest/").getPath(),
                 source: project.sourceCompatibility,
                 target: project.targetCompatibility,
                 classpath: project.configurations.uiTestRuntimeClasspath.asPath,

--- a/src/main/groovy/org/labkey/gradle/plugin/UiTest.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/UiTest.groovy
@@ -27,7 +27,7 @@ class UiTest implements Plugin<Project>
     UiTestExtension testRunnerExt
 
     public static final String TEST_SRC_DIR = "test/src"
-    public static final String TEST_RESOURCES_DIR = "test/resources";
+    public static final String TEST_RESOURCES_DIR = "test/resources"
 
     static Boolean isApplicable(Project project)
     {
@@ -72,7 +72,7 @@ class UiTest implements Plugin<Project>
         }
     }
 
-    protected void addDependencies(Project project)
+    protected static void addDependencies(Project project)
     {
         String testProjectPath = BuildUtils.getTestProjectPath(project.gradle)
 

--- a/src/main/groovy/org/labkey/gradle/plugin/XmlBeans.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/XmlBeans.groovy
@@ -96,7 +96,7 @@ class XmlBeans implements Plugin<Project>
                     task.description = "remove source and class files generated from xsd files"
                     task.configure (
                 {DeleteSpec del ->
-                            del.delete "$project.buildDir/$CLASS_DIR",
+                            del.delete project.layout.buildDirectory.dir(CLASS_DIR),
                                          "$project.labkey.srcGenDir/$CLASS_DIR"
                         }
                     )

--- a/src/main/groovy/org/labkey/gradle/plugin/XsdDoc.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/XsdDoc.groovy
@@ -19,6 +19,8 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.file.Directory
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.bundling.Zip
 import org.labkey.gradle.plugin.extension.XsdDocExtension
 import org.labkey.gradle.task.CreateXsdDocs
@@ -26,14 +28,14 @@ import org.labkey.gradle.util.GroupNames
 
 class XsdDoc implements Plugin<Project>
 {
-    static File getClientDocsBuildDir(Project project)
+    static Provider<Directory> getClientDocsBuildDir(Project project)
     {
-        return new File("${project.rootProject.buildDir}/client-api")
+        return project.rootProject.layout.buildDirectory.dir("client-api")
     }
 
-    static File getXsdDocDirectory(Project project)
+    static Directory getXsdDocDirectory(Project project)
     {
-        return new File(getClientDocsBuildDir(project), "xml-schemas")
+        return getClientDocsBuildDir(project).get().dir( "xml-schemas")
     }
 
     @Override
@@ -67,7 +69,7 @@ class XsdDoc implements Plugin<Project>
                 task.archiveVersion.set(project.getVersion().toString())
                 task.archiveExtension.set("zip")
                 task.from project.tasks.xsddoc
-                task.destinationDirectory = getXsdDocDirectory(project)
+                task.destinationDirectory.set(getXsdDocDirectory(project))
                 task.dependsOn(project.tasks.xsddoc)
         }
 

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/JsDocExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/JsDocExtension.groovy
@@ -17,10 +17,7 @@ package org.labkey.gradle.plugin.extension
 
 class JsDocExtension
 {
-    // TODO does this need to be here? Replace with Provider in JsDoc plugin?
     String root
-    // TODO perhaps can configure differently to eliminate the extension.
     String[] paths = []
-    // TODO does this need to be here? Replace with Provider in JsDoc plugin?
     File outputDir
 }

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/JsDocExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/JsDocExtension.groovy
@@ -17,7 +17,10 @@ package org.labkey.gradle.plugin.extension
 
 class JsDocExtension
 {
+    // TODO does this need to be here? Replace with Provider in JsDoc plugin?
     String root
+    // TODO perhaps can configure differently to eliminate the extension.
     String[] paths = []
+    // TODO does this need to be here? Replace with Provider in JsDoc plugin?
     File outputDir
 }

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/LabKeyExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/LabKeyExtension.groovy
@@ -16,6 +16,7 @@
 package org.labkey.gradle.plugin.extension
 
 import org.gradle.api.Project
+import org.labkey.gradle.util.BuildUtils
 
 /**
  * Created by susanh on 4/23/17.
@@ -77,11 +78,11 @@ class LabKeyExtension
 
     void setDirectories(Project project)
     {
-        explodedModuleDir = project.layout.buildDirectory.file("explodedModule").get().asFile.getPath()
+        explodedModuleDir = BuildUtils.getBuildDirFile(project,"explodedModule").getPath()
         explodedModuleWebDir = "${explodedModuleDir}/web"
         explodedModuleConfigDir = "${explodedModuleDir}/config"
         explodedModuleLibDir = "${explodedModuleDir}/lib"
-        srcGenDir = project.layout.buildDirectory.file("gensrc").get().asFile.getPath()
+        srcGenDir = BuildUtils.getBuildDirFile(project,"gensrc").getPath()
 
         externalDir = "${project.rootDir}/external"
     }

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/LabKeyExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/LabKeyExtension.groovy
@@ -77,11 +77,11 @@ class LabKeyExtension
 
     void setDirectories(Project project)
     {
-        explodedModuleDir = "${project.buildDir}/explodedModule"
+        explodedModuleDir = project.layout.buildDirectory.file("explodedModule").get().asFile.getPath()
         explodedModuleWebDir = "${explodedModuleDir}/web"
         explodedModuleConfigDir = "${explodedModuleDir}/config"
         explodedModuleLibDir = "${explodedModuleDir}/lib"
-        srcGenDir = "${project.buildDir}/gensrc"
+        srcGenDir = project.layout.buildDirectory.file("gensrc").get().asFile.getPath()
 
         externalDir = "${project.rootDir}/external"
     }

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/ModuleExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/ModuleExtension.groovy
@@ -142,7 +142,7 @@ class ModuleExtension
         modProperties.setProperty("BuildUser", System.getProperty("user.name"))
         modProperties.setProperty("BuildOS", System.getProperty("os.name"))
         modProperties.setProperty("BuildTime", SimpleDateFormat.getDateTimeInstance().format(new Date()))
-        modProperties.setProperty("BuildPath", project.layout.buildDirectory.get().asFile.getAbsolutePath())
+        modProperties.setProperty("BuildPath", BuildUtils.getBuildDir(project).getAbsolutePath())
         modProperties.setProperty("SourcePath", project.projectDir.getAbsolutePath())
         modProperties.setProperty("ResourcePath", "") // TODO  _project.getResources().... ???
         modProperties.setProperty("ReleaseVersion", (String) project.getProperty("labkeyVersion"))

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/ModuleExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/ModuleExtension.groovy
@@ -142,7 +142,7 @@ class ModuleExtension
         modProperties.setProperty("BuildUser", System.getProperty("user.name"))
         modProperties.setProperty("BuildOS", System.getProperty("os.name"))
         modProperties.setProperty("BuildTime", SimpleDateFormat.getDateTimeInstance().format(new Date()))
-        modProperties.setProperty("BuildPath", project.buildDir.getAbsolutePath())
+        modProperties.setProperty("BuildPath", project.layout.buildDirectory.get().asFile.getAbsolutePath())
         modProperties.setProperty("SourcePath", project.projectDir.getAbsolutePath())
         modProperties.setProperty("ResourcePath", "") // TODO  _project.getResources().... ???
         modProperties.setProperty("ReleaseVersion", (String) project.getProperty("labkeyVersion"))

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/ModuleExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/ModuleExtension.groovy
@@ -43,7 +43,7 @@ class ModuleExtension
 
     ModuleExtension(Project project)
     {
-        this(project, true);
+        this(project, true)
     }
 
     Project getProject()
@@ -85,7 +85,7 @@ class ModuleExtension
         if (propertiesFile.exists()) {
             PropertiesUtils.readProperties(propertiesFile, this.modProperties)
             if (logDeprecations) {
-                List<String> deprecationMsgs = [];
+                List<String> deprecationMsgs = []
                 if (this.modProperties.get(MODULE_DEPENDENCIES_PROPERTY))
                     deprecationMsgs += "The '" + MODULE_DEPENDENCIES_PROPERTY + "' property is no longer supported as of gradlePlugin version 1.25.0 (LabKey Server version 21.3.0)." +
                             " Declare the dependency in the module's build.gradle file instead using the 'modules' configuration." +
@@ -181,6 +181,6 @@ class ModuleExtension
 
     Map<String, ExternalDependency> getExternalDependencies()
     {
-        return externalDependencies;
+        return externalDependencies
     }
 }

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/ServerDeployExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/ServerDeployExtension.groovy
@@ -16,6 +16,7 @@
 package org.labkey.gradle.plugin.extension
 
 import org.gradle.api.Project
+import org.labkey.gradle.util.BuildUtils
 
 class ServerDeployExtension
 {
@@ -29,7 +30,7 @@ class ServerDeployExtension
 
     static String getServerDeployDirectory(Project project)
     {
-        return "${project.rootProject.buildDir}/deploy"
+        return BuildUtils.getRootBuildDirFile(project, "deploy").path
     }
 
     static String getEmbeddedServerDeployDirectory(Project project)

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/StagingExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/StagingExtension.groovy
@@ -16,6 +16,7 @@
 package org.labkey.gradle.plugin.extension
 
 import org.gradle.api.Project
+import org.labkey.gradle.util.BuildUtils
 
 class StagingExtension
 {
@@ -35,12 +36,13 @@ class StagingExtension
 
     void setDirectories(Project project)
     {
-        dir = "${project.rootProject.buildDir}/${STAGING_DIR}"
-        webappClassesDir = "${project.rootProject.buildDir}/${STAGING_WEBINF_DIR}/classes"
-        jspDir = "${project.rootProject.buildDir}/${STAGING_WEBINF_DIR}/jsp"
-        webInfDir = "${project.rootProject.buildDir}/${STAGING_WEBINF_DIR}"
-        webappDir = "${project.rootProject.buildDir}/${STAGING_WEBAPP_DIR}"
-        modulesDir = "${project.rootProject.buildDir}/${STAGING_MODULES_DIR}"
+        String buildDirPath = BuildUtils.getRootBuildDirPath(project)
+        dir = "${buildDirPath}/${STAGING_DIR}"
+        webappClassesDir = "${buildDirPath}/${STAGING_WEBINF_DIR}/classes"
+        jspDir = "${buildDirPath}/${STAGING_WEBINF_DIR}/jsp"
+        webInfDir = "${buildDirPath}/${STAGING_WEBINF_DIR}"
+        webappDir = "${buildDirPath}/${STAGING_WEBAPP_DIR}"
+        modulesDir = "${buildDirPath}/${STAGING_MODULES_DIR}"
         tomcatLibDir = "${dir}/tomcat-lib" // Note: Keep this path in sync with AdminController.getTomcatJars()
         pipelineLibDir = "${dir}/pipelineLib"
     }

--- a/src/main/groovy/org/labkey/gradle/task/CheckForVersionConflicts.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/CheckForVersionConflicts.groovy
@@ -70,7 +70,7 @@ class CheckForVersionConflicts  extends DefaultTask
         File[] existingFiles = directory.listFiles(new FilenameFilter() {
             @Override
             boolean accept(File dir, String name) {
-                return extension == null || name.endsWith(extension);
+                return extension == null || name.endsWith(extension)
             }
         })
         for (File dFile: existingFiles) {
@@ -111,10 +111,10 @@ class CheckForVersionConflicts  extends DefaultTask
                     if (version != null)
                         version = version.substring(1)
                     this.logger.debug("Checking name (with classifier): ${name} and version ${version}")
-                    String existingVersion = nameVersionMap.get(name).first
+                    String existingVersion = nameVersionMap.get(name).v1
                     if (existingVersion != version)
                     {
-                        existingFilesInConflict.add(nameVersionMap.get(name).second)
+                        existingFilesInConflict.add(nameVersionMap.get(name).v2)
                         conflictMessages += "Conflicting version of ${matcher.group(BuildUtils.ARTIFACT_NAME_INDEX)} ${extension} file (${existingVersion} in directory vs. ${version} from build)."
                     }
                 }

--- a/src/main/groovy/org/labkey/gradle/task/ClientLibsCompress.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ClientLibsCompress.groovy
@@ -68,7 +68,7 @@ class ClientLibsCompress extends DefaultTask
             File file ->
                 importerMap.put(file, parseXmlFile(getSourceDir(file), file))
         }
-        return importerMap;
+        return importerMap
     }
 
     static File getMinificationDir(Project project)
@@ -79,10 +79,10 @@ class ClientLibsCompress extends DefaultTask
 
     static File getSourceDir(File libXmlFile)
     {
-        String absolutePath = libXmlFile.getAbsolutePath();
+        String absolutePath = libXmlFile.getAbsolutePath()
         int endIndex = absolutePath.lastIndexOf("webapp${File.separator}")
         if (endIndex >= 0)
-            endIndex += 6;
+            endIndex += 6
         else
         {
             endIndex = absolutePath.lastIndexOf("web${File.separator}")
@@ -178,7 +178,7 @@ class ClientLibsCompress extends DefaultTask
     void compressAllFiles()
     {
         FileTree libXmlFiles = xmlFiles
-        Map<File, XmlImporter> importerMap = getImporterMap();
+        Map<File, XmlImporter> importerMap = getImporterMap()
         libXmlFiles.files.each() {
             File file -> compressSingleFile(file, importerMap.get(file))
         }
@@ -196,7 +196,7 @@ class ClientLibsCompress extends DefaultTask
         }
         else
         {
-            this.logger.info("No compile necessary for ${xmlFile}");
+            this.logger.info("No compile necessary for ${xmlFile}")
         }
     }
 
@@ -216,7 +216,7 @@ class ClientLibsCompress extends DefaultTask
         }
         catch (Exception e)
         {
-            throw new RuntimeException(e);
+            throw new RuntimeException(e)
         }
     }
 
@@ -366,7 +366,7 @@ class ClientLibsCompress extends DefaultTask
     File concatenateFilesForNpm(File xmlFile, Set<File> srcFiles, String extension)
     {
         if (srcFiles.isEmpty())
-            return null;
+            return null
 
 
         File concatFile = new File(getMinificationWorkingDir(xmlFile), getNewExtensionFileName(xmlFile, null, extension))
@@ -379,7 +379,7 @@ class ClientLibsCompress extends DefaultTask
     {
         if (!LabKeyExtension.isDevMode(project))
         {
-            this.logger.info("Compressing " + file);
+            this.logger.info("Compressing " + file)
             project.ant.gzip(
                     src: file,
                     destfile: "${file}.gz"
@@ -397,18 +397,18 @@ class ClientLibsCompress extends DefaultTask
 
     static File getOutputFile(File xmlFile, String token, String ex)
     {
-        return new File(xmlFile.getParentFile(), getNewExtensionFileName(xmlFile, token, ex));
+        return new File(xmlFile.getParentFile(), getNewExtensionFileName(xmlFile, token, ex))
     }
 
     private static void concatenateFiles(Set<File> files, File output)
     {
         try
         {
-            output.createNewFile();
+            output.createNewFile()
         }
         catch (IOException e)
         {
-            throw new RuntimeException(e);
+            throw new RuntimeException(e)
         }
 
         PrintWriter saveAs = null
@@ -423,12 +423,12 @@ class ClientLibsCompress extends DefaultTask
                 {
                     readBuff = new BufferedReader(new InputStreamReader(new FileInputStream(f), StandardCharsets.UTF_8))
 
-                    String line = readBuff.readLine();
+                    String line = readBuff.readLine()
 
                     while (line != null)
                     {
-                        saveAs.println(line);
-                        line = readBuff.readLine();
+                        saveAs.println(line)
+                        line = readBuff.readLine()
                     }
                 }
                 finally
@@ -495,23 +495,23 @@ class ClientLibsCompress extends DefaultTask
             {
                 if (attributes.getValue("compileInProductionMode") != null)
                 {
-                    doCompile = Boolean.parseBoolean(attributes.getValue("compileInProductionMode"));
+                    doCompile = Boolean.parseBoolean(attributes.getValue("compileInProductionMode"))
                 }
-                withinScriptsTag = true;
+                withinScriptsTag = true
             }
             if (withinScriptsTag && "script".equals(localName))
             {
-                String path = attributes.getValue("path");
-                File scriptFile = new File(sourceDir, path);
+                String path = attributes.getValue("path")
+                File scriptFile = new File(sourceDir, path)
                 if (!scriptFile.exists())
                 {
                     if (isExternalScript(path))
                     {
-                        throw new RuntimeException("ERROR: External scripts (e.g. https://.../script.js) cannot be declared in library definition. Consider making it a <dependency>.");
+                        throw new RuntimeException("ERROR: External scripts (e.g. https://.../script.js) cannot be declared in library definition. Consider making it a <dependency>.")
                     }
                     else
                     {
-                        throw new RuntimeException("ERROR: Unable to find script file: " + scriptFile + " from library: " + xmlFile);
+                        throw new RuntimeException("ERROR: Unable to find script file: " + scriptFile + " from library: " + xmlFile)
                     }
                 }
                 else
@@ -519,23 +519,23 @@ class ClientLibsCompress extends DefaultTask
                     //linux will be case-sensitive, so we proactively throw errors on any filesystem
                     try
                     {
-                        File f = FileUtils.getFileUtils().normalize(scriptFile.getPath());
+                        File f = FileUtils.getFileUtils().normalize(scriptFile.getPath())
                         if( !scriptFile.getCanonicalFile().getName().equals(f.getName()))
                         {
-                            throw new RuntimeException("File must be a case-sensitive match. Found: " + scriptFile.getAbsolutePath() + ", expected: " + scriptFile.getCanonicalPath());
+                            throw new RuntimeException("File must be a case-sensitive match. Found: " + scriptFile.getAbsolutePath() + ", expected: " + scriptFile.getCanonicalPath())
                         }
                     }
                     catch (IOException e)
                     {
-                        throw new RuntimeException(e);
+                        throw new RuntimeException(e)
                     }
 
                     if (scriptFile.getName().endsWith(".js"))
-                        javascriptFiles.add(scriptFile);
+                        javascriptFiles.add(scriptFile)
                     else if (scriptFile.getName().endsWith(".css"))
-                        cssFiles.add(scriptFile);
+                        cssFiles.add(scriptFile)
                     else
-                        this.logger.info("Unknown file extension, ignoring: " + scriptFile.getName());
+                        this.logger.info("Unknown file extension, ignoring: " + scriptFile.getName())
                 }
             }
         }
@@ -543,12 +543,12 @@ class ClientLibsCompress extends DefaultTask
         void endElement(String uri, String localName, String qName) throws SAXException
         {
             if ("library".equals(localName))
-                withinScriptsTag = false;
+                withinScriptsTag = false
         }
 
         private boolean isExternalScript(String path)
         {
-            return path != null && (path.contains("http://") || path.contains("https://"));
+            return path != null && (path.contains("http://") || path.contains("https://"))
         }
     }
 }

--- a/src/main/groovy/org/labkey/gradle/task/ConfigureLog4J.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ConfigureLog4J.groovy
@@ -33,7 +33,7 @@ class ConfigureLog4J extends DefaultTask
     String fileName
 
     private File stagingDir = new File((String) project.staging.webappClassesDir)
-    private File deployDir = new File("${project.serverDeploy.webappDir}/WEB-INF/classes");
+    private File deployDir = new File("${project.serverDeploy.webappDir}/WEB-INF/classes")
 
     @InputFile
     File getLog4jXml()

--- a/src/main/groovy/org/labkey/gradle/task/CreateModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/CreateModule.groovy
@@ -56,7 +56,7 @@ class CreateModule extends DefaultTask
         if (moduleName == null || moduleName == "") {
             throw new GradleException("moduleName is not specified")
         }
-        Pattern namePattern = Pattern.compile("[a-zA-Z][a-zA-Z_\\-\\d]*");
+        Pattern namePattern = Pattern.compile("[a-zA-Z][a-zA-Z_\\-\\d]*")
         if (!namePattern.matcher(moduleName).matches()) {
             throw new GradleException("Invalid module name: " + moduleName)
         }
@@ -133,7 +133,7 @@ class CreateModule extends DefaultTask
             throw new GradleException("Failed to create new module directory at ${moduleDestinationFile.getAbsolutePath()}")
         }
 
-        String[] versionParts = BuildUtils.getLabKeyModuleVersion(project.rootProject).split("\\.");
+        String[] versionParts = BuildUtils.getLabKeyModuleVersion(project.rootProject).split("\\.")
         String version = versionParts[0] + ".000"
         Map<String, String> substitutions = [
                 'MODULE_DIR_NAME' : moduleName.toLowerCase(),
@@ -199,7 +199,7 @@ class CreateModule extends DefaultTask
             renameCrawler(f, substitutions)
             String name = f.getName()
             substitutions.each({curr, updated ->
-                name = name.replace(curr, updated);
+                name = name.replace(curr, updated)
             })
             if (!name.equals(f.getName()))
             {

--- a/src/main/groovy/org/labkey/gradle/task/CreateXsdDocs.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/CreateXsdDocs.groovy
@@ -32,7 +32,7 @@ class CreateXsdDocs extends DefaultTask
     @OutputDirectory
     File getOutputDirectory()
     {
-        return new File(XsdDoc.getXsdDocDirectory(project), "docs")
+        return XsdDoc.getXsdDocDirectory(project).file( "docs").asFile
     }
 
     @TaskAction

--- a/src/main/groovy/org/labkey/gradle/task/DeployAppBase.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DeployAppBase.groovy
@@ -22,7 +22,7 @@ class DeployAppBase extends DefaultTask {
                     copy.from(project.configurations.binaries.collect { project.zipTree(it) })
                     copy.into deployBinDir.path
             })
-            project.logger.debug("Contents of ${deployBinDir}\n" + deployBinDir.listFiles());
+            project.logger.debug("Contents of ${deployBinDir}\n" + deployBinDir.listFiles())
         }
         // For TC builds, we deposit the artifacts of the Linux TPP Tools and Windows Proteomics Tools into
         // the external directory, so we want to copy those over as well.
@@ -87,7 +87,7 @@ class DeployAppBase extends DefaultTask {
         if (nlpSource.exists())
         {
             File nlpDir = new File(deployBinDir, "nlp")
-            nlpDir.mkdirs();
+            nlpDir.mkdirs()
             ant.copy(
                     toDir: nlpDir,
                     preserveLastModified: true

--- a/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
@@ -145,7 +145,7 @@ class DoThenSetup extends DefaultTask
                         }
                         if (project.hasProperty("useLocalBuild")) {
                             // Let properties file specify which properties require 'useLocalBuild'
-                            line = line.replace("#useLocalBuild#", "");
+                            line = line.replace("#useLocalBuild#", "")
 
                             // Old method enables specific properties for 'useLocalBuild' (before 22.6)
                             line = line.replace("#context.webAppLocation=", "context.webAppLocation=")
@@ -153,7 +153,7 @@ class DoThenSetup extends DefaultTask
                         }
                         else {
                             // Remove placeholder
-                            line = line.replace("#useLocalBuild#", "#");
+                            line = line.replace("#useLocalBuild#", "#")
                         }
                         if (configProperties.containsKey("extraJdbcDataSource"))
                         {
@@ -175,7 +175,7 @@ class DoThenSetup extends DefaultTask
      */
     private Properties getExtraJdbcProperties()
     {
-        def extraJdbcProperties = new Properties();
+        def extraJdbcProperties = new Properties()
         def tcProperties = TeamCityExtension.getTeamCityProperties(project)
         for (Map.Entry entry : tcProperties.entrySet())
         {

--- a/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
@@ -80,7 +80,7 @@ class DoThenSetup extends DefaultTask
                 File labkeyXml = BuildUtils.getWebappConfigFile(project, "labkey.xml")
                 project.copy({ CopySpec copy ->
                     copy.from labkeyXml
-                    copy.into "${project.rootProject.buildDir}"
+                    copy.into project.rootProject.layout.buildDirectory
                     copy.setDuplicatesStrategy(DuplicatesStrategy.INCLUDE)
                     copy.filter({ String line ->
                         if (project.ext.has('enableJms') && project.ext.enableJms) {
@@ -110,7 +110,7 @@ class DoThenSetup extends DefaultTask
                 })
 
                 project.copy({ CopySpec copy ->
-                    copy.from "${project.rootProject.buildDir}"
+                    copy.from project.rootProject.layout.buildDirectory
                     copy.into "${project.tomcat.tomcatConfDir}"
                     copy.include "labkey.xml"
                     copy.setDuplicatesStrategy(DuplicatesStrategy.INCLUDE)

--- a/src/main/groovy/org/labkey/gradle/task/GzipAction.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/GzipAction.groovy
@@ -25,18 +25,18 @@ import org.gradle.api.file.FileTree
  */
 class GzipAction implements Action<Task>
 {
-    String[] extraExcludes = [];
+    String[] extraExcludes = []
 
     @Override
     void execute(Task task)
     {
         FileTree tree = task.outputs.files.getAsFileTree().matching {
             include("**/*.css")
-            include("**/*.js");
-            include("**/*.html");
-            exclude("WEB-INF/**");
-            exclude("**/src/**");
-            exclude(extraExcludes);
+            include("**/*.js")
+            include("**/*.html")
+            exclude("WEB-INF/**")
+            exclude("**/src/**")
+            exclude(extraExcludes)
         }
 
         tree.each { File file ->

--- a/src/main/groovy/org/labkey/gradle/task/JspCompile2Java.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/JspCompile2Java.groovy
@@ -47,7 +47,7 @@ class JspCompile2Java extends DefaultTask
         if (!webappDirectory.exists())
         {
             project.logger.info("${webappDirectory.getAbsolutePath()}: no such file or directory.  Nothing to do here.")
-            return;
+            return
         }
 
         project.logger.info("${project.path} Compiling jsps to Java from ${webappDirectory.getAbsolutePath()}")
@@ -56,7 +56,7 @@ class JspCompile2Java extends DefaultTask
         FileUtils.listFiles(webappDirectory, extensions, true).forEach({
             File file ->
                 project.logger.info(file.getAbsolutePath())
-        });
+        })
 
         File classesDir = getClassesDirectory()
 

--- a/src/main/groovy/org/labkey/gradle/task/JspCompile2Java.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/JspCompile2Java.groovy
@@ -24,6 +24,7 @@ import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.labkey.gradle.util.BuildUtils
 
 @CacheableTask
 class JspCompile2Java extends DefaultTask
@@ -37,7 +38,7 @@ class JspCompile2Java extends DefaultTask
     @OutputDirectory
     File getClassesDirectory()
     {
-        return new File("${project.buildDir}/${CLASSES_DIR}")
+        return BuildUtils.getBuildDirFile(project, CLASSES_DIR)
     }
 
     @TaskAction

--- a/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
@@ -149,7 +149,7 @@ class ModuleDistribution extends DefaultTask
             if (!BuildUtils.isOpenSource(project) && licensingProject == null)
                 throw new GradleException("Cannot build non-open source distribution. Unable to find project with the plugin org.labkey.build.applyLicenses in ${project.path} ancestors.")
         }
-        return licensingProject;
+        return licensingProject
     }
 
     private void gatherModules()
@@ -345,7 +345,7 @@ class ModuleDistribution extends DefaultTask
     {
         if (makeDistribution)
         {
-            copyWindowsCoreUtilities();
+            copyWindowsCoreUtilities()
             def utilsDir = getWindowsUtilDir()
             StagingExtension staging = project.getExtensions().getByType(StagingExtension.class)
 
@@ -467,7 +467,7 @@ class ModuleDistribution extends DefaultTask
 
     private void embeddedTomcatZipArchive()
     {
-        copyWindowsCoreUtilities();
+        copyWindowsCoreUtilities()
         def utilsDir = getWindowsUtilDir()
 
         File serverJarFile = new File(getEmbeddedTomcatJarPath())
@@ -525,7 +525,7 @@ class ModuleDistribution extends DefaultTask
         project.ant.fixcrlf (srcdir: BuildUtils.getBuildDirPath(project), includes: "manual-upgrade.sh", eol: "unix")
     }
 
-    public static FileTree getDistributionResources(Project project) {
+    static FileTree getDistributionResources(Project project) {
         // This seems a very convoluted way to get to the zip file in the jar file.  Using the classLoader did not
         // work as expected, however.  Following the example from here:
         // https://discuss.gradle.org/t/gradle-plugin-copy-directory-tree-with-files-from-resources/12767/7

--- a/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
@@ -131,9 +131,9 @@ class ModuleDistribution extends DefaultTask
     @OutputDirectory
     File getModulesDir()
     {
-        // we use a common directory to save on disk space for TeamCity.  This mimics the behavior of the ant build.
+        // we use a common directory to save on disk space for TeamCity.
         // (This is just a conjecture about why it continues to run out of space and not be able to copy files from one place to the other).
-        return new File("${project.rootProject.buildDir}/distModules")
+        return new File("${BuildUtils.getRootBuildDirPath(project)}/distModules")
     }
 
     Project findLicensingProject()
@@ -180,12 +180,12 @@ class ModuleDistribution extends DefaultTask
     {
         if (makeDistribution)
         {
-            copyLibXml()
+            copyLabkeyXml()
         }
         packageArchives()
     }
 
-    private void copyLibXml()
+    private void copyLabkeyXml()
     {
         Properties copyProps = new Properties()
         // Pre-configure labkey.xml to work with postgresql
@@ -195,7 +195,7 @@ class ModuleDistribution extends DefaultTask
         project.copy
         { CopySpec copy ->
             copy.from(BuildUtils.getWebappConfigFile(project, "labkey.xml"))
-            copy.into(project.buildDir)
+            copy.into(project.layout.buildDirectory)
             copy.setDuplicatesStrategy(DuplicatesStrategy.INCLUDE)
             copy.filter({ String line ->
                 return PropertiesUtils.replaceProps(line, copyProps, true)
@@ -232,7 +232,7 @@ class ModuleDistribution extends DefaultTask
 
     private String getEmbeddedTomcatJarPath()
     {
-        return "${project.buildDir}/labkeyServer-${project.version}.jar"
+        return BuildUtils.getBuildDirFile(project, "labkeyServer-${project.version}.jar").path
     }
 
     private String getTarArchivePath()
@@ -311,13 +311,13 @@ class ModuleDistribution extends DefaultTask
                     tarfileset(dir: staging.pipelineLibDir, prefix: "${archiveName}/pipeline-lib")
                 }
 
-                tarfileset(dir: "${project.buildDir}/",
+                tarfileset(dir: "${BuildUtils.getBuildDirPath(project)}/",
                         prefix: archiveName,
                         mode: 744) {
                     include(name: "manual-upgrade.sh")
                 }
 
-                tarfileset(dir: project.buildDir,
+                tarfileset(dir: BuildUtils.getBuildDirPath(project),
                         prefix: archiveName) {
                     include(name: "README.txt")
                     include(name: "VERSION")
@@ -371,13 +371,13 @@ class ModuleDistribution extends DefaultTask
                     zipfileset(dir: staging.pipelineLibDir, prefix: "${archiveName}/pipeline-lib")
                 }
 
-                zipfileset(dir: "${project.buildDir}/",
+                zipfileset(dir: "${BuildUtils.getBuildDirPath(project)}/",
                         prefix: "${archiveName}",
                         filemode: 744){
                     include(name: "manual-upgrade.sh")
                 }
 
-                zipfileset(dir: "${project.buildDir}/",
+                zipfileset(dir: "${BuildUtils.getBuildDirPath(project)}/",
                         prefix: "${archiveName}") {
                     include(name: "README.txt")
                     include(name: "VERSION")
@@ -403,18 +403,18 @@ class ModuleDistribution extends DefaultTask
         StagingExtension staging = project.getExtensions().getByType(StagingExtension.class)
 
         File embeddedJarFile = project.configurations.embedded.singleFile
-        File modulesZipFile = new File(project.buildDir, "labkey/distribution.zip")
+        File modulesZipFile = BuildUtils.getBuildDirFile(project,"labkey/distribution.zip")
         File serverJarFile = new File(getEmbeddedTomcatJarPath())
         ant.zip(destFile: modulesZipFile.getAbsolutePath()) {
             zipfileset(dir: staging.webappDir,
                     prefix: "labkeywebapp") {
                 exclude(name: "WEB-INF/classes/distribution")
             }
-            zipfileset(dir: new File("${project.rootProject.buildDir}/distModules"),
+            zipfileset(dir: BuildUtils.getRootBuildDirFile(project, "distModules"),
                     prefix: "modules") {
                 include(name: "*.module")
             }
-            zipfileset(dir: "${project.buildDir}/") {
+            zipfileset(dir: "${BuildUtils.getBuildDirPath(project)}/") {
                 include(name: "labkeywebapp/**")
             }
         }
@@ -422,17 +422,17 @@ class ModuleDistribution extends DefaultTask
         project.copy {
             CopySpec copy ->
                 copy.from(embeddedJarFile)
-                copy.into(project.buildDir)
+                copy.into(project.layout.buildDirectory)
                 copy.rename(embeddedJarFile.getName(), serverJarFile.getName())
                 copy.setDuplicatesStrategy(DuplicatesStrategy.INCLUDE)
         }
 
         ant.jar(
-            destfile: new File(project.buildDir, serverJarFile.getName()),
+            destfile: BuildUtils.getBuildDirFile(project, serverJarFile.getName()),
             update: true,
             keepcompression: true
         ) {
-            fileset(dir: "${project.buildDir}", includes: "labkey/**")
+            fileset(dir: "${BuildUtils.getBuildDirPath(project)}", includes: "labkey/**")
         }
     }
 
@@ -448,17 +448,17 @@ class ModuleDistribution extends DefaultTask
         ant.tar(tarfile: getEmbeddedTarArchivePath(),
                 longfile: "gnu",
                 compression: "gzip") {
-            tarfileset(dir: project.buildDir, prefix: archiveName) { include(name: serverJarFile.getName()) }
+            tarfileset(dir: project.layout.buildDirectory, prefix: archiveName) { include(name: serverJarFile.getName()) }
 
             if (!simpleDistribution) {
                 tarfileset(dir: utilsDir.path, prefix: "${archiveName}/bin")
             }
 
-            tarfileset(dir: project.buildDir, prefix: archiveName) {
+            tarfileset(dir: project.layout.buildDirectory, prefix: archiveName) {
                 include(name: "VERSION")
             }
 
-            tarfileset(dir: new File(project.buildDir, "embedded"), prefix: archiveName) {
+            tarfileset(dir: BuildUtils.getBuildDirFile(project, "embedded"), prefix: archiveName) {
                 // include(name: "manual-upgrade.sh")
                 include(name: "README.txt")
             }
@@ -475,18 +475,18 @@ class ModuleDistribution extends DefaultTask
             makeEmbeddedTomcatJar()
 
         ant.zip(destfile: getEmbeddedZipArchivePath()) {
-            zipfileset(dir: project.buildDir, prefix: archiveName) { include(name: serverJarFile.getName()) }
+            zipfileset(dir: project.layout.buildDirectory, prefix: archiveName) { include(name: serverJarFile.getName()) }
 
             if (!simpleDistribution) {
                 zipfileset(dir: utilsDir.path, prefix: "${archiveName}/bin")
             }
 
-            zipfileset(dir: "${project.buildDir}/",
+            zipfileset(dir: "${BuildUtils.getBuildDirPath(project)}/",
                     prefix: "${archiveName}") {
                 include(name: "VERSION")
             }
 
-            zipfileset(dir: "${project.buildDir}/embedded/",
+            zipfileset(dir: "${BuildUtils.getBuildDirPath(project)}/embedded/",
                     prefix: "${archiveName}") {
                 // include(name: "manual-upgrade.sh")
                 include(name: "README.txt")
@@ -502,7 +502,7 @@ class ModuleDistribution extends DefaultTask
         project.copy({ CopySpec copy ->
             copy.from(zipFile)
             copy.exclude "*.xml"
-            copy.into(project.buildDir)
+            copy.into(project.layout.buildDirectory)
             copy.setDuplicatesStrategy(DuplicatesStrategy.INCLUDE)
         })
         // Allow distributions to include custom README
@@ -510,19 +510,19 @@ class ModuleDistribution extends DefaultTask
         if (resources.isDirectory()) {
             project.copy({ CopySpec copy ->
                 copy.from(resources)
-                copy.into(project.buildDir)
+                copy.into(project.layout.buildDirectory)
                 copy.setDuplicatesStrategy(DuplicatesStrategy.INCLUDE)
             })
             project.copy({ CopySpec copy ->
                 copy.from(resources)
-                copy.into(new File(project.buildDir, "embedded"))
+                copy.into(project.layout.buildDirectory.file("embedded"))
                 copy.setDuplicatesStrategy(DuplicatesStrategy.INCLUDE)
             })
         }
         // This is necessary for reasons that are unclear.  Without it, you get:
         // -bash: ./manual-upgrade.sh: /bin/sh^M: bad interpreter: No such file or directory
         // even though the original file has unix line endings. Dunno.
-        project.ant.fixcrlf (srcdir: project.buildDir, includes: "manual-upgrade.sh", eol: "unix")
+        project.ant.fixcrlf (srcdir: BuildUtils.getBuildDirPath(project), includes: "manual-upgrade.sh", eol: "unix")
     }
 
     public static FileTree getDistributionResources(Project project) {
@@ -540,7 +540,7 @@ class ModuleDistribution extends DefaultTask
 
     private File getDistributionFile()
     {
-        File distExtraDir = new File(project.buildDir, DistributionExtension.DIST_FILE_DIR)
+        File distExtraDir = BuildUtils.getBuildDirFile(project, DistributionExtension.DIST_FILE_DIR)
         return new File(distExtraDir,  DistributionExtension.DIST_FILE_NAME)
     }
 
@@ -552,7 +552,7 @@ class ModuleDistribution extends DefaultTask
     @OutputFile
     File getVersionFile()
     {
-        return new File(project.buildDir.absolutePath, DistributionExtension.VERSION_FILE_NAME)
+        return BuildUtils.getBuildDirFile(project, DistributionExtension.VERSION_FILE_NAME)
     }
 
     private void writeVersionFile()

--- a/src/main/groovy/org/labkey/gradle/task/PickDb.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/PickDb.groovy
@@ -42,6 +42,6 @@ class PickDb extends DoThenSetup
             }
             copy.setDuplicatesStrategy(DuplicatesStrategy.INCLUDE)
         })
-        super.doDatabaseTask();
+        super.doDatabaseTask()
     }
 }

--- a/src/main/groovy/org/labkey/gradle/task/PurgeArtifacts.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/PurgeArtifacts.groovy
@@ -36,7 +36,7 @@ class PurgeArtifacts extends DefaultTask
     @TaskAction
     void purgeVersions()
     {
-        String purgeVersion;
+        String purgeVersion
         if (!project.hasProperty(VERSION_PROPERTY))
             throw new GradleException("No value provided for ${VERSION_PROPERTY}.")
         purgeVersion = project.property(VERSION_PROPERTY)
@@ -90,7 +90,7 @@ class PurgeArtifacts extends DefaultTask
             return
         }
 
-        CloseableHttpClient httpClient = HttpClients.createDefault();
+        CloseableHttpClient httpClient = HttpClients.createDefault()
         String endpoint = project.property('artifactory_contextUrl')
         Response responseStatus = Response.SUCCESS
         if (!endpoint.endsWith("/"))

--- a/src/main/groovy/org/labkey/gradle/task/PurgeNpmAlphaVersions.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/PurgeNpmAlphaVersions.groovy
@@ -2,7 +2,6 @@ package org.labkey.gradle.task
 
 import groovy.json.JsonSlurper
 import org.apache.commons.lang3.StringUtils
-import org.apache.commons.lang3.SystemUtils
 import org.apache.http.HttpStatus
 import org.apache.http.client.methods.CloseableHttpResponse
 import org.apache.http.client.methods.HttpDelete
@@ -33,7 +32,7 @@ class PurgeNpmAlphaVersions extends DefaultTask
     @TaskAction
     void purgeVersions()
     {
-        String alphaPrefix;
+        String alphaPrefix
         if (!project.hasProperty(ALPHA_PREFIX_PROPERTY))
             throw new GradleException("No value provided for alphaPrefix.")
         alphaPrefix = project.property(ALPHA_PREFIX_PROPERTY)
@@ -67,7 +66,7 @@ class PurgeNpmAlphaVersions extends DefaultTask
 
     private static List<String> getNpmAlphaVersions(String packageName, String alphaPrefix)
     {
-        String alphaPrefixPattern = ".+-" + alphaPrefix + "\\.\\d+";
+        String alphaPrefixPattern = ".+-" + alphaPrefix + "\\.\\d+"
         String output = (NpmRun.getNpmCommand() + " view ${packageName} versions --json").execute().text
         if (!StringUtils.isEmpty(output)) {
             def parsedJson = new JsonSlurper().parseText(output)
@@ -109,7 +108,7 @@ class PurgeNpmAlphaVersions extends DefaultTask
      */
     boolean makeDeleteRequest(String packageName, String version)
     {
-        CloseableHttpClient httpClient = HttpClients.createDefault();
+        CloseableHttpClient httpClient = HttpClients.createDefault()
         String endpoint = project.property('artifactory_contextUrl')
         boolean success = true
         if (!endpoint.endsWith("/"))

--- a/src/main/groovy/org/labkey/gradle/task/RestoreFromTrash.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/RestoreFromTrash.groovy
@@ -28,7 +28,7 @@ class RestoreFromTrash extends DefaultTask
         String restoreVersion
         if (!project.hasProperty(VERSION_PROPERTY))
             throw new GradleException("No value provided for ${VERSION_PROPERTY}.")
-        restoreVersion = project.property(VERSION_PROPERTY);
+        restoreVersion = project.property(VERSION_PROPERTY)
         String[] unrestoredVersions = []
         int numRestored = 0
         int numNotFound = 0
@@ -77,7 +77,7 @@ class RestoreFromTrash extends DefaultTask
             return
         }
 
-        CloseableHttpClient httpClient = HttpClients.createDefault();
+        CloseableHttpClient httpClient = HttpClients.createDefault()
         String endpoint = project.property('artifactory_contextUrl')
         Response responseStatus = Response.SUCCESS
         if (!endpoint.endsWith("/"))

--- a/src/main/groovy/org/labkey/gradle/task/RunTestSuite.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/RunTestSuite.groovy
@@ -18,7 +18,6 @@ package org.labkey.gradle.task
 import org.apache.commons.lang3.StringUtils
 import org.gradle.api.file.CopySpec
 import org.gradle.api.file.DuplicatesStrategy
-import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.labkey.gradle.plugin.TeamCity
 import org.labkey.gradle.plugin.extension.TeamCityExtension
@@ -59,7 +58,7 @@ abstract class RunTestSuite extends RunUiTest
                 doLast( {
                     project.copy({ CopySpec copy ->
                         copy.from "${project.tomcat.catalinaHome}/logs"
-                        copy.into "${project.buildDir}/logs/test/tomcat"
+                        copy.into project.layout.buildDirectory.file("logs/test/tomcat")
                         copy.setDuplicatesStrategy(DuplicatesStrategy.INCLUDE)
                     })
                 })

--- a/src/main/groovy/org/labkey/gradle/task/RunUiTest.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/RunUiTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.tasks.testing.Test
 import org.labkey.gradle.plugin.extension.LabKeyExtension
 import org.labkey.gradle.plugin.extension.TomcatExtension
 import org.labkey.gradle.plugin.extension.UiTestExtension
+import org.labkey.gradle.util.BuildUtils
 
 /**
  * Class that sets up jvmArgs and our standard output options
@@ -38,9 +39,9 @@ abstract class RunUiTest extends Test
 
         reports { TestTaskReports -> reports
             reports.junitXml.required = false
-            reports.junitXml.outputLocation =  new File("${project.buildDir}/${LOG_DIR}/reports/xml")
+            reports.junitXml.outputLocation = BuildUtils.getBuildDirFile(project, "${LOG_DIR}/reports/xml")
             reports.html.required = true
-            reports.html.outputLocation = new File( "${project.buildDir}/${LOG_DIR}/reports/html")
+            reports.html.outputLocation = BuildUtils.getBuildDirFile(project, "${LOG_DIR}/reports/html")
         }
         setClasspath (project.sourceSets.uiTest.runtimeClasspath)
         setTestClassesDirs (project.sourceSets.uiTest.output.classesDirs)
@@ -83,7 +84,7 @@ abstract class RunUiTest extends Test
                 systemProperty key, testConfig.get(key)
         }
         systemProperty "devMode", LabKeyExtension.isDevMode(project)
-        systemProperty "failure.output.dir", "${project.buildDir}/${LOG_DIR}"
+        systemProperty "failure.output.dir", "${BuildUtils.getBuildDirPath(project)}/${LOG_DIR}"
         systemProperty "labkey.root", project.rootProject.projectDir
         systemProperty "project.root", project.rootProject.projectDir
         systemProperty "user.home", System.getProperty('user.home')

--- a/src/main/groovy/org/labkey/gradle/task/SchemaCompile.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/SchemaCompile.groovy
@@ -38,7 +38,7 @@ class SchemaCompile extends DefaultTask {
   @Input
   String getXmlBeansVersion()
   {
-    return project.property('xmlbeansVersion');
+    return project.property('xmlbeansVersion')
   }
 
   @InputDirectory

--- a/src/main/groovy/org/labkey/gradle/task/SchemaCompile.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/SchemaCompile.groovy
@@ -24,6 +24,7 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.labkey.gradle.plugin.XmlBeans
+import org.labkey.gradle.util.BuildUtils
 
 /**
  * Task to compile XSD schema files into Java class files using the ant XMLBean
@@ -59,7 +60,7 @@ class SchemaCompile extends DefaultTask {
   @OutputDirectory
   File getClassesDir()
   {
-    return new File("$project.buildDir/$XmlBeans.CLASS_DIR")
+    return BuildUtils.getBuildDirFile(project, XmlBeans.CLASS_DIR)
   }
 
   @TaskAction

--- a/src/main/groovy/org/labkey/gradle/task/TeamCityDbSetup.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/TeamCityDbSetup.groovy
@@ -29,7 +29,7 @@ class TeamCityDbSetup extends DoThenSetup
     @Override
     protected void doDatabaseTask()
     {
-        databaseProperties.mergePropertiesFromFile();
+        databaseProperties.mergePropertiesFromFile()
         if (dropDatabase) {
             if (testValidationOnly){
                 logger.info("The 'testValidationOnly' flag is true, not going to drop the database.")

--- a/src/main/groovy/org/labkey/gradle/task/WriteDependenciesFile.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/WriteDependenciesFile.groovy
@@ -73,7 +73,7 @@ class WriteDependenciesFile extends DefaultTask
         List<String> licenseMissing = []
         configuration.resolvedConfiguration.resolvedArtifacts.forEach {
             ResolvedArtifact artifact ->
-                String versionString = artifact.moduleVersion.toString();
+                String versionString = artifact.moduleVersion.toString()
                 if (!StringUtils.isEmpty(artifact.getClassifier()))
                     versionString += ":" + artifact.getClassifier()
                 ExternalDependency dep = extension.getExternalDependency(versionString)
@@ -97,7 +97,7 @@ class WriteDependenciesFile extends DefaultTask
                         licenseMissing.add(artifact.moduleVersion.toString())
                     }
                     parts.add(dep.getPurpose() == null ? "" : dep.getPurpose())
-                    writer.write("${parts.join("|")}\n");
+                    writer.write("${parts.join("|")}\n")
                 } else {
                     missing.add(artifact.moduleVersion.toString())
                 }
@@ -115,7 +115,7 @@ class WriteDependenciesFile extends DefaultTask
     {
         ModuleExtension extension = project.extensions.findByType(ModuleExtension.class)
         if (extension.getExternalDependencies().isEmpty())
-            return;
+            return
 
         OutputStreamWriter writer = null
         try {

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -171,7 +171,8 @@ class BuildUtils
                 ModuleFinder finder = new ModuleFinder(rootDir, path, excludedModules)
                 Files.walkFileTree(Paths.get(rootDir.getAbsolutePath()), finder)
                 finder.modulePaths.each{String modulePath ->
-                    settings.include modulePath
+                    if (!excludedModules.contains(modulePath))
+                        settings.include modulePath
                 }
             }
             else
@@ -184,9 +185,13 @@ class BuildUtils
                         // exclude non-directories, explicitly excluded names, and directories beginning with a .
                         f.isDirectory() && !excludedModules.contains(f.getName()) &&  !(f.getName() =~ "^\\..*") && !f.getName().equals("node_modules")
                     }
-                    settings.include potentialModules.collect {
+                    List<String> includePaths =  potentialModules.collect {
                         (String) "${prefix}:${it.getName()}"
-                    }.toArray(new String[0])
+                    }
+                    includePaths.forEach(includePath -> {
+                        if (!excludedModules.contains(includePath))
+                            settings.include includePath
+                    })
 
                     if (includeModuleContainers)
                     {

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -231,8 +231,8 @@ class BuildUtils
     }
 
     static String convertPathToRelativeDir(String path) {
-        String relativePath = path.startsWith(":") ? path.substring(1) : path;
-        relativePath.replace(":", "/");
+        String relativePath = path.startsWith(":") ? path.substring(1) : path
+        relativePath.replace(":", "/")
     }
 
     static String convertDirToPath(File rootDir, File directory)
@@ -297,7 +297,7 @@ class BuildUtils
         // without the toString call below, you get the following error:
         // Caused by: java.lang.ArrayStoreException: arraycopy: element type mismatch: can not cast one of the elements of
         // java.lang.Object[] to the type of the destination array, java.lang.String
-        return "${getPlatformProjectPath(gradle)}:${name}".toString();
+        return "${getPlatformProjectPath(gradle)}:${name}".toString()
     }
 
     // The gradle path to the project containing the platform (base) modules (e.g., core)
@@ -309,7 +309,7 @@ class BuildUtils
 
     static String getCommonAssayModuleProjectPath(Gradle gradle, String name)
     {
-        return "${getCommonAssaysProjectPath(gradle)}:${name}".toString();
+        return "${getCommonAssaysProjectPath(gradle)}:${name}".toString()
     }
 
     // The gradle path to the project containing the common assays
@@ -360,7 +360,7 @@ class BuildUtils
 
     static String getJdbcApiProjectPath(Gradle gradle)
     {
-        return getProjectPath(gradle, "jdbcApiProjectPath", ":remoteapi:labkey-api-jdbc");
+        return getProjectPath(gradle, "jdbcApiProjectPath", ":remoteapi:labkey-api-jdbc")
     }
 
     static String getLabKeyClientApiVersion(Project project)
@@ -450,7 +450,7 @@ class BuildUtils
             if (rootBranch.startsWith("release") && /* e.g. release20.11-SNAPSHOT */
                     project.labkeyVersion.contains("-SNAPSHOT")) /* e.g. 20.11-SNAPSHOT */
             {
-                distVersion = distVersion.replace("-SNAPSHOT", "Beta");
+                distVersion = distVersion.replace("-SNAPSHOT", "Beta")
             }
             project.logger.info("${project.path} version ${distVersion}")
         }
@@ -532,7 +532,7 @@ class BuildUtils
 
     static void addTomcatBuildDependencies(Project project, String configuration)
     {
-        List<String> tomcatLibs = new ArrayList<>(TOMCAT_LIBS); // Don't modify list
+        List<String> tomcatLibs = new ArrayList<>(TOMCAT_LIBS) // Don't modify list
         if (!"${project.apacheTomcatVersion}".startsWith("7."))
             tomcatLibs.replaceAll({it.replace('tomcat7-', 'tomcat-')})
         for (String lib : tomcatLibs)
@@ -577,7 +577,7 @@ class BuildUtils
         distributionProject.logger.info("${distributionProject.path}: adding ${depProjectPath} as dependency for config ${config}")
         addLabKeyDependency(project: distributionProject, config: config, depProjectPath: depProjectPath, depProjectConfig: "published", depExtension: "module", depVersion: distributionProject.labkeyVersion)
         if (addTransitive) {
-            Set<String> pathsAdded = new HashSet<>();
+            Set<String> pathsAdded = new HashSet<>()
             addTransitiveModuleDependencies(distributionProject, distributionProject.findProject(depProjectPath), config, pathsAdded)
         }
 
@@ -784,7 +784,7 @@ class BuildUtils
 
         String[] thisVersionParts = ((String) thisVersion).split("\\.")
         String[] thatVersionParts = ((String) thatVersion).split("\\.")
-        int i = 0;
+        int i = 0
         while (i < thisVersionParts.length && i < thatVersionParts.length)
         {
             int thisPartNum = Integer.valueOf(thisVersionParts[i])
@@ -818,7 +818,7 @@ class BuildUtils
         File[] jarFiles = deployDir.listFiles(new FilenameFilter() {
             @Override
             boolean accept(File dir, String name) {
-                return name.endsWith("jar");
+                return name.endsWith("jar")
             }
         })
         if (jarFiles.size() == 0)

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -834,4 +834,29 @@ class BuildUtils
             dependency -> addExternalDependency(project, dependency)
         })
     }
+
+    static File getBuildDir(Project project)
+    {
+        return project.layout.buildDirectory.getAsFile().get()
+    }
+
+    static String getBuildDirPath(Project project)
+    {
+        return getBuildDir(project).path
+    }
+
+    static File getBuildDirFile(Project project, String filePath)
+    {
+        return project.layout.buildDirectory.file(filePath).get().asFile
+    }
+
+    static File getRootBuildDirFile(Project project, String filePath)
+    {
+        return project.rootProject.layout.buildDirectory.file(filePath).get().asFile
+    }
+
+    static String getRootBuildDirPath(Project project)
+    {
+        return project.rootProject.layout.buildDirectory.get().asFile.path
+    }
 }

--- a/src/main/groovy/org/labkey/gradle/util/ModuleFinder.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/ModuleFinder.groovy
@@ -68,6 +68,11 @@ class ModuleFinder extends SimpleFileVisitor<Path>
         }
     }
 
+    List<String> getModulePaths()
+    {
+        return modulePaths
+    }
+
     // This method is called before all plugins are applied, so we cannot use a check for the Distribution Plugin here.
     static boolean isDistributionProject(Project p)
     {

--- a/src/main/groovy/org/labkey/gradle/util/PropertiesUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/PropertiesUtils.groovy
@@ -62,12 +62,12 @@ class PropertiesUtils
     {
         if (val != null)
         {
-            String stringVal = val.toString();
+            String stringVal = val.toString()
             if (xmlEncode)
                 stringVal = StringEscapeUtils.escapeXml10(stringVal)
             return line.replace("@@" + propName + "@@", stringVal)
         }
-        return line;
+        return line
     }
 
     static String replaceProps(String line, Properties props, Boolean xmlEncode = false)

--- a/src/main/groovy/org/labkey/gradle/util/TaskUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/TaskUtils.groovy
@@ -16,6 +16,7 @@
 package org.labkey.gradle.util
 
 import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.api.UnknownTaskException
 
 class TaskUtils
@@ -26,5 +27,20 @@ class TaskUtils
             project.tasks.named(taskName).configure closure
         }
         catch (UnknownTaskException ignore) {}
+    }
+
+    static void addOptionalTaskDependency(Project project, Task task, String optionalTaskName)
+    {
+        try {
+            def optionalTask = project.tasks.named(optionalTaskName)
+            task.dependsOn(optionalTask)
+        } catch (UnknownTaskException ignore) { }
+    }
+
+    static void addOptionalTaskDependencies(Project project, Task task, List<String> taskNames)
+    {
+        for (String taskName : taskNames) {
+            addOptionalTaskDependency(project, task, taskName)
+        }
     }
 }

--- a/src/main/groovy/org/labkey/gradle/util/TaskUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/TaskUtils.groovy
@@ -64,4 +64,14 @@ class TaskUtils
             return defaultValue
         }
     }
+
+    static Optional<TaskProvider> getOptionalTask(Project project, String taskName)
+    {
+        try {
+            return Optional.of(project.tasks.named(taskName))
+        }
+        catch (UnknownTaskException ignore) {
+            return Optional.empty()
+        }
+    }
 }

--- a/src/main/groovy/org/labkey/gradle/util/TaskUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/TaskUtils.groovy
@@ -36,11 +36,4 @@ class TaskUtils
             task.dependsOn(optionalTask)
         } catch (UnknownTaskException ignore) { }
     }
-
-    static void addOptionalTaskDependencies(Project project, Task task, List<String> taskNames)
-    {
-        for (String taskName : taskNames) {
-            addOptionalTaskDependency(project, task, taskName)
-        }
-    }
 }

--- a/src/main/groovy/org/labkey/gradle/util/TaskUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/TaskUtils.groovy
@@ -18,6 +18,10 @@ package org.labkey.gradle.util
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.UnknownTaskException
+import org.gradle.api.tasks.TaskProvider
+
+import java.util.function.Consumer
+import java.util.function.Function
 
 class TaskUtils
 {
@@ -35,5 +39,29 @@ class TaskUtils
             def optionalTask = project.tasks.named(optionalTaskName)
             task.dependsOn(optionalTask)
         } catch (UnknownTaskException ignore) { }
+    }
+
+    static TaskProvider doIfTaskPresent(Project project, String taskName, Consumer<TaskProvider> consumer)
+    {
+        return getFromTaskIfPresent(project, taskName, task -> {
+            consumer.accept(task)
+            return task
+        })
+    }
+
+    static <R> R getFromTaskIfPresent(Project project, String taskName, Function<TaskProvider, R> func)
+    {
+        return getFromTaskIfPresent(project, taskName, func, null)
+    }
+
+    static <R> R getFromTaskIfPresent(Project project, String taskName, Function<TaskProvider, R> func, R defaultValue)
+    {
+        try {
+            var task = project.tasks.named(taskName)
+            return func.apply(task)
+        }
+        catch (UnknownTaskException ignore) {
+            return defaultValue
+        }
     }
 }


### PR DESCRIPTION
#### Rationale
In Gradle 8.3, the use of `project.buildDir` was [deprecated](https://docs.gradle.org/current/userguide/upgrading_version_8.html#project_builddir) in favor of `project.layout.buildDirectory`.  We make adjustments here to upgrade to the new world order.  We also take this opportunity to do a little housecleaning of a good number of stray semicolons that are cluttering the space and to replace almost all remaining usages of `task.findTaskByName` with `task.named`.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* [Issue 49045](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49045) - make copying to the modules-api directory a proper task, so it can run even if apiJar does not
* Eliminate usages of deprecated `project.buildDir`
* Update `BuildUtils.includeModules` to be able to specify full module paths for exclusion, not just directory names
