### PR TITLE
Strip "_dist" suffix from project.name if present

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ on how to do that, including how to develop and test locally and the versioning 
 
 ## Release Notes
 
-### TBD
+### 4.1.0-SNAPSHOT
 *Released*: TBD
 (Earliest compatible LabKey version: 24.10)
+- Update default value handling for `subDirName` and `extraFileIdentifier` properties: strip `"_dist"` suffix from `project.name` if present
 
 ### 4.0.0
 *Released*: 5 September 2024

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "4.1.0-SNAPSHOT"
+project.version = "4.1.0-fb_dist-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group 'org.labkey.build'
-project.version = "4.1.0-fb_dist-SNAPSHOT"
+project.version = "4.1.0-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
@@ -21,7 +21,6 @@ import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.file.CopySpec
 import org.gradle.api.file.DuplicatesStrategy
-import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
 import org.labkey.gradle.plugin.ApplyLicenses
 import org.labkey.gradle.plugin.extension.DistributionExtension
@@ -37,7 +36,7 @@ class ModuleDistribution extends DefaultTask
     @Optional @Input
     String versionPrefix = null
     @Optional @Input
-    final abstract Property<String> subDirName = project.objects.property(String).convention(project.name)
+    String subDirName = null
     @Optional @Input
     String archivePrefix = "LabKey"
     @Optional @Input
@@ -70,7 +69,7 @@ class ModuleDistribution extends DefaultTask
     File getDistributionDir()
     {
         if (distributionDir == null) {
-            distributionDir = project.file("${distExtension.dir}/" + subDirName.get())
+            distributionDir = project.file("${distExtension.dir}/" + getSubDir())
         }
         return distributionDir
     }
@@ -150,17 +149,28 @@ class ModuleDistribution extends DefaultTask
     @Input
     String getArtifactId()
     {
-        return subDirName.get()
+        return getSubDir()
     }
 
     String getArchiveName()
     {
         if (archiveName == null)
         {
-            var extraIdentifier = extraFileIdentifier != null ? extraFileIdentifier : "-" + project.name
+            var extraIdentifier = extraFileIdentifier != null ? extraFileIdentifier : "-" + getProjectName()
             archiveName = "${archivePrefix}${BuildUtils.getDistributionVersion(project)}" + extraIdentifier
         }
         return archiveName
+    }
+
+    private String getSubDir()
+    {
+        return subDirName == null ? getProjectName() : subDirName;
+    }
+
+    private String getProjectName()
+    {
+        int idx = project.name.indexOf("_dist")
+        return idx == -1 ? project.name : project.name.substring(0, idx);
     }
 
     private String getEmbeddedTomcatJarPath()

--- a/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
@@ -156,7 +156,7 @@ class ModuleDistribution extends DefaultTask
     {
         if (archiveName == null)
         {
-            var extraIdentifier = extraFileIdentifier != null ? extraFileIdentifier : "-" + getProjectName()
+            var extraIdentifier = extraFileIdentifier != null ? extraFileIdentifier : "-" + getDefaultName()
             archiveName = "${archivePrefix}${BuildUtils.getDistributionVersion(project)}" + extraIdentifier
         }
         return archiveName
@@ -164,10 +164,11 @@ class ModuleDistribution extends DefaultTask
 
     private String getSubDir()
     {
-        return subDirName == null ? getProjectName() : subDirName;
+        return subDirName == null ? getDefaultName() : subDirName;
     }
 
-    private String getProjectName()
+    // Standard name to use when extraFileIdentifier or subDirName properties aren't provided
+    private String getDefaultName()
     {
         int idx = project.name.indexOf("_dist")
         return idx == -1 ? project.name : project.name.substring(0, idx);

--- a/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/ModuleDistribution.groovy
@@ -167,7 +167,7 @@ class ModuleDistribution extends DefaultTask
         return subDirName == null ? getDefaultName() : subDirName;
     }
 
-    // Standard name to use when extraFileIdentifier or subDirName properties aren't provided
+    // Standard name to use when extraFileIdentifier or subDirName property isn't provided
     private String getDefaultName()
     {
         int idx = project.name.indexOf("_dist")


### PR DESCRIPTION
#### Rationale
Produce more useful `subDirName` and `extraFileIdentifier` property default values for `project.names` such as `nci_dist`, `cds_dist`, etc. This will eventually help with https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=47603
