### PR TITLE
Allow `useEmbeddedTomcat` and `useLocalBuild` to be turned off

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ on how to do that, including how to develop and test locally and the versioning 
 _Note: 1.28.0 and later require Gradle 7_
 
 ### 2.2.2
-*Released*: TBD
+*Released*: 31 January 2024
 (Earliest compatible LabKey version: 24.2)
 * Allow `useEmbeddedTomcat` and `useLocalBuild` to be turned off
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,12 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
-### 2.1.1
+### 2.2.2
+*Released*: TBD
+(Earliest compatible LabKey version: 24.2)
+* Allow `useEmbeddedTomcat` and `useLocalBuild` to be turned off
+
+### 2.2.1
 *Released*: 22 January 2024
 (Earliest compatible LabKey version: 24.2)
 * Make `stopTomcat` and `killFirefox` tasks more reliable on TeamCity

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ _Note: 1.28.0 and later require Gradle 7_
 (Earliest compatible LabKey version: 24.2)
 * Make `stopTomcat` and `killFirefox` tasks more reliable on TeamCity
 
+### 2.1.1 - 2.2.0 accidentally skipped
+
 ### 2.1.0
 *Released*: 12 January 2024
 (Earliest compatible LabKey version: 24.2)

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "2.2.0-SNAPSHOT"
+project.version = "2.2.2-useEmbeddedTomcatFalse-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "2.2.2-useEmbeddedTomcatFalse-SNAPSHOT"
+project.version = "2.3.0-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
@@ -144,7 +144,7 @@ class DoThenSetup extends DefaultTask
                         if (project.hasProperty("useSsl")) {
                             line = line.replace("#server.ssl", "server.ssl")
                         }
-                        if (project.hasProperty("useLocalBuild")) {
+                        if (project.hasProperty("useLocalBuild") && "false" != project.property("useLocalBuild")) {
                             // Enable properties that require 'useLocalBuild' (e.g. 'context.webAppLocation' and 'spring.devtools.restart.additional-paths')
                             line = line.replace("#useLocalBuild#", "")
                         }

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -892,7 +892,7 @@ class BuildUtils
 
     private static boolean _useEmbeddedTomcat(Object o)
     {
-        o.hasProperty(USE_EMBEDDED_TOMCAT) && o.properties[USE_EMBEDDED_TOMCAT] != "false"
+        o.hasProperty(USE_EMBEDDED_TOMCAT) && o[USE_EMBEDDED_TOMCAT] != "false"
     }
 
     static void addExternalDependency(Project project, ExternalDependency dependency, Closure closure=null)

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -882,7 +882,7 @@ class BuildUtils
 
     static boolean useEmbeddedTomcat(Project project)
     {
-        project.hasProperty(USE_EMBEDDED_TOMCAT)
+        project.hasProperty(USE_EMBEDDED_TOMCAT) && "false" != project.property(USE_EMBEDDED_TOMCAT)
     }
 
     static void addExternalDependency(Project project, ExternalDependency dependency, Closure closure=null)

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -882,7 +882,17 @@ class BuildUtils
 
     static boolean useEmbeddedTomcat(Project project)
     {
-        project.hasProperty(USE_EMBEDDED_TOMCAT) && "false" != project.property(USE_EMBEDDED_TOMCAT)
+        _useEmbeddedTomcat(project)
+    }
+
+    static boolean useEmbeddedTomcat(Settings settings)
+    {
+        _useEmbeddedTomcat(settings)
+    }
+
+    private static boolean _useEmbeddedTomcat(Object o)
+    {
+        o.hasProperty(USE_EMBEDDED_TOMCAT) && o.properties[USE_EMBEDDED_TOMCAT] != "false"
     }
 
     static void addExternalDependency(Project project, ExternalDependency dependency, Closure closure=null)


### PR DESCRIPTION
#### Rationale
In order to make embedded tomcat the default, we need a way to turn it off for testing on TeamCity.

#### Related Pull Requests
- N/A

#### Changes
- Allow `useEmbeddedTomcat` and `useLocalBuild` to be turned off with a "false" value
