### PR TITLE
Don't create reload trigger file if output directory doesn't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ _Note: 1.28.0 and later require Gradle 7_
 ### TBD
 *Released*: TBD
 (Earliest compatible LabKey version: 24.2)
-* Create output directory for reloadTrigger file if it doesn't exist
+* Account for missing directory for reloadTrigger fle
 
 ### 2.6.0
 *Released*: 11 March 2024

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ _Note: 1.28.0 and later require Gradle 7_
 ### 2.6.1
 *Released*: 12 March 2024
 (Earliest compatible LabKey version: 24.2)
-* Account for missing directory for reloadTrigger file
+* Account for a missing directory for reloadTrigger file
 
 ### 2.6.0
 *Released*: 11 March 2024

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### TBD
+*Released*: TBD
+(Earliest compatible LabKey version: 24.2)
+* Create output directory for reloadTrigger file if it doesn't exist
+
 ### 2.6.0
 *Released*: 11 March 2024
 (Earliest compatible LabKey version: 24.2)

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
-### TBD
-*Released*: TBD
+### 2.6.1
+*Released*: 12 March 2024
 (Earliest compatible LabKey version: 24.2)
-* Account for missing directory for reloadTrigger fle
+* Account for missing directory for reloadTrigger file
 
 ### 2.6.0
 *Released*: 11 March 2024

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "2.7.0-SNAPSHOT"
+project.version = "2.7.0-createTriggerDir-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "2.7.0-createTriggerDir-SNAPSHOT"
+project.version = "2.7.0-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -921,11 +921,12 @@ class BuildUtils
         if (!project.hasProperty('useLocalBuild') || "false" == project.property("useLocalBuild"))
             return
 
+        File triggerFileDir = project.rootProject.layout.buildDirectory.file("deploy/modules").get().getAsFile()
+        if (!triggerFileDir.exists())
+            return
+
         OutputStreamWriter writer = null
         try {
-            File triggerFileDir = project.rootProject.layout.buildDirectory.file("deploy/modules").get().getAsFile()
-            triggerFileDir.mkdirs()
-
             File triggerFile = new File(triggerFileDir, RESTART_FILE_NAME)
             writer = new OutputStreamWriter(new FileOutputStream(triggerFile), StandardCharsets.UTF_8)
             writer.write(SimpleDateFormat.getDateTimeInstance().format(new Date()))

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -923,7 +923,10 @@ class BuildUtils
 
         OutputStreamWriter writer = null
         try {
-            File triggerFile = project.rootProject.layout.buildDirectory.file("deploy/modules/${RESTART_FILE_NAME}").get().getAsFile()
+            File triggerFileDir = project.rootProject.layout.buildDirectory.file("deploy/modules").get().getAsFile()
+            triggerFileDir.mkdirs()
+
+            File triggerFile = new File(triggerFileDir, RESTART_FILE_NAME)
             writer = new OutputStreamWriter(new FileOutputStream(triggerFile), StandardCharsets.UTF_8)
             writer.write(SimpleDateFormat.getDateTimeInstance().format(new Date()))
         }


### PR DESCRIPTION
#### Rationale
Since the reload trigger file is not designated as an output file of any of the tasks that use this utility method, the directory does not automatically get created. If there is no `build/deploy/modules` directory, there is no restart to be triggered, so we'll just exit from the method that wants to update that file.

#### Related Pull Requests
- https://github.com/LabKey/server/pull/766

#### Changes
- Update `BuildUtils.updateRestartTriggerFile` to check for output directory before trying to write the file.
