### PR TITLE
Allow `application.properties` to define `server.tomcat.basedir`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### 1.43.2
+*Released*: TBD
+(Earliest compatible LabKey version: 23.3)
+* Add syntax to uncomment certain properties in `application.properties` during deploy tasks
+* Update example `log4j2.xml` configuration file
+* Introduce [connection pool optimizations](https://github.com/LabKey/server/pull/304) to `labkey.xml`
+
 ### 1.43.1
 *Released*: 16 November 2023
 (Earliest compatible LabKey version: 23.3)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
-### 1.43.2
+### 1.44.0
 *Released*: TBD
 (Earliest compatible LabKey version: 23.3)
 * Add syntax to uncomment certain properties in `application.properties` during deploy tasks

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.43.2-embeddedAccessLog-SNAPSHOT"
+project.version = "1.45.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.44.0-SNAPSHOT"
+project.version = "1.43.2-embeddedAccessLog-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/distributionResources/labkey.xml
+++ b/distributionResources/labkey.xml
@@ -1,26 +1,30 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!-- https://www.labkey.org/Documentation/wiki-page.view?name=installComponents#4 -->
 <Context docBase="@@appDocBase@@" reloadable="true" crossContext="true">
-    
+
     <Resource name="jdbc/labkeyDataSource" auth="Container"
-        type="javax.sql.DataSource"
-        username="@@jdbcUser@@"
-        password="@@jdbcPassword@@"
-        driverClassName="@@jdbcDriverClassName@@"
-        url="@@jdbcURL@@"
-        maxTotal="20"
-        maxIdle="10"
-        maxWaitMillis="120000"
-        accessToUnderlyingConnectionAllowed="true"
-        validationQuery="SELECT 1"
-        />
+              type="javax.sql.DataSource"
+              username="@@jdbcUser@@"
+              password="@@jdbcPassword@@"
+              driverClassName="@@jdbcDriverClassName@@"
+              url="@@jdbcURL@@"
+              maxTotal="20"
+              maxIdle="3"
+              minIdle="1"
+              maxWaitMillis="120000"
+              testOnBorrow="false"
+              testWhileIdle="true"
+              timeBetweenEvictionRunsMillis="300000"
+              minEvictableIdleTimeMillis="300000"
+              accessToUnderlyingConnectionAllowed="true"
+    />
 
     <!-- https://www.labkey.org/Documentation/wiki-page.view?name=cpasxml#SMTPsettings -->
     <Resource name="mail/Session" auth="Container"
-        type="javax.mail.Session"
-        mail.smtp.host="@@smtpHost@@"
-        mail.smtp.user="@@smtpUser@@"
-        mail.smtp.port="@@smtpPort@@"/>
+              type="javax.mail.Session"
+              mail.smtp.host="@@smtpHost@@"
+              mail.smtp.user="@@smtpUser@@"
+              mail.smtp.port="@@smtpPort@@"/>
 
     <Resources cachingAllowed="true" cacheMaxSize="20000" />
 

--- a/distributionResources/log4j2.xml
+++ b/distributionResources/log4j2.xml
@@ -21,8 +21,22 @@
             </PatternLayout>
             <Policies>
                 <OnStartupTriggeringPolicy />
+                <SizeBasedTriggeringPolicy size="10 MB"/>
             </Policies>
-            <DefaultRolloverStrategy max="3"/>
+            <DefaultRolloverStrategy fileIndex="min" max="3">
+                <Delete basePath="${sys:labkey.log.home}">
+                    <ScriptCondition>
+                        <!-- Use custom Java code to retain the first log file from the current session if it's about
+                        to be rotated out. It may have root cause information about problems that would otherwise be lost -->
+                        <Script name="retainFirst" language="rhino"><![CDATA[
+                                var ErrorLogRotator = org.labkey.api.util.logging.ErrorLogRotator;
+                                var rotator = new ErrorLogRotator();
+                                rotator.filter(pathList);
+                            ]]>
+                        </Script>
+                    </ScriptCondition>
+                </Delete>
+            </DefaultRolloverStrategy>
 
         </RollingFile>
 
@@ -39,7 +53,7 @@
                 <OnStartupTriggeringPolicy />
                 <SizeBasedTriggeringPolicy size="100 MB"/>
             </Policies>
-            <DefaultRolloverStrategy max="3"/>
+            <DefaultRolloverStrategy max="3" fileIndex="min" />
         </RollingFile>
 
         <RollingFile name="QUERY_STATS"
@@ -55,7 +69,7 @@
                 <OnStartupTriggeringPolicy />
                 <SizeBasedTriggeringPolicy size="100 MB"/>
             </Policies>
-            <DefaultRolloverStrategy max="3"/>
+            <DefaultRolloverStrategy max="3" fileIndex="min" />
         </RollingFile>
 
         <RollingFile name="LABKEY"
@@ -70,6 +84,7 @@
             <Policies>
                 <SizeBasedTriggeringPolicy size="10 MB"/>
             </Policies>
+            <DefaultRolloverStrategy fileIndex="min" />
         </RollingFile>
 
         <RollingFile name="LABKEY_AUDIT"
@@ -84,6 +99,7 @@
             <Policies>
                 <SizeBasedTriggeringPolicy size="10 MB"/>
             </Policies>
+            <DefaultRolloverStrategy fileIndex="min" />
         </RollingFile>
 
         <SessionAppender name="SessionAppender">
@@ -103,6 +119,7 @@
             <Policies>
                 <SizeBasedTriggeringPolicy size="1000 KB"/>
             </Policies>
+            <DefaultRolloverStrategy fileIndex="min" />
         </RollingFile>
 
         <RollingFile name="THREAD_DUMP"
@@ -116,6 +133,36 @@
             <Policies>
                 <SizeBasedTriggeringPolicy size="10 MB"/>
             </Policies>
+            <DefaultRolloverStrategy fileIndex="min" />
+        </RollingFile>
+
+        <RollingFile name="CSP_REPORT"
+                     fileName="${sys:labkey.log.home}/csp-report.log"
+                     append="true"
+                     filePattern="${sys:labkey.log.home}/csp-report.log.%i">
+            <!-- p=priority c=category d=datetime t=thread m=message n=newline -->
+            <PatternLayout>
+                <Pattern>%-5p %-24.24c{1} %d{ISO8601} %24.24t : %m%n</Pattern>
+            </PatternLayout>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="10 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy fileIndex="min" />
+        </RollingFile>
+
+        <RollingFile name="INDEXED_DOCUMENTS"
+                     fileName="${sys:labkey.log.home}/labkey-indexed-documents.log"
+                     append="true"
+                     bufferedIO="false"
+                     filePattern="${sys:labkey.log.home}/labkey-indexed-documents.log.%i">
+            <!-- d=datetime m=message n=newline -->
+            <PatternLayout>
+                <Pattern>%d{ISO8601} %m%n</Pattern>
+            </PatternLayout>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="1 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="3" fileIndex="min" />
         </RollingFile>
 
     </Appenders>
@@ -214,8 +261,17 @@
             <AppenderRef ref="LABKEYMemory"/>
         </Logger>
 
+        <Logger name="org.labkey.api.search.SearchService$SearchCategory" additivity="false" level="info">
+            <AppenderRef ref="INDEXED_DOCUMENTS"/>
+        </Logger>
+
         <Logger name="org.labkey.api.util.DebugInfoDumper" level="debug">
             <AppenderRef ref="THREAD_DUMP"/>
+        </Logger>
+
+        <Logger name="org.labkey.core.admin.AdminController.ContentSecurityPolicyReportAction"  additivity="false" level="warn">
+            <AppenderRef ref="CSP_REPORT" />
+            <AppenderRef ref="CONSOLE"/>
         </Logger>
 
         <!--

--- a/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
@@ -121,9 +121,8 @@ class DoThenSetup extends DefaultTask
             if (!embeddedConfigUpToDate()) {
                 Properties configProperties = databaseProperties.getConfigProperties()
                 configProperties.putAll(getExtraJdbcProperties())
-                if (project.hasProperty("useLocalBuild"))
-                    // in .properties files, backward slashes are seen as escape characters, so all paths must use forward slashes, even on Windows
-                    configProperties.setProperty("pathToServer", project.rootDir.getAbsolutePath().replaceAll("\\\\", "/"))
+                // in .properties files, backward slashes are seen as escape characters, so all paths must use forward slashes, even on Windows
+                configProperties.setProperty("pathToServer", project.rootDir.getAbsolutePath().replaceAll("\\\\", "/"))
                 if (TeamCityExtension.getLabKeyServerPort(project) != null)
                     configProperties.setProperty("serverPort", TeamCityExtension.getLabKeyServerPort(project))
                 else if (project.hasProperty("serverPort"))
@@ -140,6 +139,8 @@ class DoThenSetup extends DefaultTask
                     copy.include "application.properties"
                     copy.setDuplicatesStrategy(DuplicatesStrategy.INCLUDE)
                     copy.filter({ String line ->
+                        // Always uncomment properties prepended by '#setupTask#'
+                        line = line.replace("#setupTask#", "")
                         if (project.hasProperty("useSsl")) {
                             line = line.replace("#server.ssl", "server.ssl")
                         }
@@ -147,7 +148,7 @@ class DoThenSetup extends DefaultTask
                             // Let properties file specify which properties require 'useLocalBuild'
                             line = line.replace("#useLocalBuild#", "")
 
-                            // Old method enables specific properties for 'useLocalBuild' (before 22.6)
+                            // Old method enables specific properties for 'useLocalBuild' (before 24.1)
                             line = line.replace("#context.webAppLocation=", "context.webAppLocation=")
                             line = line.replace("#spring.devtools.restart.additional-paths=", "spring.devtools.restart.additional-paths=")
                         }


### PR DESCRIPTION
#### Rationale
To get access to all of the embedded server logs on TeamCity, we need to set `server.tomcat.basedir` to a known location (it defaults to a temp directory). Injecting `pathToServer` into `application.properties` is currently locked behind the `useLocalBuild` property. That property only works when building and running from a dev enlistment, some of the properties it enables don't work when deploying a distribution into a TeamCity test environment.

#### Related Pull Requests
- https://github.com/LabKey/server/pull/478

#### Changes
- Don't require `useLocalBuild` to inject server path into `application.properties`
- Update `log4j2.xml` and `labkey.xml` to include recent server changes
