### PR TITLE
Reconcile log4j2.xml file with embedded version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ on how to do that, including how to develop and test locally and the versioning 
 _Note: 1.28.0 and later require Gradle 7_
 
 ### 2.4.0
-*Released*: TBD
+*Released*: 27 February 2024
 (Earliest compatible LabKey version: 24.2)
 * Make `-PbuildFromSource=force` force modules to be built from source
+* Update `log4j2.xml` to match embedded tomcat version
 
 ### 2.3.0
 *Released*: 19 February 2024

--- a/distributionResources/log4j2.xml
+++ b/distributionResources/log4j2.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
-<Configuration packages="org.labkey.api.util">
+<Configuration packages="org.labkey.api.util,org.labkey.embedded">
 
     <Appenders>
         <Console name="CONSOLE" target="SYSTEM_OUT">
             <!-- p=priority c=category d=datetime t=thread m=message n=newline -->
             <PatternLayout pattern="%-5p %-24.24c{1} %d{ISO8601} %24.24t : %m%n" />
-
         </Console>
 
         <RollingFile name="ERRORS"
@@ -21,23 +20,12 @@
             </PatternLayout>
             <Policies>
                 <OnStartupTriggeringPolicy />
-                <SizeBasedTriggeringPolicy size="10 MB"/>
+                <SizeBasedTriggeringPolicy size="100 MB"/>
             </Policies>
-            <DefaultRolloverStrategy fileIndex="min" max="3">
-                <Delete basePath="${sys:labkey.log.home}">
-                    <ScriptCondition>
-                        <!-- Use custom Java code to retain the first log file from the current session if it's about
-                        to be rotated out. It may have root cause information about problems that would otherwise be lost -->
-                        <Script name="retainFirst" language="rhino"><![CDATA[
-                                var ErrorLogRotator = org.labkey.api.util.logging.ErrorLogRotator;
-                                var rotator = new ErrorLogRotator();
-                                rotator.filter(pathList);
-                            ]]>
-                        </Script>
-                    </ScriptCondition>
-                </Delete>
+            <DefaultRolloverStrategy fileIndex="min">
+                <LabKeyDelete basePath="${sys:labkey.log.home}">
+                </LabKeyDelete>
             </DefaultRolloverStrategy>
-
         </RollingFile>
 
         <RollingFile name="ACTION_STATS"
@@ -168,31 +156,44 @@
     </Appenders>
 
     <Loggers>
+        <!--
+            Set all packages to INFO level (org.labkey, org.fhcrc, third-party dependencies) by default
+            and send errors to the labkey-errors.log as well.
+        -->
+        <Root level="info">
+            <AppenderRef ref="CONSOLE"/>
+            <AppenderRef ref="LABKEY"/>
+            <AppenderRef ref="ERRORS"/>
+        </Root>
 
         <!-- category for server side script messages -->
         <Logger name="org.labkey.api.script.ScriptService.Console" level="info">
             <AppenderRef ref="SessionAppender"/>
         </Logger>
 
-
         <!-- category for Mule messages -->
         <Logger name="org.mule.MuleManager" level="info"/>
 
         <!--
             <Logger name="org.labkey.pipeline.mule.transformers" level="debug"/>
-         -->
+        -->
 
         <!-- category for jasper messages -->
         <Logger name="org.apache.jasper" level="warn"/>
 
-        <!-- application classes -->
-        <Logger name="org.fhcrc" level="info"/>
+        <Logger name="org.labkey" />
 
-
-        <Logger name="org.labkey" level="info">
+        <!-- uncomment to enable 'DEBUG' level on external SAML libraries to troubleshoot.
+        Note: you will also have to set dependency on slf4j lib in saml/build.gradle - uncomment 'slf4j' external libraries and build
+        <Logger name="org.opensaml" level="DEBUG">
             <AppenderRef ref="CONSOLE"/>
             <AppenderRef ref="LABKEY"/>
         </Logger>
+
+        <Logger name="org.apache.xml.security" level="DEBUG">
+            <AppenderRef ref="CONSOLE"/>
+            <AppenderRef ref="LABKEY"/>
+        </Logger> -->
 
         <Logger name="mondrian." level="info" />
 
@@ -209,6 +210,9 @@
 
         <!-- don't need to log PDFBox errors (e.g., FlateFilter, PDCIDFontType2) -->
         <Logger name="org.apache.pdfbox" level="fatal"/>
+
+        <!-- Suppress EHCache "maxElementsInMemory of 0" warnings, Issue 49593 -->
+        <Logger name="net.sf.ehcache.config.CacheConfiguration" level="error"/>
 
         <!-- this is a very verbose logger for security/permissions checking -->
         <!--
@@ -231,7 +235,6 @@
         </Logger>
 
         <Logger name="org.labkey.rstudio" level="info"/>
-
 
         <!--
             <Logger name="org.labkey.api.cache" level="debug"/>
@@ -321,7 +324,7 @@
             SearchAuditEvent
             SelectQuery
          To enable logging of all events, set the level for the org.labkey.audit.event to
-         something other than "OFF".  To enable individual audit event logging, configure the
+         something other than "OFF". To enable individual audit event logging, configure the
          individual stanza like the one shown below, where you prefix the audit event type
          with 'org.labkey.audit.event'. Then set the level to INFO and specify the appenders.
         -->
@@ -331,9 +334,5 @@
         </Logger>
 
         <Logger name="NoOpLogger" level="OFF" additivity="false"/>
-
-        <Root level="error">
-            <AppenderRef ref="ERRORS"/>
-        </Root>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
#### Rationale
We have two copies of this file, one for standalone Tomcat (in the gradle plugin) and one for embedded Tomcat (in the server embedded module). They should have the same content.

#### Related Pull Requests
- https://github.com/LabKey/server/pull/735