### PR TITLE
Remove redundant plugin identifiers and other misc changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### 2.0.0
+*Released*: TBD
+(Earliest compatible LabKey version: 24.2)
+* Remove redundant plugin identifiers using org.labkey namespace instead of org.labkey.build 
+   (e.g., org.labkey.module removed in favor of org.labkey.build.module)
+* Add support for using the net.nemerosa.versioning plugin directly instead of our forked version 
+* Update dependency versions
+* Add `substituteModuleDependecies` utility method for experimentation with some dependency substitution ([Issue 49316](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=49316))
+
 ### 1.44.1
 *Released*: 28 December 2023
 (Earliest compatible LabKey version: 23.3)

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.45.0-SNAPSHOT"
+project.version = "1.45.0-miscMaintenance-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,6 @@ group 'org.labkey.build'
 project.version = "1.45.0-miscMaintenance-SNAPSHOT"
 
 gradlePlugin {
-    // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins
     plugins {
         antBuild {
             id = 'org.labkey.build.antBuild'

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.45.0-miscMaintenance-SNAPSHOT"
+project.version = "2.0.0-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,15 +2,15 @@ artifactory_contextUrl=https://labkey.jfrog.io/artifactory
 
 artifactoryPluginVersion=4.28.2
 
-commonsIoVersion=2.11.0
-commonsLang3Version=3.12.0
-commonsTextVersion=1.10.0
+commonsIoVersion=2.15.1
+commonsLang3Version=3.14.0
+commonsTextVersion=1.11.0
 
-grgitGradleVersion=5.0.0
-graphqlJavaVersion=21.0
+grgitGradleVersion=5.2.1
+graphqlJavaVersion=21.3
 
 httpclientVersion=4.5.14
 httpcoreVersion=4.4.16
 
-jacksonVersion=2.14.1
-jsonVersion=20230227
+jacksonVersion=2.16.1
+jsonVersion=20231013

--- a/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
@@ -49,10 +49,6 @@ class FileModule implements Plugin<Project>
         List<String> indicators = new ArrayList<>()
         if (!project.file(ModuleExtension.MODULE_PROPERTIES_FILE).exists())
             indicators.add(ModuleExtension.MODULE_PROPERTIES_FILE + " does not exist")
-        if (project.hasProperty("skipBuild")) {
-            project.logger.quiet("${project.path}: The skipBuild property is deprecated and will be removed in version 2.0.0. Use the property excludedModules instead. See https://www.labkey.org/Documentation/wiki-page.view?name=customizingBuild#skip. ")
-            indicators.add("skipBuild property set for Gradle project")
-        }
 
         if (indicators.size() > 0 && logMessages)
         {

--- a/src/main/groovy/org/labkey/gradle/plugin/LabKey.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/LabKey.groovy
@@ -25,7 +25,6 @@ import org.labkey.gradle.util.BuildUtils
 /**
  * Defines a set of extension properties for ease of reference. This also adds a two extensions
  * for some basic properties.
- * Created by susanh on 4/13/16.
  */
 class LabKey implements Plugin<Project>
 {
@@ -38,7 +37,10 @@ class LabKey implements Plugin<Project>
     {
         if (project.hasProperty('includeVcs'))
         {
-            project.apply plugin: 'org.labkey.versioning'
+            if (project.hasProperty('nemerosaVersioningPluginVersion'))
+                project.apply plugin: 'net.nemerosa.versioning'
+            else
+                project.apply plugin: 'org.labkey.versioning'
         }
 
         project.group = LabKeyExtension.LABKEY_GROUP

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/LabKeyExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/LabKeyExtension.groovy
@@ -50,8 +50,6 @@ class LabKeyExtension
         }
     }
 
-    Boolean skipBuild = false // set this to true in an individual module's build.gradle file to skip building
-
     String explodedModuleDir
     String explodedModuleWebDir
     String explodedModuleConfigDir

--- a/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
@@ -145,12 +145,8 @@ class DoThenSetup extends DefaultTask
                             line = line.replace("#server.ssl", "server.ssl")
                         }
                         if (project.hasProperty("useLocalBuild")) {
-                            // Let properties file specify which properties require 'useLocalBuild'
+                            // Enable properties that require 'useLocalBuild' (e.g. 'context.webAppLocation' and 'spring.devtools.restart.additional-paths')
                             line = line.replace("#useLocalBuild#", "")
-
-                            // Old method enables specific properties for 'useLocalBuild' (before 24.1)
-                            line = line.replace("#context.webAppLocation=", "context.webAppLocation=")
-                            line = line.replace("#spring.devtools.restart.additional-paths=", "spring.devtools.restart.additional-paths=")
                         }
                         else {
                             // Remove placeholder

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -941,10 +941,10 @@ class BuildUtils
                                         ds.substitute ds.module("org.labkey.module:${p.name}") using ds.project(p.path)
                                         p.logger.debug("Substituting org.labkey.module:${p.name} with ${p.path}")
                                     }
-                                    if (p.plugins.hasPlugin('org.labkey.build.api'))
-                                    {
-                                        ds.substitute ds.module("org.labkey.api:${p.name}")
-                                    }
+//                                    if (p.plugins.hasPlugin('org.labkey.build.api'))
+//                                    {
+//                                        ds.substitute ds.module("org.labkey.api:${p.name}") using ds.project(p.path)
+//                                    }
                                 }
                             }
                     }

--- a/src/main/resources/META-INF/gradle-plugins/org.labkey.antBuild.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.labkey.antBuild.properties
@@ -1,1 +1,0 @@
-implementation-class=org.labkey.gradle.plugin.AntBuild

--- a/src/main/resources/META-INF/gradle-plugins/org.labkey.antlr.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.labkey.antlr.properties
@@ -1,1 +1,0 @@
-implementation-class=org.labkey.gradle.plugin.Antlr

--- a/src/main/resources/META-INF/gradle-plugins/org.labkey.api.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.labkey.api.properties
@@ -1,1 +1,0 @@
-implementation-class=org.labkey.gradle.plugin.Api

--- a/src/main/resources/META-INF/gradle-plugins/org.labkey.base.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.labkey.base.properties
@@ -1,1 +1,0 @@
-implementation-class=org.labkey.gradle.plugin.LabKey

--- a/src/main/resources/META-INF/gradle-plugins/org.labkey.database.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.labkey.database.properties
@@ -1,1 +1,0 @@
-implementation-class=org.labkey.gradle.plugin.Database

--- a/src/main/resources/META-INF/gradle-plugins/org.labkey.distribution.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.labkey.distribution.properties
@@ -1,1 +1,0 @@
-implementation-class=org.labkey.gradle.plugin.Distribution

--- a/src/main/resources/META-INF/gradle-plugins/org.labkey.fileModule.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.labkey.fileModule.properties
@@ -1,1 +1,0 @@
-implementation-class=org.labkey.gradle.plugin.FileModule

--- a/src/main/resources/META-INF/gradle-plugins/org.labkey.gwt.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.labkey.gwt.properties
@@ -1,1 +1,0 @@
-implementation-class=org.labkey.gradle.plugin.Gwt

--- a/src/main/resources/META-INF/gradle-plugins/org.labkey.javaModule.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.labkey.javaModule.properties
@@ -1,1 +1,0 @@
-implementation-class=org.labkey.gradle.plugin.JavaModule

--- a/src/main/resources/META-INF/gradle-plugins/org.labkey.jsdoc.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.labkey.jsdoc.properties
@@ -1,1 +1,0 @@
-implementation-class=org.labkey.gradle.plugin.JsDoc

--- a/src/main/resources/META-INF/gradle-plugins/org.labkey.jsp.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.labkey.jsp.properties
@@ -1,1 +1,0 @@
-implementation-class=org.labkey.gradle.plugin.Jsp

--- a/src/main/resources/META-INF/gradle-plugins/org.labkey.module.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.labkey.module.properties
@@ -1,1 +1,0 @@
-implementation-class=org.labkey.gradle.plugin.Module

--- a/src/main/resources/META-INF/gradle-plugins/org.labkey.multiGit.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.labkey.multiGit.properties
@@ -1,1 +1,0 @@
-implementation-class=org.labkey.gradle.plugin.MultiGit

--- a/src/main/resources/META-INF/gradle-plugins/org.labkey.npmRun.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.labkey.npmRun.properties
@@ -1,1 +1,0 @@
-implementation-class=org.labkey.gradle.plugin.NpmRun

--- a/src/main/resources/META-INF/gradle-plugins/org.labkey.serverDeploy.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.labkey.serverDeploy.properties
@@ -1,1 +1,0 @@
-implementation-class=org.labkey.gradle.plugin.ServerDeploy

--- a/src/main/resources/META-INF/gradle-plugins/org.labkey.springConfig.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.labkey.springConfig.properties
@@ -1,1 +1,0 @@
-implementation-class=org.labkey.gradle.plugin.SpringConfig

--- a/src/main/resources/META-INF/gradle-plugins/org.labkey.teamCity.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.labkey.teamCity.properties
@@ -1,1 +1,0 @@
-implementation-class=org.labkey.gradle.plugin.TeamCity

--- a/src/main/resources/META-INF/gradle-plugins/org.labkey.testRunner.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.labkey.testRunner.properties
@@ -1,1 +1,0 @@
-implementation-class=org.labkey.gradle.plugin.TestRunner

--- a/src/main/resources/META-INF/gradle-plugins/org.labkey.tomcat.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.labkey.tomcat.properties
@@ -1,1 +1,0 @@
-implementation-class=org.labkey.gradle.plugin.Tomcat

--- a/src/main/resources/META-INF/gradle-plugins/org.labkey.uiTest.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.labkey.uiTest.properties
@@ -1,1 +1,0 @@
-implementation-class=org.labkey.gradle.plugin.UiTest

--- a/src/main/resources/META-INF/gradle-plugins/org.labkey.webapp.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.labkey.webapp.properties
@@ -1,1 +1,0 @@
-implementation-class=org.labkey.gradle.plugin.Webapp

--- a/src/main/resources/META-INF/gradle-plugins/org.labkey.xmlBeans.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.labkey.xmlBeans.properties
@@ -1,1 +1,0 @@
-implementation-class=org.labkey.gradle.plugin.XmlBeans

--- a/src/main/resources/META-INF/gradle-plugins/org.labkey.xsddoc.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.labkey.xsddoc.properties
@@ -1,1 +1,0 @@
-implementation-class=org.labkey.gradle.plugin.XsdDoc


### PR DESCRIPTION
#### Rationale
Quite some time ago, we transitioned to using `gradlePlugin { plugins { ... } }` for configuring our plugin ids and updated the ids to use `org.labkey.build` as the namespace instead of `org.labkey`.  It's finally time to remove the old identifiers that are codified in properties files in the `resources` directory. 

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- Update to latest dependency versions
- Remove properties files that declare redundant plugin ids
- Add conditional support for net.nemorosa.versioning plugin to possibly remove the need for our fork
