### PR TITLE
Update embedded property replacement for new jdbc config pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### 2.2.3
+*Released*: TBD
+(Earliest compatible LabKey version: 24.2)
+* `DoThenSetup` tasks: update embedded property replacement for new jdbc config pattern
+
 ### 2.2.2
 *Released*: 31 January 2024
 (Earliest compatible LabKey version: 24.2)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
-### 2.2.3
+### TBD
 *Released*: TBD
 (Earliest compatible LabKey version: 24.2)
 * `DoThenSetup` tasks: update embedded property replacement for new jdbc config pattern

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "2.3.0-SNAPSHOT"
+project.version = "2.2.3-extraJdbc-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "2.2.3-extraJdbc-SNAPSHOT"
+project.version = "2.3.0-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
@@ -152,9 +152,9 @@ class DoThenSetup extends DefaultTask
                             // Remove placeholder
                             line = line.replace("#useLocalBuild#", "#")
                         }
-                        if (configProperties.containsKey("extraJdbcDataSource"))
+                        if (configProperties.containsKey("extraJdbcDataSource") && line.contains("=@@extraJdbc"))
                         {
-                            line = line.replaceAll("^#(context\\..+\\[1].*)", "\$1")
+                            line = line.replace("#context.", "context.")
                         }
                         if (line.startsWith("#")) {
                             return line // Don't apply replacements to comments


### PR DESCRIPTION
#### Rationale
The structure of data source definitions in `application.properties` is changing. We should have a more generic replacement solution to configure a second JDBC data source defined with the new pattern.

Old:
```
#context.dataSourceName[1]=jdbc/@@extraJdbcDataSource@@
#context.driverClassName[1]=@@extraJdbcDriverClassName@@
#context.url[1]=@@extraJdbcUrl@@
#context.username[1]=@@extraJdbcUsername@@
#context.password[1]=@@extraJdbcPassword@@
```
New:
```
#context.resources.jdbc.@@extraJdbcDataSource@@.driverClassName=@@extraJdbcDriverClassName@@
#context.resources.jdbc.@@extraJdbcDataSource@@.url=@@extraJdbcUrl@@
#context.resources.jdbc.@@extraJdbcDataSource@@.username=@@extraJdbcUsername@@
#context.resources.jdbc.@@extraJdbcDataSource@@.password=@@extraJdbcPassword@@
```

#### Related Pull Requests
- https://github.com/LabKey/server/pull/713

#### Changes
- Update embedded property replacement for new jdbc config pattern
