### PR TITLE
Make `startTomcat` environment consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### 1.44.3
+*Released*: TBD
+(Earliest compatible LabKey version: 23.3)
+* Make `startTomcat` environment consistent between standalone and embedded Tomcat
+
 ### 1.44.2
 *Released*: 4 January 2024
 (Earliest compatible LabKey version: 23.3)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ on how to do that, including how to develop and test locally and the versioning 
 _Note: 1.28.0 and later require Gradle 7_
 
 ### 2.0.0
-*Released*: TBD
+*Released*: 9 January 2024
 (Earliest compatible LabKey version: 24.2)
 * Remove redundant plugin identifiers using org.labkey namespace instead of org.labkey.build 
    (e.g., org.labkey.module removed in favor of org.labkey.build.module)

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "2.0.0-embeddedEnv-SNAPSHOT"
+project.version = "2.0.0-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "1.45.0-SNAPSHOT"
+project.version = "1.45.0-embeddedEnv-SNAPSHOT"
 
 gradlePlugin {
     // TODO after transitioning to using these plugin ids, remove the properties files from resources/META-INF.gradle-plugins

--- a/src/main/groovy/org/labkey/gradle/task/StartTomcat.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/StartTomcat.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskAction
+import org.gradle.internal.impldep.it.unimi.dsi.fastutil.Hash
 import org.labkey.gradle.plugin.Tomcat
 import org.labkey.gradle.plugin.extension.LabKeyExtension
 import org.labkey.gradle.plugin.extension.ServerDeployExtension
@@ -65,10 +66,12 @@ class StartTomcat extends DefaultTask
             if (!logFile.exists())
                 logFile.createNewFile()
             FileOutputStream outputStream = new FileOutputStream(logFile)
+            def envMap = new HashMap<>(System.getenv())
+            envMap.put('PATH', "${ServerDeployExtension.getEmbeddedServerDeployDirectory(project)}/bin${File.pathSeparator}${System.getenv("PATH")}")
             def env = []
-            env += "PATH=${ServerDeployExtension.getEmbeddedServerDeployDirectory(project)}/bin${File.pathSeparator}${System.getenv("PATH")}"
-            if (System.getenv("R_LIBS_USER") != null)
-                env += "R_LIBS_USER=${System.getenv("R_LIBS_USER")}"
+            for (String key : envMap.keySet()) {
+                env += "${key}=${envMap.get(key)}"
+            }
             this.logger.info("Starting embedded tomcat with command ${commandParts} and env ${env} in directory ${ServerDeployExtension.getEmbeddedServerDeployDirectory(project)}")
             Process process = commandParts.execute(env, new File(ServerDeployExtension.getEmbeddedServerDeployDirectory(project)))
             process.consumeProcessOutput(outputStream, outputStream)

--- a/src/main/groovy/org/labkey/gradle/task/StartTomcat.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/StartTomcat.groovy
@@ -21,7 +21,6 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskAction
-import org.gradle.internal.impldep.it.unimi.dsi.fastutil.Hash
 import org.labkey.gradle.plugin.Tomcat
 import org.labkey.gradle.plugin.extension.LabKeyExtension
 import org.labkey.gradle.plugin.extension.ServerDeployExtension


### PR DESCRIPTION
#### Rationale
`startTomcat` for embedded tomcat only populates the `PATH` and `R_LIBS_USER` environment variables. This is causing failures on TeamCity because the `LANG` is not set, making the server unable to create folders with extended unicode characters. `startTomcat` for standalone uses `ant.exec` to start tomcat, which passes through all environment variables.

```
ava.nio.file.InvalidPathException: Malformed input or input contains unmappable characters: /mnt/teamcity/work/ac5fdd0903d80fb5/build/deploy/embedded/server/files/PanoramaPublicChromLibTest Project ☃~!@$&()_+{}-=[],.#äöüÅ
       at java.base/sun.nio.fs.UnixPath.encode(UnixPath.java:121)
       at java.base/sun.nio.fs.UnixPath.<init>(UnixPath.java:68)
       at java.base/sun.nio.fs.UnixFileSystem.getPath(UnixFileSystem.java:279)
       at java.base/java.io.File.toPath(File.java:2387)
       at org.labkey.filecontent.FileContentServiceImpl.getDefaultRootPath(FileContentServiceImpl.java:337)
       at org.labkey.filecontent.FileContentServiceImpl.getFileRootPath(FileContentServiceImpl.java:294)
```

#### Related Pull Requests
- N/A

#### Changes
- Pass all environment variables to embedded tomcat Process
