### PR TITLE
Update coordinates for gwt dependencies to `org.gwtproject` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### 2.?.?
+*Released*: TBD
+(Earliest compatible LabKey version: 24.2)
+* Update coordinates for gwt dependencies to `org.gwtproject` instead of `com.google.gwt`
+
 ### 2.0.0
 *Released*: 9 January 2024
 (Earliest compatible LabKey version: 24.2)

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
-### 2.?.?
-*Released*: TBD
+### 2.1.0
+*Released*: 12 January 2024
 (Earliest compatible LabKey version: 24.2)
 * Update coordinates for gwt dependencies to `org.gwtproject` instead of `com.google.gwt`
 

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "2.0.0-SNAPSHOT"
+project.version = "2.1.0-gwtCoordsUpdate-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "2.1.0-gwtCoordsUpdate-SNAPSHOT"
+project.version = "2.2.0-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/src/main/groovy/org/labkey/gradle/plugin/Gwt.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Gwt.groovy
@@ -66,9 +66,16 @@ class Gwt implements Plugin<Project>
     {
         project.dependencies {
             gwtImplementation "org.gwtproject:gwt-user:${project.gwtVersion}",
-                    "org.gwtproject:gwt-dev:${project.gwtVersion}",
-                    "javax.validation:validation-api:${project.validationApiVersion}"
+                    "org.gwtproject:gwt-dev:${project.gwtVersion}"
         }
+        if (project.hasProperty("validationJakartaApiVersion"))
+            project.dependencies {
+                gwtImplementation "jakarta.validation:jakarta.validation-api:${validationJakartaApiVersion}"
+            }
+        else if (project.hasProperty("validationApiVersion"))
+            project.dependencies {
+                gwtImplementation "javax.validation:validation-api:${project.validationApiVersion}"
+            }
     }
 
     private void addSourceSets()

--- a/src/main/groovy/org/labkey/gradle/plugin/Gwt.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Gwt.groovy
@@ -70,7 +70,7 @@ class Gwt implements Plugin<Project>
         }
         if (project.hasProperty("validationJakartaApiVersion"))
             project.dependencies {
-                gwtImplementation "jakarta.validation:jakarta.validation-api:${validationJakartaApiVersion}"
+                gwtImplementation "jakarta.validation:jakarta.validation-api:${project.validationJakartaApiVersion}"
             }
         else if (project.hasProperty("validationApiVersion"))
             project.dependencies {

--- a/src/main/groovy/org/labkey/gradle/plugin/Gwt.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Gwt.groovy
@@ -65,8 +65,8 @@ class Gwt implements Plugin<Project>
     private void addDependencies()
     {
         project.dependencies {
-            gwtImplementation "com.google.gwt:gwt-user:${project.gwtVersion}",
-                    "com.google.gwt:gwt-dev:${project.gwtVersion}",
+            gwtImplementation "org.gwtproject:gwt-user:${project.gwtVersion}",
+                    "org.gwtproject:gwt-dev:${project.gwtVersion}",
                     "javax.validation:validation-api:${project.validationApiVersion}"
         }
     }


### PR DESCRIPTION
#### Rationale
Seems that gwt artifacts have migrated from the group `com.google.gwt` to `org.gwtproject`. The latest version, which we need for our Tomcat10 conversion is available only at the new coordinates.


#### Changes
- Update dependency declarations for Gwt plugin
