### PR TITLE
Don't log XMLBeans version so loudly

### DIFF
--- a/src/main/groovy/org/labkey/gradle/plugin/XmlBeans.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/XmlBeans.groovy
@@ -55,7 +55,7 @@ class XmlBeans implements Plugin<Project>
                     xmlbeans "org.apache.xmlbeans:xmlbeans:${project.xmlbeansVersion}"
                 }
 
-        project.logger.quiet("XMLBeans version: ${project.xmlbeansVersion}")
+        project.logger.debug("XMLBeans version: ${project.xmlbeansVersion}")
         String schemasProjectPath = BuildUtils.getSchemasProjectPath(project.gradle)
         if (!project.path.equals(schemasProjectPath))
         {

--- a/src/main/groovy/org/labkey/gradle/plugin/XmlBeans.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/XmlBeans.groovy
@@ -55,7 +55,7 @@ class XmlBeans implements Plugin<Project>
                     xmlbeans "org.apache.xmlbeans:xmlbeans:${project.xmlbeansVersion}"
                 }
 
-        project.logger.debug("XMLBeans version: ${project.xmlbeansVersion}")
+        project.logger.info("XMLBeans version: ${project.xmlbeansVersion}")
         String schemasProjectPath = BuildUtils.getSchemasProjectPath(project.gradle)
         if (!project.path.equals(schemasProjectPath))
         {


### PR DESCRIPTION
#### Rationale
Gradle's "quiet" [log level](https://docs.gradle.org/current/userguide/logging.html) is actually the second loudest, between "error" and "warn". It is also the default log level. We probably don't need to log the XMLBeans version a dozen times for normal builds.
Do we need it at all? Maybe this was accidentally left in.

#### Related Pull Requests
- #227 

#### Changes
- Log XMLBeans version at a lower level
