### PR TITLE
Support testing with serverContext on TeamCity

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,15 @@ on how to do that, including how to develop and test locally and the versioning 
 
 ## Release Notes
 
-### 6.2.0-SNAPSHOT
+### 6.3.0-SNAPSHOT
 *Released*: TBD
 (Earliest compatible LabKey version: 25.2)
+
+### 6.2.0
+*Released*: 23 April, 2025
+(Earliest compatible LabKey version: 25.2)
+- allow TC property `system.labkey.contextpath` (or local commandline arg -PcontextPath=<path>) to uncomment and set 
+  context.contextPath in pick task
 
 ### 6.1.0
 *Released*: 10 January, 2025

--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ on how to do that, including how to develop and test locally and the versioning 
 ### 6.2.0
 *Released*: 23 April, 2025
 (Earliest compatible LabKey version: 25.2)
-- allow TC property `system.labkey.contextpath` (or local commandline arg -PcontextPath=<path>) to uncomment and set 
-  context.contextPath in pick task
+- Allow `PickDb` task to set server context path via `labkey.contextpath` property
 
 ### 6.1.0
 *Released*: 10 January, 2025

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group = 'org.labkey.build'
-project.version = "6.2.0_fb_serverContext_SNAPSHOT"
+project.version = "6.2.0_fb_serverContext-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group = 'org.labkey.build'
-project.version = "6.2.0-SNAPSHOT"
+project.version = "6.2.0_fb_serverContext_SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group = 'org.labkey.build'
-project.version = "6.2.0"
+project.version = "6.3.0-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group = 'org.labkey.build'
-project.version = "6.2.0_fb_serverContext-SNAPSHOT"
+project.version = "6.2.0"
 
 gradlePlugin {
     plugins {

--- a/src/main/groovy/org/labkey/gradle/plugin/extension/TeamCityExtension.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/extension/TeamCityExtension.groovy
@@ -178,6 +178,11 @@ class TeamCityExtension
         return getTeamCityProperty(project, "labkey.server", "http://localhost")
     }
 
+    static String getLabKeyContextPath(Project project)
+    {
+        return getTeamCityProperty(project, "labkey.contextpath", null)
+    }
+
     static String getLabKeyServerPort(Project project)
     {
         return getTeamCityProperty(project, 'tomcat.port', null)

--- a/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
@@ -22,8 +22,6 @@ import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
-import org.gradle.initialization.Environment
-import org.gradle.internal.component.external.model.ComponentVariant
 import org.labkey.gradle.plugin.extension.TeamCityExtension
 import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.DatabaseProperties
@@ -52,7 +50,7 @@ class DoThenSetup extends DefaultTask
     void setup() {
         doDatabaseTask()
         if (!embeddedConfigUpToDate()) {
-            Environment.Properties configProperties = databaseProperties.getConfigProperties()
+            Properties configProperties = databaseProperties.getConfigProperties()
             configProperties.putAll(getExtraJdbcProperties())
             // in .properties files, backward slashes are seen as escape characters, so all paths must use forward slashes, even on Windows
             configProperties.setProperty("pathToServer", project.rootDir.getAbsolutePath().replaceAll("\\\\", "/"))
@@ -85,7 +83,7 @@ class DoThenSetup extends DefaultTask
             }
 
             String embeddedDir = BuildUtils.getEmbeddedConfigPath(project)
-            ComponentVariant.File configsDir = new File(BuildUtils.getConfigsProject(project).projectDir, "configs")
+            File configsDir = new File(BuildUtils.getConfigsProject(project).projectDir, "configs")
             project.copy({ CopySpec copy ->
                 copy.from configsDir
                 copy.into embeddedDir

--- a/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/DoThenSetup.groovy
@@ -22,6 +22,8 @@ import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
+import org.gradle.initialization.Environment
+import org.gradle.internal.component.external.model.ComponentVariant
 import org.labkey.gradle.plugin.extension.TeamCityExtension
 import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.DatabaseProperties
@@ -50,7 +52,7 @@ class DoThenSetup extends DefaultTask
     void setup() {
         doDatabaseTask()
         if (!embeddedConfigUpToDate()) {
-            Properties configProperties = databaseProperties.getConfigProperties()
+            Environment.Properties configProperties = databaseProperties.getConfigProperties()
             configProperties.putAll(getExtraJdbcProperties())
             // in .properties files, backward slashes are seen as escape characters, so all paths must use forward slashes, even on Windows
             configProperties.setProperty("pathToServer", project.rootDir.getAbsolutePath().replaceAll("\\\\", "/"))
@@ -59,6 +61,11 @@ class DoThenSetup extends DefaultTask
                     TeamCityExtension::getLabKeyServerPort,
                     "serverPort",
                     project.hasProperty("useSsl") ? "8443" : "8080"))
+
+            configProperties.setProperty("contextPath", tcPropOrDefault(project,
+                    TeamCityExtension::getLabKeyContextPath,
+                    "contextPath",
+                    ""))
 
             configProperties.setProperty("shutdownPort", tcPropOrDefault(project,
                     TeamCityExtension::getLabKeyServerShutdownPort,
@@ -78,7 +85,7 @@ class DoThenSetup extends DefaultTask
             }
 
             String embeddedDir = BuildUtils.getEmbeddedConfigPath(project)
-            File configsDir = new File(BuildUtils.getConfigsProject(project).projectDir, "configs")
+            ComponentVariant.File configsDir = new File(BuildUtils.getConfigsProject(project).projectDir, "configs")
             project.copy({ CopySpec copy ->
                 copy.from configsDir
                 copy.into embeddedDir
@@ -99,6 +106,10 @@ class DoThenSetup extends DefaultTask
                         line = line.replace("#useLocalBuild#", "#")
                     }
                     if (configProperties.containsKey("extraJdbcDataSource") && line.contains("=@@extraJdbc"))
+                    {
+                        line = line.replace("#context.", "context.")
+                    }
+                    if (configProperties.containsKey("contextPath") && line.contains("=@@contextPath"))
                     {
                         line = line.replace("#context.", "context.")
                     }


### PR DESCRIPTION
#### Rationale
This change updates the gradle plugin to accept system.labkey.contextPath values (via command line or set as TC property) and write the specified value to application.settings at the context.contextPath key.
This work is part of this story https://github.com/LabKey/kanban/issues/664 , the requirement is that we be able to test on TC with the server's contextPath setting set.

#### Related Pull Requests
(related server pr) https://github.com/LabKey/server/pull/1050

#### Changes
pass contextPath value through
