### PR TITLE
Hack to fix BuildUtils.getModuleProjectPath to account for limsModules repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### 2.6.2
+*Released*: TBD
+(Earliest compatible LabKey version: 24.3)
+* Fix problem with `BuildUtils.getModuleProjectPath` to account for `limsModules` repo
+
 ### 2.6.1
 *Released*: 12 March 2024
 (Earliest compatible LabKey version: 24.2)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ on how to do that, including how to develop and test locally and the versioning 
 _Note: 1.28.0 and later require Gradle 7_
 
 ### 2.6.2
-*Released*: TBD
+*Released*: 6 April 2024
 (Earliest compatible LabKey version: 24.3)
 * Fix problem with `BuildUtils.getModuleProjectPath` to account for `limsModules` repo
 

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "2.7.0-limsModulesProjectPath-SNAPSHOT"
+project.version = "2.7.0-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "2.7.0-SNAPSHOT"
+project.version = "2.7.0-limsModulesProjectPath-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -551,6 +551,8 @@ class BuildUtils
             'tomcat7-websocket'
     ]
 
+    private static List LIMS_MODULES = ["biologics", "inventory", "labbook", "puppeteer", "recipe", "sampleManagement"]
+
     static String getGitUrl(Project project)
     {
         def grgit = Grgit.open(currentDir: project.projectDir)
@@ -788,6 +790,8 @@ class BuildUtils
 
     static String getModuleProjectPath(ModuleDependency dependency)
     {
+        if (LIMS_MODULES.contains(dependency.getName()))
+            return ":server:modules:limsModules:" + dependency.getName()
         return ":server:modules:" + dependency.getName()
     }
 


### PR DESCRIPTION
#### Rationale
The `BuildUtils.getModuleProjectPath` assumed all modules were at the top level, but that is not true. This fix is a hack that does enough for our 24.3 release purposes. We'll want to change the dependency exclusion declaration to move away from using the project path and use either the group and artifact designation instead (e.g., "org.labkey.module:biologics") or probably just the module name, but this change is sufficient for current purposes.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- Special case for limsModules in `BuildUtils.getModuleProjectPath`
