### PR TITLE
Skip trigger file creation if not using local build

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ _Note: 1.28.0 and later require Gradle 7_
 *Released*: BD
 (Earliest compatible LabKey version: 24.2)
 * Don't write restartTrigger file if not using local build (e.g., on TeamCity)
+* Avoid errors for missing `distributionDir` property
 
 ### 2.5.0
 *Released*: 10 March 2024

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### TBD
+*Released*: BD
+(Earliest compatible LabKey version: 24.2)
+* Don't write restartTrigger file if not using local build (e.g., on TeamCity)
+
 ### 2.5.0
 *Released*: 10 March 2024
 (Earliest compatible LabKey version: 24.2)

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
-### TBD
-*Released*: BD
+### 2.5.1
+*Released*: 11 March 2024
 (Earliest compatible LabKey version: 24.2)
 * Don't write restartTrigger file if not using local build (e.g., on TeamCity)
 * Avoid errors for missing `distributionDir` property

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "2.6.0-SNAPSHOT"
+project.version = "2.6.0-skipTriggerFile-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "2.6.0-skipTriggerFile-SNAPSHOT"
+project.version = "2.6.0-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
@@ -242,27 +242,27 @@ class ModuleDistribution extends DefaultTask
 
     private String getTarArchivePath()
     {
-        return "${getResolvedDistributionDir()}/${getArchiveName()}.${DistributionExtension.TAR_ARCHIVE_EXTENSION}"
+        return "${getDistributionDir()}/${getArchiveName()}.${DistributionExtension.TAR_ARCHIVE_EXTENSION}"
     }
 
     private String getEmbeddedTarArchivePath()
     {
-        return "${getResolvedDistributionDir()}/${getArchiveName()}${DistributionExtension.EMBEDDED_SUFFIX}.${DistributionExtension.TAR_ARCHIVE_EXTENSION}"
+        return "${getDistributionDir()}/${getArchiveName()}${DistributionExtension.EMBEDDED_SUFFIX}.${DistributionExtension.TAR_ARCHIVE_EXTENSION}"
     }
 
     private String getZipArchivePath()
     {
-        return "${getResolvedDistributionDir()}/${getArchiveName()}.${DistributionExtension.ZIP_ARCHIVE_EXTENSION}"
+        return "${getDistributionDir()}/${getArchiveName()}.${DistributionExtension.ZIP_ARCHIVE_EXTENSION}"
     }
 
     private String getEmbeddedZipArchivePath()
     {
-        return "${getResolvedDistributionDir()}/${getArchiveName()}${DistributionExtension.EMBEDDED_SUFFIX}.${DistributionExtension.ZIP_ARCHIVE_EXTENSION}"
+        return "${getDistributionDir()}/${getArchiveName()}${DistributionExtension.EMBEDDED_SUFFIX}.${DistributionExtension.ZIP_ARCHIVE_EXTENSION}"
     }
 
     private String getWarArchivePath()
     {
-        return "${getResolvedDistributionDir()}/${getArchiveName()}.war"
+        return "${getDistributionDir()}/${getArchiveName()}.war"
     }
 
     private File getWindowsUtilDir()

--- a/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
@@ -15,6 +15,8 @@
  */
 package org.labkey.gradle.task
 
+import org.apache.commons.lang3.StringUtils
+
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.Project
@@ -54,8 +56,7 @@ class ModuleDistribution extends DefaultTask
     @Input
     boolean simpleDistribution = false // Set to true to exclude pipeline tools and remote pipeline libraries
 
-    @OutputDirectory
-    File distributionDir
+    private File distributionDir
 
     private final DistributionExtension distExtension
     private Project licensingProject
@@ -77,10 +78,14 @@ class ModuleDistribution extends DefaultTask
     }
 
     @OutputDirectory
-    File getResolvedDistributionDir()
+    File getDistributionDir()
     {
-        if (distributionDir == null && subDirName != null)
-            distributionDir = project.file("${distExtension.dir}/${subDirName}")
+        if (distributionDir == null) {
+            var subDir = StringUtils.trimToNull(subDirName)
+            if (subDir == null)
+                subDir = project.name
+            distributionDir = project.file("${distExtension.dir}/${subDir}")
+        }
         return distributionDir
     }
 

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -918,6 +918,9 @@ class BuildUtils
      */
     static void updateRestartTriggerFile(Project project)
     {
+        if (!project.hasProperty('useLocalBuild') || "false" == project.property("useLocalBuild"))
+            return
+
         OutputStreamWriter writer = null
         try {
             File triggerFile = project.rootProject.layout.buildDirectory.file("deploy/modules/${RESTART_FILE_NAME}").get().getAsFile()


### PR DESCRIPTION
#### Rationale
TeamCity apparently does not have a `build/deploy/modules` directory and is angry about our trying to write a file there.  We'll skip the writing of this file if not using a local build.

#### Related Pull Requests
- #200 

#### Changes
- Don't write trigger file if not using local build.
