### PR TITLE
Make `stopTomcat` and `killFirefox` tasks more reliable on TeamCity

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ on how to do that, including how to develop and test locally and the versioning 
 _Note: 1.28.0 and later require Gradle 7_
 
 ### 2.1.1
-*Released*: TBD
+*Released*: 22 January 2024
 (Earliest compatible LabKey version: 24.2)
 * Make `stopTomcat` and `killFirefox` tasks more reliable on TeamCity
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### 2.1.1
+*Released*: TBD
+(Earliest compatible LabKey version: 24.2)
+* Make `stopTomcat` and `killFirefox` tasks more reliable on TeamCity
+
 ### 2.1.0
 *Released*: 12 January 2024
 (Earliest compatible LabKey version: 24.2)

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "2.2.0-SNAPSHOT"
+project.version = "2.1.1-stopEmbeddedTomcat-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "2.1.1-stopEmbeddedTomcat-SNAPSHOT"
+project.version = "2.2.0-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
@@ -352,6 +352,10 @@ class TeamCity extends Tomcat
                     }
             project.ant.exec(executable: "killall")
                     {
+                        arg(line: "-q firefox-bin")
+                    }
+            project.ant.exec(executable: "killall")
+                    {
                         arg(line: "-q geckodriver")
                     }
         }
@@ -470,7 +474,7 @@ class TeamCity extends Tomcat
     private void ensureShutdown(Project project)
     {
         String debugPort = extension.getTeamCityProperty("tomcat.debug")
-        if (!debugPort.isEmpty() && !BuildUtils.useEmbeddedTomcat(project))
+        if (!debugPort.isEmpty())
         {
             project.logger.debug("Ensuring shutdown using port ${debugPort}")
             try


### PR DESCRIPTION
#### Rationale
For some reason, the shutdown endpoint doesn't kill the java process for embedded tomcat on TeamCity. We run with the debug port open (`-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=${project.tomcat.debugPort}`) and the port is still in use after triggering the shutdown endpoint, though LabKey itself shuts down gracefully.
Open ports before shutdown:
```
java      177536 teamcity-agent    4u  IPv4 2887334      0t0  TCP 127.0.0.1:8213 (LISTEN)
java      177536 teamcity-agent  518u  IPv6 2890550      0t0  TCP *:8211 (LISTEN)
java      177536 teamcity-agent  581u  IPv6 2899254      0t0  TCP *:33153 (LISTEN)
```
Open ports after shutdown:
```
java      177536 teamcity-agent  518u  IPv6 2890550      0t0  TCP *:8211 (LISTEN)
java      177536 teamcity-agent  581u  IPv6 2899254      0t0  TCP *:33153 (LISTEN)
```
There might be some problem with our shutdown lifecycle but we might as well use the port to make sure the process is stopped.

While troubleshooting this, I also noticed numerous `firefox-bin` processes running; adding that to the list of processes to kill with `killFirefox`.

#### Related Pull Requests
- N/A

#### Changes
- Allow `threadDumpAndKill` to work with embedded tomcat
- Stop `firefox-bin` processes after tests on TeamCity
