### PR TITLE
Issue 49824: Improve embedded Tomcat auto-redeploy using a trigger file

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### TBD
+*Released*: TBD
+(Eraliest compatible LabKey version: 24.2)
+* [Issue 49824](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49824): Improve embedded Tomcat auto-redeploy using a trigger file
+
 ### 2.4.0
 *Released*: 27 February 2024
 (Earliest compatible LabKey version: 24.2)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ _Note: 1.28.0 and later require Gradle 7_
 
 ### TBD
 *Released*: TBD
-(Eraliest compatible LabKey version: 24.2)
+(Earliest compatible LabKey version: 24.2)
 * [Issue 49824](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49824): Improve embedded Tomcat auto-redeploy using a trigger file
 
 ### 2.4.0

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "2.4.0-SNAPSHOT"
+project.version = "2.5.0-restartTrigger-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "2.5.0-restartTrigger-SNAPSHOT"
+project.version = "2.5.0-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
@@ -243,7 +243,7 @@ class FileModule implements Plugin<Project>
                             copy.into ServerDeployExtension.getModulesDeployDirectory(project)
                             copy.setDuplicatesStrategy(DuplicatesStrategy.INCLUDE)
                         }
-                        BuildUtils.touchRestartTriggerFile(project)
+                        BuildUtils.updateRestartTriggerFile(project)
                     }
                 }
 
@@ -266,7 +266,7 @@ class FileModule implements Plugin<Project>
                         Api.deleteModulesApiJar(project)
                     }
                     task.doLast {
-                        BuildUtils.touchRestartTriggerFile(project)
+                        BuildUtils.updateRestartTriggerFile(project)
                     }
             }
 

--- a/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
@@ -243,6 +243,7 @@ class FileModule implements Plugin<Project>
                             copy.into ServerDeployExtension.getModulesDeployDirectory(project)
                             copy.setDuplicatesStrategy(DuplicatesStrategy.INCLUDE)
                         }
+                        BuildUtils.touchRestartTriggerFile(project)
                     }
                 }
 
@@ -263,6 +264,9 @@ class FileModule implements Plugin<Project>
                     task.doFirst {
                         undeployModule(project)
                         Api.deleteModulesApiJar(project)
+                    }
+                    task.doLast {
+                        BuildUtils.touchRestartTriggerFile(project)
                     }
             }
 

--- a/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
@@ -79,7 +79,7 @@ class ServerDeploy implements Plugin<Project>
                 task.group = GroupNames.DEPLOY
                 task.description = "Deploy the application locally into ${serverDeploy.dir}"
                 task.doLast( {
-                    BuildUtils.touchRestartTriggerFile(project)
+                    BuildUtils.updateRestartTriggerFile(project)
                 } )
         }
 

--- a/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ServerDeploy.groovy
@@ -78,6 +78,9 @@ class ServerDeploy implements Plugin<Project>
             DeployApp task ->
                 task.group = GroupNames.DEPLOY
                 task.description = "Deploy the application locally into ${serverDeploy.dir}"
+                task.doLast( {
+                    BuildUtils.touchRestartTriggerFile(project)
+                } )
         }
 
         StagingExtension staging = project.getExtensions().getByType(StagingExtension.class)

--- a/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
@@ -180,7 +180,7 @@ class DoThenSetup extends DefaultTask
                         return PropertiesUtils.replaceProps(line, configProperties, false)
                     })
                 })
-                BuildUtils.touchRestartTriggerFile(project)
+                BuildUtils.updateRestartTriggerFile(project)
             }
         }
     }

--- a/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
@@ -180,6 +180,7 @@ class DoThenSetup extends DefaultTask
                         return PropertiesUtils.replaceProps(line, configProperties, false)
                     })
                 })
+                BuildUtils.touchRestartTriggerFile(project)
             }
         }
     }

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -914,7 +914,7 @@ class BuildUtils
      * We use build/deploy/modules because when using a local build it's added in the application.properties file as a
      * spring.devtools.restart.additional-paths
      *
-     * @param project
+     * @param project - for use in getting the rootProject's build directory
      */
     static void updateRestartTriggerFile(Project project)
     {

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -909,7 +909,7 @@ class BuildUtils
     /**
      * Writes a file in the build/deploy/modules directory that can be used as a trigger file for restarting
      * SpringBoot. Without this, restarts may happen before the full application deployment is done, resulting
-     * if a failed start. See
+     * in a failed start. See
      * https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#using.devtools.restart.triggerfile
      * We use build/deploy/modules because when using a local build it's added in the application.properties file as a
      * spring.devtools.restart.additional-paths

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -916,7 +916,7 @@ class BuildUtils
      *
      * @param project
      */
-    static void touchRestartTriggerFile(Project project)
+    static void updateRestartTriggerFile(Project project)
     {
         OutputStreamWriter writer = null
         try {

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -33,8 +33,10 @@ import org.labkey.gradle.plugin.extension.ServerDeployExtension
 import org.labkey.gradle.plugin.extension.TeamCityExtension
 import org.labkey.gradle.task.ModuleDistribution
 
+import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Paths
+import java.text.SimpleDateFormat
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
@@ -50,7 +52,7 @@ class BuildUtils
     public static final String PLATFORM_MODULES_DIR = "server/modules/platform"
     public static final String COMMON_ASSAYS_MODULES_DIR = "server/modules/commonAssays"
     public static final String CUSTOM_MODULES_DIR = "server/modules/customModules"
-
+    private static final String RESTART_FILE_NAME = ".restartTrigger"
 
     public static final List<String> EHR_MODULE_NAMES = [
             "EHR_ComplianceDB",
@@ -902,6 +904,31 @@ class BuildUtils
     private static boolean _useEmbeddedTomcat(Object o)
     {
         o.hasProperty(USE_EMBEDDED_TOMCAT) && o[USE_EMBEDDED_TOMCAT] != "false"
+    }
+
+    /**
+     * Writes a file in the build/deploy/modules directory that can be used as a trigger file for restarting
+     * SpringBoot. Without this, restarts may happen before the full application deployment is done, resulting
+     * if a failed start. See
+     * https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#using.devtools.restart.triggerfile
+     * We use build/deploy/modules because when using a local build it's added in the application.properties file as a
+     * spring.devtools.restart.additional-paths
+     *
+     * @param project
+     */
+    static void touchRestartTriggerFile(Project project)
+    {
+        OutputStreamWriter writer = null
+        try {
+            File triggerFile = project.rootProject.layout.buildDirectory.file("deploy/modules/${RESTART_FILE_NAME}").get().getAsFile()
+            writer = new OutputStreamWriter(new FileOutputStream(triggerFile), StandardCharsets.UTF_8)
+            writer.write(SimpleDateFormat.getDateTimeInstance().format(new Date()))
+        }
+        finally
+        {
+            if (writer != null)
+                writer.close()
+        }
     }
 
     static void addExternalDependency(Project project, ExternalDependency dependency, Closure closure=null)


### PR DESCRIPTION
#### Rationale
[Issue 49824](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49824) Currently, we have configured the restart of embedded tomcat by having SpringBoot watch the `build/deploy/modules` and `build/deploy/embedded` directories. Since we write a lot of things to these directories during a deployment, when using a local build, usually the restart from SpringBoot happens before all the copying is complete, resulting in a failed start and the need to start manually.  This PR adds a final step in various tasks that are meant to trigger a restart , which will modify a file that we will configure SpringBoot to look for as a signal to restart (see [SpringBoot docs](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#using.devtools.restart.triggerfile)).

#### Related Pull Requests
- https://github.com/LabKey/server/pull/759

#### Changes
- Add a `BuildUtils.updateRestartTriggerFile` method and tie it into various restart-triggering tasks
