### PR TITLE
Add and update flags for embedded tomcat

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ on how to do that, including how to develop and test locally and the versioning 
 _Note: 1.28.0 and later require Gradle 7_
 
 ### 2.7.0
-*Released*: TBD
+*Released*: 14 May 2024
 (Earliest compatible LabKey version: 24.5)
 * Include required reflection parameters to embedded `StartTomcat`
 * Build embedded distribution archives regardless of `useEmbeddedTomcat` flag

--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### 2.7.0
+*Released*: TBD
+(Earliest compatible LabKey version: 24.5)
+* Include required reflection parameters to embedded `StartTomcat`
+* Build embedded distribution archives regardless of `useEmbeddedTomcat` flag
+* Add flags to override distributions' specified archive type (`forceStandaloneDist` & `forceEmbeddedDist`)
+
 ### 2.6.4
 *Released*: 6 May 2024
 (Earliest compatible LabKey version: 24.5)

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "2.7.0-SNAPSHOT"
+project.version = "2.7.0-embeddedDistFlags-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "2.7.0-embeddedDistFlags-SNAPSHOT"
+project.version = "2.8.0-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/Distribution.groovy
@@ -101,10 +101,7 @@ class Distribution implements Plugin<Project>
                 utilities "org.labkey.tools.windows:utils:${project.windowsUtilsVersion}@zip"
             }
 
-        if (BuildUtils.useEmbeddedTomcat(project))
-        {
-            BuildUtils.addLabKeyDependency(project: project, config: "embedded", depProjectPath: BuildUtils.getEmbeddedProjectPath(project.gradle), depVersion: project.labkeyVersion, depProjectConfig: "embedded", transitive: false)
-        }
+        BuildUtils.addLabKeyDependency(project: project, config: "embedded", depProjectPath: BuildUtils.getEmbeddedProjectPath(project.gradle), depVersion: project.labkeyVersion, depProjectConfig: "embedded", transitive: false)
         TaskUtils.configureTaskIfPresent(project, 'artifactoryDeploy', { dependsOn(project.tasks.distribution) })
 
     }

--- a/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
@@ -89,8 +89,12 @@ class ModuleDistribution extends DefaultTask
     }
 
     private boolean shouldBuildEmbeddedArchive(String extension = null) {
-        return (embeddedArchiveType != null && (extension == null || embeddedArchiveType.indexOf(extension) >= 0)) &&
-                makeDistribution && BuildUtils.useEmbeddedTomcat(project)
+        return (embeddedArchiveType != null && (extension == null || embeddedArchiveType.indexOf(extension) >= 0)) && makeDistribution
+                || DistributionExtension.TAR_ARCHIVE_EXTENSION == extension && project.hasProperty("forceEmbeddedDist")
+    }
+
+    private boolean shouldBuildStandaloneTarGz() {
+        includeTarGZArchive || project.hasProperty("forceStandaloneDist")
     }
 
     @OutputFiles
@@ -101,7 +105,7 @@ class ModuleDistribution extends DefaultTask
         if (shouldBuildEmbeddedArchive())
             distFiles.add(new File(getEmbeddedTomcatJarPath()))
 
-        if (includeTarGZArchive)
+        if (shouldBuildStandaloneTarGz())
             distFiles.add(new File(getTarArchivePath()))
         if (shouldBuildEmbeddedArchive(DistributionExtension.TAR_ARCHIVE_EXTENSION))
             distFiles.add(new File(getEmbeddedTarArchivePath()))
@@ -209,7 +213,7 @@ class ModuleDistribution extends DefaultTask
 
     private void packageArchives()
     {
-        if (includeTarGZArchive)
+        if (shouldBuildStandaloneTarGz())
             tarArchives()
         if (shouldBuildEmbeddedArchive(DistributionExtension.TAR_ARCHIVE_EXTENSION))
             embeddedTomcatTarArchive()

--- a/src/main/groovy/org/labkey/gradle/task/StartTomcat.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/StartTomcat.groovy
@@ -174,7 +174,7 @@ class StartTomcat extends DefaultTask
         }
 
         if (project.hasProperty("extraCatalinaOpts"))
-            optsList.addAll(((String) project.property("extraCatalinaOpts")).split(" "))
+            optsList.addAll(((String) project.property("extraCatalinaOpts")).split("\\s+"))
 
         return optsList.stream()
                 .filter({String opt -> return !StringUtils.isEmpty(opt)})
@@ -185,7 +185,7 @@ class StartTomcat extends DefaultTask
     private static List<String> getEmbeddedReflectionOpts(Project project)
     {
         if (project.hasProperty(EMBEDDED_REFLECTION_PARAM)) {
-            return ((String) project.property(EMBEDDED_REFLECTION_PARAM)).trim().split(" +")
+            return ((String) project.property(EMBEDDED_REFLECTION_PARAM)).trim().split("\\s+")
         }
         else {
             return DEFAULT_EMBEDDED_REFLECTION_OPTS

--- a/src/main/groovy/org/labkey/gradle/task/StartTomcat.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/StartTomcat.groovy
@@ -31,6 +31,15 @@ import java.util.stream.Collectors
 
 class StartTomcat extends DefaultTask
 {
+    private static final String EMBEDDED_REFLECTION_PARAM = "embeddedReflectionArgs"
+    private static final List<String> DEFAULT_EMBEDDED_REFLECTION_OPTS = [
+            "--add-opens=java.base/java.lang=ALL-UNNAMED",
+            "--add-opens=java.base/java.io=ALL-UNNAMED",
+            "--add-opens=java.base/java.util=ALL-UNNAMED",
+            "--add-opens=java.desktop/java.awt.font=ALL-UNNAMED",
+            "--add-opens=java.base/java.text=ALL-UNNAMED"
+    ]
+
     @TaskAction
     void action()
     {
@@ -57,6 +66,7 @@ class StartTomcat extends DefaultTask
             if (!javaExec.exists())
                 throw new GradleException("Invalid value for JAVA_HOME. Could not find java command in ${javaExec}")
             String[] commandParts = [javaExec.getAbsolutePath()]
+            commandParts += getEmbeddedReflectionOpts(project)
             commandParts += getStartupOpts(project)
             commandParts += ["-jar", jarFile.getName()]
 
@@ -170,5 +180,15 @@ class StartTomcat extends DefaultTask
                 .filter({String opt -> return !StringUtils.isEmpty(opt)})
                 .collect(Collectors.toList())
 
+    }
+
+    private static List<String> getEmbeddedReflectionOpts(Project project)
+    {
+        if (project.hasProperty(EMBEDDED_REFLECTION_PARAM)) {
+            return ((String) project.property(EMBEDDED_REFLECTION_PARAM)).trim().split(" +")
+        }
+        else {
+            return DEFAULT_EMBEDDED_REFLECTION_OPTS
+        }
     }
 }


### PR DESCRIPTION
#### Rationale
Adding override flags for distribution types will allow us to create non-standard distributions more easily.
Adding the required `--add-opens` parameters to the `startTomcat` task for embedded tomcat will make it function correctly by default without having to use the `extraCatalinaOpts` parameter.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Include required reflection parameters to embedded `StartTomcat`
* Build embedded distribution archives regardless of `useEmbeddedTomcat` flag
* Add flags to override distributions' specified archive type (`forceStandaloneDist` & `forceEmbeddedDist`)
