### PR TITLE
Make `ModuleDistribution` tasks more efficient with disk space

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### 2.7.2
+*Released*: TBD
+(Earliest compatible LabKey version: 24.5)
+* Make `ModuleDistribution` tasks more efficient with disk space
+
 ### 2.7.1
 *Released*: 12 June 2024
 (Earliest compatible LabKey version: 24.5)

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ on how to do that, including how to develop and test locally and the versioning 
 _Note: 1.28.0 and later require Gradle 7_
 
 ### 2.7.2
-*Released*: TBD
+*Released*: 24 June 2024
 (Earliest compatible LabKey version: 24.5)
-* Make `ModuleDistribution` tasks more efficient with disk space
+* Remediate excessive disk space usage by `ModuleDistribution` tasks
 
 ### 2.7.1
 *Released*: 12 June 2024

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "2.8.0-SNAPSHOT"
+project.version = "2.7.2-distDiskSpace-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "2.7.2-distDiskSpace-SNAPSHOT"
+project.version = "2.8.0-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
@@ -140,7 +140,6 @@ class ModuleDistribution extends DefaultTask
     File getModulesDir()
     {
         // we use a common directory to save on disk space for TeamCity.
-        // (This is just a conjecture about why it continues to run out of space and not be able to copy files from one place to the other).
         return new File("${BuildUtils.getRootBuildDirPath(project)}/distModules")
     }
 
@@ -240,7 +239,12 @@ class ModuleDistribution extends DefaultTask
 
     private String getEmbeddedTomcatJarPath()
     {
-        return BuildUtils.getBuildDirFile(project, "labkeyServer.jar").path
+        return new File(getModulesDir(), "labkeyServer.jar").path
+    }
+
+    private String getDistributionZipPath()
+    {
+        return new File(getModulesDir(), "labkey/distribution.zip").path
     }
 
     private String getTarArchivePath()
@@ -411,14 +415,14 @@ class ModuleDistribution extends DefaultTask
         StagingExtension staging = project.getExtensions().getByType(StagingExtension.class)
 
         File embeddedJarFile = project.configurations.embedded.singleFile
-        File modulesZipFile = BuildUtils.getBuildDirFile(project,"labkey/distribution.zip")
+        String modulesZipFile = getDistributionZipPath()
         File serverJarFile = new File(getEmbeddedTomcatJarPath())
-        ant.zip(destFile: modulesZipFile.getAbsolutePath()) {
+        ant.zip(destFile: modulesZipFile) {
             zipfileset(dir: staging.webappDir,
                     prefix: "labkeywebapp") {
                 exclude(name: "WEB-INF/classes/distribution")
             }
-            zipfileset(dir: BuildUtils.getRootBuildDirFile(project, "distModules"),
+            zipfileset(dir: getModulesDir(),
                     prefix: "modules") {
                 include(name: "*.module")
             }
@@ -444,7 +448,7 @@ class ModuleDistribution extends DefaultTask
             update: true,
             keepcompression: true
         ) {
-            fileset(dir: "${BuildUtils.getBuildDirPath(project)}", includes: "labkey/**")
+            fileset(dir: "${getModulesDir()}", includes: "labkey/**")
         }
     }
 


### PR DESCRIPTION
#### Rationale
We leave multiple copies of the zipped up modules for each embedded distribution built (`distribution.zip` and `labkeyServer.jar`). This nearly fills the disk drive when building all distributions on TeamCity.
Non-embedded distributions share `build/distModules` to gather modules; we can put the `distribution.zip` and `labkeyServer.jar` files there so they get cleaned up between distributions.

#### Related Pull Requests
N/A

#### Changes
- Clean up `distribution.zip` and `labkeyServer.jar` files between `ModuleDistribution` tasks
