### PR TITLE
Stop accepting deprecated properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,12 @@ on how to do that, including how to develop and test locally and the versioning 
 
 ## Release Notes
 
-### 6.1.0-SNAPSHOT
+### 6.2.0-SNAPSHOT
 *Released*: TBD
+(Earliest compatible LabKey version: 25.2)
+
+### 6.1.0
+*Released*: 10 January, 2025
 (Earliest compatible LabKey version: 25.2)
 - Module template: first script is now incremental, use three-digit version numbers, stop creating SQL Server scripts
 - Module template: update test files to avoid IDE warnings

--- a/README.md
+++ b/README.md
@@ -15,9 +15,12 @@ on how to do that, including how to develop and test locally and the versioning 
 
 ### 6.1.0-SNAPSHOT
 *Released*: TBD
-(Earliest compatible LabKey version: 24.11)
+(Earliest compatible LabKey version: 25.2)
 - Module template: first script is now incremental, use three-digit version numbers, stop creating SQL Server scripts
 - Module template: update test files to avoid IDE warnings
+- `module.properties`: change `ManageVersion` default value to `false` (to [exclude externally developed modules from
+  old schema version checks at upgrade time](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=47369)),
+  set to `true` in module template, and throw if old, unsupported properties are detected. 
 - Update dependency versions
 
 ### 6.0.0

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group = 'org.labkey.build'
-project.version = "6.1.0-SNAPSHOT"
+project.version = "6.1.0-deprecated_props-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group = 'org.labkey.build'
-project.version = "6.1.0-deprecated_props-SNAPSHOT"
+project.version = "6.2.0-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/moduleTemplate/module.properties
+++ b/moduleTemplate/module.properties
@@ -5,3 +5,4 @@ Description: FIXME! Write a paragraph describing the functionality and the \
 URL: http://example.com/FIXME
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+ManageVersion: true

--- a/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
@@ -129,6 +129,8 @@ class FileModule implements Plugin<Project>
                 project.configurations.modules.dependencies.each {
                     Dependency dep -> moduleDependencies += dep.getName()
                 }
+                if (!moduleDependencies.isEmpty())
+                    project.lkModule.setPropertyValue("moduleDependencies", moduleDependencies.join(", "))
                 task.getModuleProperties().set(project.lkModule.getModProperties())
                 if (project.file("build.gradle").exists())
                     task.inputs.file(project.file("build.gradle"))

--- a/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
@@ -36,10 +36,7 @@ import org.labkey.gradle.task.ModuleXmlFile
 import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.GroupNames
 import org.labkey.gradle.util.PomFileHelper
-import org.labkey.gradle.util.PropertiesUtils
 import org.labkey.gradle.util.TaskUtils
-
-import java.util.regex.Matcher
 
 /**
  * This class is used for building a LabKey file-based module, which contains only client-side code.
@@ -132,8 +129,6 @@ class FileModule implements Plugin<Project>
                 project.configurations.modules.dependencies.each {
                     Dependency dep -> moduleDependencies += dep.getName()
                 }
-                if (!moduleDependencies.isEmpty())
-                    project.lkModule.setPropertyValue(ModuleExtension.MODULE_DEPENDENCIES_PROPERTY, moduleDependencies.join(", "))
                 task.getModuleProperties().set(project.lkModule.getModProperties())
                 if (project.file("build.gradle").exists())
                     task.inputs.file(project.file("build.gradle"))

--- a/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/FileModule.groovy
@@ -130,7 +130,7 @@ class FileModule implements Plugin<Project>
                     Dependency dep -> moduleDependencies += dep.getName()
                 }
                 if (!moduleDependencies.isEmpty())
-                    project.lkModule.setPropertyValue("moduleDependencies", moduleDependencies.join(", "))
+                    project.lkModule.setPropertyValue("ModuleDependencies", moduleDependencies.join(", "))
                 task.getModuleProperties().set(project.lkModule.getModProperties())
                 if (project.file("build.gradle").exists())
                     task.inputs.file(project.file("build.gradle"))

--- a/src/main/groovy/org/labkey/gradle/plugin/MultiGit.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/MultiGit.groovy
@@ -183,22 +183,13 @@ class MultiGit implements Plugin<Project>
         private Boolean isPrivate = false
         private Boolean isExternal = false
         private Boolean isArchived = false
-        private Boolean isSvn = false
         private Type type = Type.other
         private Project project
         private File enlistmentDir
         private Project rootProject
         private Properties moduleProperties
-        private String dependencies
         private String supportedDatabases = "mssql,pgsql"
         private List<PullRequest> pullRequests
-
-        Repository(Project rootProject, String name, Boolean isSvn)
-        {
-            this.name = name
-            this.isSvn = isSvn
-            setProject(rootProject)
-        }
 
         Repository(Project rootProject, String name, String url, Boolean isPrivate, Boolean isArchived, List<String> topics)
         {
@@ -233,7 +224,6 @@ class MultiGit implements Plugin<Project>
             }
             setProject(rootProject)
         }
-
 
         String getName()
         {
@@ -313,26 +303,6 @@ class MultiGit implements Plugin<Project>
         void setIsArchived(Boolean isArchived)
         {
             this.isArchived = isArchived
-        }
-
-        Boolean getIsSvn()
-        {
-            return isSvn
-        }
-
-        void setIsSvn(Boolean isSvn)
-        {
-            this.isSvn = isSvn
-        }
-
-        String getDependencies()
-        {
-            return dependencies
-        }
-
-        void setDependencies(String dependencies)
-        {
-            this.dependencies = dependencies
         }
 
         String getSupportedDatabases()
@@ -464,8 +434,6 @@ class MultiGit implements Plugin<Project>
                         this.setLicenseURL((String) this.moduleProperties.get("LicenseURL"))
                     if (this.moduleProperties.containsKey("Description") && !StringUtils.isEmpty(((String) this.moduleProperties.get("Description")).trim()))
                         this.setDescription((String) this.moduleProperties.get("Description"))
-                    if (this.moduleProperties.containsKey(ModuleExtension.MODULE_DEPENDENCIES_PROPERTY))
-                        this.setDependencies((String) this.moduleProperties.get(ModuleExtension.MODULE_DEPENDENCIES_PROPERTY))
                     if (this.moduleProperties.containsKey("SupportedDatabases"))
                         this.setSupportedDatabases((String) this.moduleProperties.get("SupportedDatabases"))
                 }
@@ -566,8 +534,6 @@ class MultiGit implements Plugin<Project>
                 if (this.getLicenseURL() != null)
                     builder.append(" (${this.getLicenseURL()})")
                 builder.append("\n")
-                if (this.dependencies != null)
-                    builder.append("\tModule Dependencies: ${this.getDependencies()}\n")
                 builder.append("\tRepoURL: ${this.getUrl()}\n")
                 builder.append("\tSupported Databases: ${this.supportedDatabases}\n")
                 List<PullRequest> prs = this.getPullRequests()
@@ -1327,14 +1293,6 @@ class MultiGit implements Plugin<Project>
                         if (repositories.containsKey(name))
                         {
                             enlist(repositories, (Repository) repositories.get(name), enlisted, branch)
-                        }
-                        else
-                        {
-                            Repository svnRepo = new Repository(project, name, true)
-                            if (svnRepo.getEnlistmentDir().exists())
-                                project.logger.quiet("Already have svn enlistment for ${svnRepo.getName()} in ${svnRepo.getEnlistmentDir()}")
-                            else
-                                project.logger.warn("WARNING: No repository found for dependency '${svnRepo.getProjectPath()}'.")
                         }
                     }
             })

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/ModuleExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/ModuleExtension.groovy
@@ -27,7 +27,6 @@ class ModuleExtension
 {
     private static final String ENLISTMENT_PROPERTIES = "enlistment.properties"
     public static final String MODULE_PROPERTIES_FILE = "module.properties"
-    public static final String MODULE_DEPENDENCIES_PROPERTY = "ModuleDependencies"
     private Map<Object, Object> modProperties = new HashMap<>()
     private Project project
     private Map<String, ExternalDependency> externalDependencies = new HashMap<>()
@@ -57,7 +56,6 @@ class ModuleExtension
     {
         String value = modProperties.get(propertyName)
         return value == null ? defaultValue : value
-
     }
 
     String getPropertyValue(String propertyName)
@@ -81,25 +79,30 @@ class ModuleExtension
         if (propertiesFile.exists()) {
             Properties props = new Properties()
             PropertiesUtils.readProperties(propertiesFile, props)
+
             this.modProperties.putAll(props)
             if (logDeprecations) {
                 List<String> deprecationMsgs = []
-                if (this.modProperties.get(MODULE_DEPENDENCIES_PROPERTY))
-                    deprecationMsgs += "The '" + MODULE_DEPENDENCIES_PROPERTY + "' property is no longer supported as of gradlePlugin version 1.25.0 (LabKey Server version 21.3.0)." +
-                            " Declare the dependency in the module's build.gradle file instead using the 'modules' configuration." +
-                            " See https://www.labkey.org/Documentation/wiki-page.view?name=gradleDepend for more information."
-
-                if (this.modProperties.get("ConsolidateScripts"))
-                    deprecationMsgs += "The 'ConsolidateScripts' property is no longer supported."
-                if (this.modProperties.get("Version"))
-                    deprecationMsgs += "The 'Version' property is no longer supported."
+//          Follow this pattern to deprecate a property in module.properties
+//                if (this.modProperties.get("OldProperty"))
+//                    deprecationMsgs += "The OldProperty property is no longer supported."
                 if (!deprecationMsgs.isEmpty())
                     project.logger.quiet("${propertiesFile.absolutePath}: Deprecated or unsupported properties detected.\n\t"
-                            + deprecationMsgs.join("\n\t")
-                            + "\nRefer to https://www.labkey.org/Documentation/wiki-page.view?name=includeModulePropertiesFile for the current set of supported properties.")
+                        + deprecationMsgs.join("\n\t")
+                        + "\nRefer to https://www.labkey.org/Documentation/wiki-page.view?name=includeModulePropertiesFile for the current set of supported properties.")
             }
-            if (this.modProperties.get(MODULE_DEPENDENCIES_PROPERTY))
-                this.modProperties.remove(MODULE_DEPENDENCIES_PROPERTY)
+
+            List<String> unsupportedMsgs = []
+            if (this.modProperties.get("ModuleDependencies"))
+                unsupportedMsgs += "The 'ModuleDependencies' property is no longer supported."
+            if (this.modProperties.get("ConsolidateScripts"))
+                unsupportedMsgs += "The 'ConsolidateScripts' property is no longer supported."
+            if (this.modProperties.get("Version"))
+                unsupportedMsgs += "The 'Version' property is no longer supported."
+            if (!unsupportedMsgs.isEmpty())
+                throw new GradleException("${propertiesFile.absolutePath}: Unsupported properties detected.\n\t"
+                    + unsupportedMsgs.join("\n\t")
+                    + "\nRefer to https://www.labkey.org/Documentation/wiki-page.view?name=includeModulePropertiesFile for the current set of supported properties.")
         }
         else
             project.logger.info("${project.path} - no ${MODULE_PROPERTIES_FILE} found")
@@ -146,14 +149,11 @@ class ModuleExtension
         modProperties.put("ReleaseVersion", (String) project.getProperty("labkeyVersion"))
         if (modProperties.get("ManageVersion") == null)
         {
-            modProperties.put("ManageVersion", "true")
+            modProperties.put("ManageVersion", "false") // Issue #47369
         }
         if (modProperties.get("SchemaVersion") == null)
         {
-            if (modProperties.get("Version") == null)
-                modProperties.put("SchemaVersion", "")  // Spring binds this as setSchemaVersion(null), which is what we want
-            else
-                modProperties.put("SchemaVersion", modProperties.get("Version"))  // For backward compatibility with old modules TODO: Remove
+            modProperties.put("SchemaVersion", "")  // Spring binds this as setSchemaVersion(null), which is what we want
         }
     }
 

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/ModuleExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/ModuleExtension.groovy
@@ -84,6 +84,7 @@ class ModuleExtension
             if (logDeprecations) {
                 List<String> deprecationMsgs = []
 //          Follow this pattern to deprecate a property in module.properties
+                  // Remove check for OldProperty in mmm, yyyy (one year after deprecation)
 //                if (this.modProperties.get("OldProperty"))
 //                    deprecationMsgs += "The OldProperty property is no longer supported."
                 if (!deprecationMsgs.isEmpty())
@@ -93,6 +94,7 @@ class ModuleExtension
             }
 
             List<String> unsupportedMsgs = []
+            // Remove checks for ModuleDependencies, ConsolidateScripts, and Version properties in Jan, 2026 (one year after designated as unsupported)
             if (this.modProperties.get("ModuleDependencies"))
                 unsupportedMsgs += "The 'ModuleDependencies' property is no longer supported."
             if (this.modProperties.get("ConsolidateScripts"))


### PR DESCRIPTION
#### Rationale
The `module.properties` properties `ModuleDependencies`, `ConsolidateScripts`, and `Version` have been deprecated for years. It's time to stop accepting and accommodating them. For now, throw if they're detected to make their use obvious.

We want `ManageVersion` to default to `false` if not specified. This allows us to detect unsupported upgrade scenarios in more cases. https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=47369

Remove some unused SVN references.