### PR TITLE
Add property to force modules to be built from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ _Note: 1.28.0 and later require Gradle 7_
 ### 2.4.0
 *Released*: TBD
 (Earliest compatible LabKey version: 24.2)
-* Add property to force modules to be built from source (`forceBuildModulesFromSource`)
+* Make `-PbuildFromSource=force` force modules to be built from source
 
 ### 2.3.0
 *Released*: 19 February 2024

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### 2.4.0
+*Released*: TBD
+(Earliest compatible LabKey version: 24.2)
+* Add property to force modules to be built from source (`forceBuildModulesFromSource`)
+
 ### 2.3.0
 *Released*: 19 February 2024
 (Earliest compatible LabKey version: 24.2)

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "2.4.0-SNAPSHOT"
+project.version = "2.4.0-forceBuildModulesFromSource-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "2.4.0-forceBuildModulesFromSource-SNAPSHOT"
+project.version = "2.4.0-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -266,8 +266,8 @@ class BuildUtils
             if (isSvnModule(project))
                 reasons.add("svn module without ${property} property set to true")
         }
-        else if (!Boolean.valueOf((String) value))
-            reasons.add("${property} property is false")
+        else if (BuildFromSource.fromProperty(value) == BuildFromSource._FALSE)
+            reasons.add("${property} property is not 'true'")
 
         return reasons
     }
@@ -703,6 +703,9 @@ class BuildUtils
         {
             if (depProject != null)
                 parentProject.logger.debug("Found project ${depProjectPath}; building ${depProjectPath} from source")
+            else
+                parentProject.logger.debug("Did not find project ${depProjectPath}; forcing project dependency as requested by '-P${BUILD_FROM_SOURCE_PROP}'")
+
             if (depProjectConfig != null)
                 parentProject.dependencies.add(parentProjectConfig, parentProject.dependencies.project(path: depProjectPath, configuration: depProjectConfig, transitive: isTransitive), closure)
             else
@@ -738,7 +741,7 @@ class BuildUtils
 
     private static boolean shouldForceBuildFromSource(Project parentProject, String projectPath)
     {
-        return parentProject.hasProperty('forceBuildModulesFromSource') && projectPath.contains(":modules:")
+        return BuildFromSource.fromProperty(parentProject, BUILD_FROM_SOURCE_PROP) == BuildFromSource.FORCE && projectPath.contains(":modules:")
     }
 
     static String getLabKeyArtifactName(Project parentProject, String projectPath, String version, String extension)
@@ -968,6 +971,24 @@ class BuildUtils
             }
         } catch (UnknownDomainObjectException ignore) {
             project.logger.debug("No ${configName} configuration found for ${project.path}.")
+        }
+    }
+
+    enum BuildFromSource {
+        _TRUE,
+        _FALSE,
+        FORCE
+
+        static BuildFromSource fromProperty(Project project, String propertyName) {
+            String propertyValue = project.hasProperty(propertyName) ? project.property(propertyName) : null
+            fromProperty(propertyValue)
+        }
+
+        static BuildFromSource fromProperty(String propertyValue) {
+            if ('force' == propertyValue)
+                return FORCE
+            else
+                return Boolean.valueOf(propertyValue) ? _TRUE : _FALSE
         }
     }
 }

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -738,7 +738,7 @@ class BuildUtils
 
     private static boolean shouldForceBuildFromSource(Project parentProject, String projectPath)
     {
-        return parentProject.hasProperty('forceBuildModulesFromSource') && projectPath.startsWith(":server:modules:")
+        return parentProject.hasProperty('forceBuildModulesFromSource') && projectPath.contains(":modules:")
     }
 
     static String getLabKeyArtifactName(Project parentProject, String projectPath, String version, String extension)

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -699,9 +699,10 @@ class BuildUtils
     {
         Project depProject = parentProject.rootProject.findProject(depProjectPath)
 
-        if (depProject != null && shouldBuildFromSource(depProject))
+        if (depProject != null && shouldBuildFromSource(depProject) || shouldForceBuildFromSource(parentProject, depProjectPath))
         {
-            parentProject.logger.debug("Found project ${depProjectPath}; building ${depProjectPath} from source")
+            if (depProject != null)
+                parentProject.logger.debug("Found project ${depProjectPath}; building ${depProjectPath} from source")
             if (depProjectConfig != null)
                 parentProject.dependencies.add(parentProjectConfig, parentProject.dependencies.project(path: depProjectPath, configuration: depProjectConfig, transitive: isTransitive), closure)
             else
@@ -733,6 +734,11 @@ class BuildUtils
 
             parentProject.dependencies.add(parentProjectConfig, getLabKeyArtifactName(parentProject, depProjectPath, depVersion, depExtension), combinedClosure)
         }
+    }
+
+    private static boolean shouldForceBuildFromSource(Project parentProject, String projectPath)
+    {
+        return parentProject.hasProperty('forceBuildModulesFromSource') && projectPath.startsWith(":server:modules:")
     }
 
     static String getLabKeyArtifactName(Project parentProject, String projectPath, String version, String extension)


### PR DESCRIPTION
#### Rationale
Sometime we remove modules and don't realize that they were still being referenced somewhere until we bump `labkeyVersion`. We are going to move a large number of modules soon so we should have some mechanism to prevent builds on TeamCity from pulling pre-built modules when we don't expect them to.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- Add property to force modules to be built from source
