### PR TITLE
Fix symlink node and add deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
-### TBD
-*Released*: TBD
+### 1.44.2
+*Released*: 4 January 2024
 (Earliest compatible LabKey version: 23.3)
 * Fix `symlinkNode` task to use proper propject
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### TBD
+*Released*: TBD
+(Earliest compatible LabKey version: 23.3)
+* Fix `symlinkNode` task to use proper propject
+
 ### 1.44.1
 *Released*: 28 December 2023
 (Earliest compatible LabKey version: 23.3)

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.45.0-fixSymlinkNode-SNAPSHOT"
+project.version = "1.45.0-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.45.0-SNAPSHOT"
+project.version = "1.45.0-fixSymlinkNode-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
@@ -49,8 +49,10 @@ class FileModule implements Plugin<Project>
         List<String> indicators = new ArrayList<>()
         if (!project.file(ModuleExtension.MODULE_PROPERTIES_FILE).exists())
             indicators.add(ModuleExtension.MODULE_PROPERTIES_FILE + " does not exist")
-        if (project.hasProperty("skipBuild"))
+        if (project.hasProperty("skipBuild")) {
+            project.logger.quiet("The skipBuild property is deprecated and will be removed in version 2.0.0. Use the property excludedModules instead. See https://www.labkey.org/Documentation/wiki-page.view?name=customizingBuild#skip. ")
             indicators.add("skipBuild property set for Gradle project")
+        }
 
         if (indicators.size() > 0 && logMessages)
         {

--- a/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
@@ -50,7 +50,7 @@ class FileModule implements Plugin<Project>
         if (!project.file(ModuleExtension.MODULE_PROPERTIES_FILE).exists())
             indicators.add(ModuleExtension.MODULE_PROPERTIES_FILE + " does not exist")
         if (project.hasProperty("skipBuild")) {
-            project.logger.quiet("The skipBuild property is deprecated and will be removed in version 2.0.0. Use the property excludedModules instead. See https://www.labkey.org/Documentation/wiki-page.view?name=customizingBuild#skip. ")
+            project.logger.quiet("${project.path}: The skipBuild property is deprecated and will be removed in version 2.0.0. Use the property excludedModules instead. See https://www.labkey.org/Documentation/wiki-page.view?name=customizingBuild#skip. ")
             indicators.add("skipBuild property set for Gradle project")
         }
 

--- a/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
@@ -534,7 +534,7 @@ class ServerDeploy implements Plugin<Project>
         Path nodeLinkPath = Paths.get("${linkContainer.getPath()}/node")
         if (!Files.isSymbolicLink(nodeLinkPath) || !Files.readSymbolicLink(nodeLinkPath).getFileName().toString().startsWith(nodeFilePrefix))
         {
-            File nodeDir = BuildUtils.getBuildDirFile(project, project.nodeWorkDirectory)
+            File nodeDir = BuildUtils.getBuildDirFile(pmLinkProject, project.nodeWorkDirectory)
             File[] nodeFiles = nodeDir.listFiles({ File file -> file.name.startsWith(nodeFilePrefix) } as FileFilter)
             if (nodeFiles != null && nodeFiles.length > 0)
             {


### PR DESCRIPTION
#### Rationale
When converting to non-deprecated references for the build directory, the project used in creating the source for the symlinkNode link was mistakenly changed.  This fixes that.

We also add a deprecation warning message for the `skipBuild` property so it can be removed with the 2.0.0 version of the plugins.

#### Related Pull Requests
- #185 

#### Changes
- Fix `symlinkNode` task to use proper propject
- Add deprecation warning
