### PR TITLE
Add missing input for `CopyJsp` and missing `onlyIf` config for `WriteDependenciesFile`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
-### TBD
-*Released*: TBD
+### 3.0.1
+*Released*: 18 July 2024
 (Earliest compatible LabKey version: 24.8)
 - Fix issue with JSP copying because of missing input directory
 - Add missing `onlyIf` condition for `WriteDependenciesFile`

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 _Note: 1.28.0 and later require Gradle 7_
 
+### TBD
+*Released*: TBD
+(Earliest compatible LabKey version: 24.8)
+- Fix issue with JSP copying because of missing input directory
+
 ### 3.0.0
 *Released*: 15 July 2024
 (Earliest compatible LabKey version: 24.8)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ _Note: 1.28.0 and later require Gradle 7_
 *Released*: TBD
 (Earliest compatible LabKey version: 24.8)
 - Fix issue with JSP copying because of missing input directory
+- Add missing `onlyIf` condition for `WriteDependenciesFile`
 
 ### 3.0.0
 *Released*: 15 July 2024

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "3.1.0-fixCopyJsp-SNAPSHOT"
+project.version = "3.1.0-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "3.1.0-SNAPSHOT"
+project.version = "3.1.0-fixCopyJsp-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/src/main/groovy/org/labkey/gradle/plugin/ModuleResources.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ModuleResources.groovy
@@ -42,9 +42,6 @@ class ModuleResources
                             task.getArtifactIds().set(artifacts.map(new WriteDependenciesFile.IdExtractor()))
                     }
                     task.externalDependencies.set(project.extensions.findByType(ModuleExtension.class).getExternalDependencies())
-                    task.onlyIf {
-                        return !task.externalDependencies.get().isEmpty()
-                    }
                 } catch (UnknownDomainObjectException ignore) {
 
                 }

--- a/src/main/groovy/org/labkey/gradle/plugin/ModuleResources.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/ModuleResources.groovy
@@ -41,10 +41,13 @@ class ModuleResources
                             Provider<Set<ResolvedArtifactResult>> artifacts = config.getIncoming().getArtifacts().getResolvedArtifacts();
                             task.getArtifactIds().set(artifacts.map(new WriteDependenciesFile.IdExtractor()))
                     }
+                    task.externalDependencies.set(project.extensions.findByType(ModuleExtension.class).getExternalDependencies())
+                    task.onlyIf {
+                        return !task.externalDependencies.get().isEmpty()
+                    }
                 } catch (UnknownDomainObjectException ignore) {
 
                 }
-                task.externalDependencies.set(project.extensions.findByType(ModuleExtension.class).getExternalDependencies())
         }
 
         project.tasks.named("processModuleResources").configure {dependsOn(project.tasks.named('writeDependenciesList'))}

--- a/src/main/groovy/org/labkey/gradle/task/CopyJsp.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/CopyJsp.groovy
@@ -3,6 +3,7 @@ package org.labkey.gradle.task
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileSystemOperations
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 
@@ -14,6 +15,9 @@ abstract class CopyJsp extends DefaultTask
 
     @Inject abstract FileSystemOperations getFs()
 
+    @InputDirectory
+    final abstract DirectoryProperty srcDir = project.objects.directoryProperty().convention(project.layout.projectDirectory.dir('src'))
+
     @OutputDirectory
     final abstract DirectoryProperty webappDir = project.objects.directoryProperty().convention(project.layout.buildDirectory.dir(WEBAPP_DIR).get())
 
@@ -23,7 +27,7 @@ abstract class CopyJsp extends DefaultTask
             it.delete(webappDir.get().dir("org"))
         }
         fs.copy {
-            from 'src'
+            from srcDir.get()
             into webappDir.get()
             include '**/*.jsp'
         }

--- a/src/main/groovy/org/labkey/gradle/task/WriteDependenciesFile.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/WriteDependenciesFile.groovy
@@ -57,6 +57,9 @@ abstract class WriteDependenciesFile extends DefaultTask
         {
             this.inputs.file(project.file("gradle.properties"))
         }
+        onlyIf {
+            !externalDependencies.get().isEmpty()
+        }
     }
 
     private void writeDependencies(OutputStreamWriter writer)

--- a/src/main/groovy/org/labkey/gradle/task/WriteDependenciesFile.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/WriteDependenciesFile.groovy
@@ -61,9 +61,6 @@ abstract class WriteDependenciesFile extends DefaultTask
 
     private void writeDependencies(OutputStreamWriter writer)
     {
-        if (externalDependencies.get().isEmpty())
-            return
-
         List<String> missing = []
         List<String> licenseMissing = []
         Map<String, ExternalDependency> dependencies = externalDependencies.get()
@@ -109,6 +106,9 @@ abstract class WriteDependenciesFile extends DefaultTask
 
     void writeJarsTxt()
     {
+        if (externalDependencies.get().isEmpty())
+            return
+
         OutputStreamWriter writer = null
         try {
             writer = new OutputStreamWriter(new FileOutputStream(jarsTxtFile.get().asFile), StandardCharsets.UTF_8)


### PR DESCRIPTION
#### Rationale
The previous PR failed to configure the `CopyJsp` task properly so changes to individual `Jsp` files were not being picked up (not sure this change to requiring the use of FileSystem injection is altogether a good thing...). 

The previous PR also failed to prevent the `WriteDependenciesFile` task from running when a module, such as a file-based module, has no dependencies to write about.

#### Related Pull Requests
- #212 

#### Changes
- Add `InputDirectory` for `CopyJsp` task
- Add `onlyIf` config for `WriteDependenciesFile` task
