### PR TITLE
Prevent improper caching of `jsp2Java` task

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ on how to do that, including how to develop and test locally and the versioning 
 _Note: 1.28.0 and later require Gradle 7_
 
 ### 1.44.1
-*Released*: TBD
+*Released*: 28 December 2023
 (Earliest compatible LabKey version: 23.3)
 * Prevent improper caching of `jsp2Java` task
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### 1.44.1
+*Released*: TBD
+(Earliest compatible LabKey version: 23.3)
+* Prevent improper caching of `jsp2Java` task
+
 ### 1.44.0
 *Released*: 19 December 2023
 (Earliest compatible LabKey version: 23.3)

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.44.1-jsp2JavaCaching-SNAPSHOT"
+project.version = "1.45.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.45.0-SNAPSHOT"
+project.version = "1.44.1-jsp2JavaCaching-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/plugin/Jsp.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Jsp.groovy
@@ -174,7 +174,7 @@ class Jsp implements Plugin<Project>
                task.description = "compile jsp files into Java classes"
 
                if (project.hasProperty('apacheTomcatVersion'))
-                   task.inputs.property 'apacheTomcatVersion', property('apacheTomcatVersion')
+                   task.inputs.property 'apacheTomcatVersion', project.property('apacheTomcatVersion')
                else
                    task.outputs.cacheIf { false } // Just don't cache if we can't be sure of the Jasper version
                task.inputs.files project.tasks.copyJsp

--- a/src/main/groovy/org/labkey/gradle/plugin/Jsp.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Jsp.groovy
@@ -173,7 +173,10 @@ class Jsp implements Plugin<Project>
                task.group = GroupNames.JSP
                task.description = "compile jsp files into Java classes"
 
-               task.inputs.files project.configurations.jspCompileClasspath
+               if (project.hasProperty('apacheTomcatVersion'))
+                   task.inputs.property 'apacheTomcatVersion', property('apacheTomcatVersion')
+               else
+                   task.outputs.cacheIf { false } // Just don't cache if we can't be sure of the Jasper version
                task.inputs.files project.tasks.copyJsp
                task.inputs.files project.tasks.copyResourceJsp
                task.inputs.files project.tasks.copyTagLibs

--- a/src/main/groovy/org/labkey/gradle/plugin/Jsp.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Jsp.groovy
@@ -173,6 +173,7 @@ class Jsp implements Plugin<Project>
                task.group = GroupNames.JSP
                task.description = "compile jsp files into Java classes"
 
+               task.inputs.files project.configurations.jspCompileClasspath
                task.inputs.files project.tasks.copyJsp
                task.inputs.files project.tasks.copyResourceJsp
                task.inputs.files project.tasks.copyTagLibs


### PR DESCRIPTION
#### Rationale
When setting up builds for our Tomcat 10 migration, I had to disable the build cache because the `jsp2Java` task because it would pull cached results from our normal develop builds.

#### Related Pull Requests
- N/A

#### Changes
- Include `jspCompileClasspath` in `jsp2Java` task inputs to prevent bad cache hits
