### PR TITLE
Remove references to 'tomcat.home' and 'CATALINA_HOME'

### DIFF
--- a/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/TeamCity.groovy
@@ -66,11 +66,7 @@ class TeamCity extends Tomcat
         // from TeamCity's configuration when creating the UITestExtension on TeamCity
         super.apply(project)
         project.tomcat.assertionFlag = "-ea"
-        String truststoreFile = "${project.tomcat.catalinaHome}/localhost.truststore"
-        if (!project.file(truststoreFile).exists())
-        {
-            truststoreFile = "${System.getProperty("user.home")}/localhost.truststore"
-        }
+        truststoreFile = "${System.getProperty("user.home")}/localhost.truststore"
         if (project.file(truststoreFile).exists())
         {
             project.tomcat.trustStore = "-Djavax.net.ssl.trustStore=${truststoreFile}"

--- a/src/main/groovy/org/labkey/gradle/plugin/TestRunner.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/TestRunner.groovy
@@ -17,8 +17,6 @@ package org.labkey.gradle.plugin
 
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.api.tasks.TaskProvider
-import org.gradle.api.tasks.bundling.Zip
 import org.labkey.gradle.plugin.extension.TeamCityExtension
 import org.labkey.gradle.task.RunTestSuite
 import org.labkey.gradle.util.BuildUtils
@@ -34,8 +32,6 @@ class TestRunner extends UiTest
         addPasswordTasks(project)
 
         addDataFileTasks(project)
-
-        addExtensionsTasks(project)
 
         addTestSuiteTask(project)
 
@@ -161,36 +157,6 @@ class TestRunner extends UiTest
                             writer.close()
                     }
                 })
-        }
-    }
-
-    private static void addExtensionsTasks(Project project)
-    {
-        File extensionsDir = project.file("chromeextensions")
-        if (extensionsDir.exists())
-        {
-            List<TaskProvider> extensionsZipTasks = new ArrayList<>()
-            extensionsDir.eachDir({
-                File dir ->
-
-                    String extensionTaskName = "package" + dir.getName().capitalize()
-                    project.tasks.register(extensionTaskName, Zip) {
-                        Zip task ->
-                            task.description = "Package the ${dir.getName()} chrome extension used for testing"
-                            task.archiveBaseName.set(dir.getName())
-                            task.archiveExtension.set("zip")
-                            task.from dir
-                            task.destinationDirectory.set(project.layout.buildDirectory.dir("chromextensions"))
-                    }
-
-                    extensionsZipTasks.add(project.tasks.named(extensionTaskName))
-            })
-            project.tasks.register("packageChromeExtensions") {
-                Task task ->
-                    task.description = "Package all chrome extensions used for testing"
-                    task.dependsOn (extensionsZipTasks)
-            }
-
         }
     }
 

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/TomcatExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/TomcatExtension.groovy
@@ -21,8 +21,6 @@ class TomcatExtension
 {
     private final Project project
 
-    String catalinaHome
-    String tomcatConfDir
     String assertionFlag = "-ea" // set to -da to disable assertions and -ea to enable assertions
     String maxMemory = "2G"
     boolean disableRecompileJsp = false
@@ -35,49 +33,5 @@ class TomcatExtension
     TomcatExtension(Project project)
     {
         this.project = project
-        setCatalinaDirs(project)
-    }
-
-    String getCatalinaHome()
-    {
-        return catalinaHome
-    }
-
-    String getTomcatConfDir()
-    {
-        return tomcatConfDir
-    }
-
-    private void setCatalinaDirs(Project project)
-    {
-        if (System.getenv("CATALINA_HOME") != null)
-        {
-            this.catalinaHome = System.getenv("CATALINA_HOME")
-        }
-        else if (project.hasProperty("tomcatDir"))
-        {
-            this.catalinaHome = project.tomcatDir
-        }
-        else if (project.ext.hasProperty("tomcatDir"))
-        {
-            this.catalinaHome = project.ext.tomcatDir
-        }
-        else
-        {
-            this.catalinaHome = TeamCityExtension.getTeamCityProperty(project, "tomcat.home", null)
-        }
-
-        if (project.ext.hasProperty("tomcatConfDir"))
-        {
-            this.tomcatConfDir = project.ext.tomcatConfDir
-        }
-        else if (this.catalinaHome != null)
-        {
-            this.tomcatConfDir = "${this.catalinaHome}/conf/Catalina/localhost"
-        }
-        else
-        {
-            this.tomcatConfDir = null
-        }
     }
 }

--- a/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
@@ -16,7 +16,6 @@
 package org.labkey.gradle.task
 
 import org.gradle.api.DefaultTask
-import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.file.CopySpec
 import org.gradle.api.file.DuplicatesStrategy
@@ -139,30 +138,6 @@ class DoThenSetup extends DefaultTask
             }
         }
         return extraJdbcProperties
-    }
-
-
-    // labkeyXml is up to date if it was created after the current config file was created
-    // and it has the current appDocBase
-    boolean labkeyXmlUpToDate(String appDocBase)
-    {
-        if (this.dbPropertiesChanged)
-            return false
-
-        File dbPropFile = DatabaseProperties.getPickedConfigFile(project)
-        File tomcatLabkeyXml = new File("${project.tomcat.tomcatConfDir}", "labkey.xml")
-        if (!dbPropFile.exists() || !tomcatLabkeyXml.exists())
-            return false
-        if (dbPropFile.lastModified() < tomcatLabkeyXml.lastModified())
-        {
-            // make sure we haven't switch contexts
-            for (String line: tomcatLabkeyXml.readLines())
-            {
-                if (line.contains("docBase=\"" + appDocBase + "\""))
-                    return true
-            }
-        }
-        return false
     }
 
     boolean embeddedConfigUpToDate()

--- a/src/main/groovy/org/labkey/gradle/task/RunTestSuite.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/RunTestSuite.groovy
@@ -16,13 +16,10 @@
 package org.labkey.gradle.task
 
 import org.apache.commons.lang3.StringUtils
-import org.gradle.api.file.CopySpec
-import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.tasks.Internal
 import org.labkey.gradle.plugin.TeamCity
 import org.labkey.gradle.plugin.extension.TeamCityExtension
 import org.labkey.gradle.util.DatabaseProperties
-import org.labkey.gradle.util.TaskUtils
 
 /**
  * Class that sets our test/Runner.class as the junit test suite and configures a bunch of system properties for
@@ -44,26 +41,10 @@ abstract class RunTestSuite extends RunUiTest
         dependsOn(project.tasks.writeSampleDataFile)
 
         dependsOn(project.tasks.ensurePassword)
-        if (project.findProject(":tools:Rpackages:install") != null)
-            dependsOn(project.project(':tools:Rpackages:install'))
-        if (!project.getPlugins().hasPlugin(TeamCity.class)) {
-            TaskUtils.addOptionalTaskDependency(project, this, 'packageChromeExtensions')
-        }
         if (project.getPlugins().hasPlugin(TeamCity.class))
         {
             dependsOn(project.tasks.killChrome)
-            dependsOn(project.tasks.ensurePassword)
-
-            if (project.tomcat.catalinaHome != null)
-            {
-                doLast( {
-                    project.copy({ CopySpec copy ->
-                        copy.from "${project.tomcat.catalinaHome}/logs"
-                        copy.into project.layout.buildDirectory.file("logs/test/tomcat")
-                        copy.setDuplicatesStrategy(DuplicatesStrategy.INCLUDE)
-                    })
-                })
-            }
+            dependsOn(project.tasks.killFirefox)
         }
     }
 
@@ -80,7 +61,6 @@ abstract class RunTestSuite extends RunUiTest
                 systemProperty "testRecentlyFailed", "${runRiskGroupTestsFirst.contains("recentlyFailed")}"
             }
             systemProperty "teamcity.buildType.id", project.teamcity['teamcity.buildType.id']
-            systemProperty "tomcat.home", System.getenv("CATALINA_HOME")
             systemProperty "tomcat.port", project.teamcity["tomcat.port"]
             systemProperty "tomcat.debug", project.teamcity["tomcat.debug"]
             systemProperty "labkey.port", project.teamcity['tomcat.port']

--- a/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/BuildUtils.groovy
@@ -30,7 +30,6 @@ import org.labkey.gradle.plugin.extension.LabKeyExtension
 import org.labkey.gradle.plugin.extension.ModuleExtension
 import org.labkey.gradle.plugin.extension.ServerDeployExtension
 import org.labkey.gradle.plugin.extension.TeamCityExtension
-import org.labkey.gradle.task.ModuleDistribution
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
@@ -546,7 +545,7 @@ class BuildUtils
             'tomcat-jsp-api',
             'tomcat-util',
             'tomcat-websocket-api',
-            'tomcat7-websocket'
+            'tomcat-websocket'
     ]
 
     static String getGitUrl(Project project)
@@ -569,10 +568,7 @@ class BuildUtils
 
     static void addTomcatBuildDependencies(Project project, String configuration)
     {
-        List<String> tomcatLibs = new ArrayList<>(TOMCAT_LIBS) // Don't modify list
-        if (!"${project.apacheTomcatVersion}".startsWith("7."))
-            tomcatLibs.replaceAll({it.replace('tomcat7-', 'tomcat-')})
-        for (String lib : tomcatLibs)
+        for (String lib : TOMCAT_LIBS)
             project.dependencies.add(configuration, "org.apache.tomcat:${lib}:${project.apacheTomcatVersion}")
     }
 


### PR DESCRIPTION
#### Rationale
There are several unnecessary references to `tomcat.home` and `CATALINA_HOME` that can and should be removed.

#### Related Pull Requests
- #216 

#### Changes
- Remove all references to 'tomcat.home' and 'CATALINA_HOME'
- Remove some obsolete task and project references
  - `:tools:Rpackages:install`
  - `packageChromeExtensions`
- Remove reference to `tomcat7-websocket`
