### PR TITLE
Put startup properties in correct folder for embedded deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### 2.6.4
+*Released*: TBD
+(Earliest compatible LabKey version: 24.5)
+* Put startup properties in correct folder for embedded deployments
+
 ### 2.6.3
 *Released*: 12 April 2024
 (Earliest compatible LabKey version: 24.5)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ on how to do that, including how to develop and test locally and the versioning 
 _Note: 1.28.0 and later require Gradle 7_
 
 ### 2.6.4
-*Released*: TBD
+*Released*: 6 May 2024
 (Earliest compatible LabKey version: 24.5)
 * Put startup properties in correct folder for embedded deployments
 

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "2.6.4-startupEmbedded-SNAPSHOT"
+project.version = "2.7.0-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "2.7.0-SNAPSHOT"
+project.version = "2.6.4-startupEmbedded-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
@@ -146,7 +146,9 @@ class TeamCity extends Tomcat
             doLast {
                 String properties = extension.getTeamCityProperty('labkey.startup.properties')
 
-                extension.writeStartupProperties('99_teamcity_startup.properties', properties)
+                if (!properties.isBlank()) {
+                    extension.writeStartupProperties('99_teamcity_startup.properties', properties)
+                }
             }
         }
 

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/TeamCityExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/TeamCityExtension.groovy
@@ -118,7 +118,7 @@ class TeamCityExtension
     File startupPropertiesDir() {
         File startupDir
         if (BuildUtils.useEmbeddedTomcat(project)) {
-            startupDir = new File(new File(ServerDeployExtension.getEmbeddedServerDeployDirectory(project)), 'server/startup')
+            startupDir = new File(new File(ServerDeployExtension.getEmbeddedServerDeployDirectory(project)), 'startup')
         } else {
             startupDir = new File(new File(ServerDeployExtension.getServerDeployDirectory(project)), 'startup')
         }


### PR DESCRIPTION
#### Rationale
Distributions no longer extract themselves into `build/deploy/embedded/server`. The correct location for startup properties files is now `build/deploy/embedded/startup`.

#### Related Pull Requests
- https://github.com/LabKey/server/pull/752

#### Changes
- Put startup properties in correct folder for embedded deployments
- Don't create empty startup properties file
