### PR TITLE
Change `Distribution.inheritDependencies` exclusion list to be just the module names

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### TBD
+*Released*: TBD
+(Earliest compatible LabKey version: 24.3)
+* Change `Distribution.inheritDependencies` exclusion list to be just the module names
+
 ### 2.6.2
 *Released*: 6 April 2024
 (Earliest compatible LabKey version: 24.3)

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
-### TBD
-*Released*: TBD
-(Earliest compatible LabKey version: 24.4)
+### 2.6.3
+*Released*: 12 April 2024
+(Earliest compatible LabKey version: 24.5)
 * Change `Distribution.inheritDependencies` exclusion list to be just the module names
 
 ### 2.6.2

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ _Note: 1.28.0 and later require Gradle 7_
 
 ### TBD
 *Released*: TBD
-(Earliest compatible LabKey version: 24.3)
+(Earliest compatible LabKey version: 24.4)
 * Change `Distribution.inheritDependencies` exclusion list to be just the module names
 
 ### 2.6.2

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "2.7.0-moduleExclusion-SNAPSHOT"
+project.version = "2.7.0-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "2.7.0-SNAPSHOT"
+project.version = "2.7.0-moduleExclusion-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
@@ -154,7 +154,7 @@ class Distribution implements Plugin<Project>
      * to easily build upon one another.
      * @param project the project that is to inherit dependencies
      * @param inheritedProjectPath the project whose dependencies are inherited
-     * @param list of paths for modules that are to be excluded from the set of inherited modules (e.g., [":server:modules:search"])
+     * @param list of names of modules that are to be excluded from the set of inherited modules (e.g., ["search"])
      */
     static void inheritDependencies(Project project, String inheritedProjectPath, List<String> excludedModules=[])
     {
@@ -165,10 +165,10 @@ class Distribution implements Plugin<Project>
         project.project(inheritedProjectPath).configurations.distribution.dependencies.each {
             Dependency dep ->
                 if (dep instanceof ProjectDependency) {
-                    if (!excludedModules.contains(dep.dependencyProject.path))
+                    if (!excludedModules.contains(dep.getName()))
                         project.dependencies.add("distribution", dep)
                 }
-                else if (dep instanceof ModuleDependency && !excludedModules.contains(BuildUtils.getModuleProjectPath(dep)))
+                else if (dep instanceof ModuleDependency && !excludedModules.contains(dep.getName()))
                     project.dependencies.add("distribution", dep)
         }
     }

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -551,8 +551,6 @@ class BuildUtils
             'tomcat7-websocket'
     ]
 
-    private static List LIMS_MODULES = ["biologics", "inventory", "labbook", "puppeteer", "recipe", "sampleManagement"]
-
     static String getGitUrl(Project project)
     {
         def grgit = Grgit.open(currentDir: project.projectDir)
@@ -786,13 +784,6 @@ class BuildUtils
         String extensionString = extension == null ? "" : "@$extension"
 
         return "${group}:${moduleName}${versionString}${extensionString}"
-    }
-
-    static String getModuleProjectPath(ModuleDependency dependency)
-    {
-        if (LIMS_MODULES.contains(dependency.getName()))
-            return ":server:modules:limsModules:" + dependency.getName()
-        return ":server:modules:" + dependency.getName()
     }
 
     static String getRepositoryKey(Project project)


### PR DESCRIPTION
#### Rationale
Since module names have to be unique, using a gradle project path for the exclusion of modules is unnecessary and not robust to those modules moving into common repositories.

#### Related Pull Requests
- #206 
- https://github.com/LabKey/distributions/pull/441

#### Changes
- Remove `BuildUtils.getModuleProjectPath`
- Update `Distribution.inheritDependencies` to expect a set of names of modules