### PR TITLE
Issue 53067: remove unnecessary output declarations that interfere with caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ on how to do that, including how to develop and test locally and the versioning 
 ### 6.3.0-SNAPSHOT
 *Released*: TBD
 (Earliest compatible LabKey version: 25.2)
+- Issue 53067: Update `npmRunBuild` and `npmRunBuildProd` tasks to not declare outputs as they duplicate the wrapped tasks causing caching to be disabled
 
 ### 6.2.0
 *Released*: 23 April, 2025

--- a/README.md
+++ b/README.md
@@ -13,10 +13,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 ## Release Notes
 
-### 6.3.0-SNAPSHOT
-*Released*: TBD
+### 6.3.0
+*Released*: 3 July 2025
 (Earliest compatible LabKey version: 25.2)
 - Issue 53067: Update `npmRunBuild` and `npmRunBuildProd` tasks to not declare outputs as they duplicate the wrapped tasks causing caching to be disabled
+- Remove extra configurations for `npmInstall` that are no longer required and not compatible with configuration cache
 
 ### 6.2.0
 *Released*: 23 April, 2025

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group = 'org.labkey.build'
-project.version = "6.3.0-SNAPSHOT"
+project.version = "6.3.0-npmBuild-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 }
 
 group = 'org.labkey.build'
-project.version = "6.3.0-npmBuild-SNAPSHOT"
+project.version = "6.4.0-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -86,8 +86,7 @@ done
 # shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
 # Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
-APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s
-' "$PWD" ) || exit
+APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s\n' "$PWD" ) || exit
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum

--- a/src/main/groovy/org/labkey/gradle/plugin/NpmRun.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/NpmRun.groovy
@@ -128,11 +128,6 @@ class NpmRun implements Plugin<Project>
                     task.description ="Runs 'npm run ${project.npmRun.buildDev}'"
                     task.dependsOn "npm_run_${project.npmRun.buildDev}"
                     task.mustRunAfter "npmInstall"
-                    task.doFirst({
-                        task.logger.info("npmWorkDir ${project.node.npmWorkDir.get()}")
-                        task.logger.info("workDir ${project.node.workDir.get()}")
-                        task.logger.info("resolvedNodeDir ${project.node.resolvedNodeDir.get()}")
-                    })
                 }
 
         configureBuildTask(project.tasks.named("npm_run_${project.npmRun.buildDev}"))
@@ -146,15 +141,8 @@ class NpmRun implements Plugin<Project>
 
         project.tasks.named('npmInstall').configure
                 {Task task ->
-                    task.inputs.file project.file(NPM_PROJECT_FILE)
-                    if (project.file(NPM_PROJECT_LOCK_FILE).exists())
-                        task.inputs.file project.file(NPM_PROJECT_LOCK_FILE)
                     // Specify legacy peer dependency mode for npm v7+
                     task.args = ["--legacy-peer-deps"]
-                    task.outputs.upToDateWhen { project.file(NODE_MODULES_DIR).exists() }
-                    if (BuildUtils.useServerNode(project)) {
-                        task.dependsOn(BuildUtils.getServerProject(project).tasks.npmSetup)
-                    }
                 }
 
         def runCommand = LabKeyExtension.isDevMode(project) && !project.hasProperty('useNpmProd') ? npmRunBuild : npmRunBuildProd

--- a/src/main/groovy/org/labkey/gradle/plugin/NpmRun.groovy
+++ b/src/main/groovy/org/labkey/gradle/plugin/NpmRun.groovy
@@ -120,7 +120,6 @@ class NpmRun implements Plugin<Project>
                     task.mustRunAfter "npmInstall"
 
                 }
-        configureBuildTask(project.tasks.named('npmRunBuildProd'))
         configureBuildTask(project.tasks.named("npm_run_${project.npmRun.buildProd}"))
 
         def npmRunBuild = project.tasks.register("npmRunBuild")
@@ -136,7 +135,6 @@ class NpmRun implements Plugin<Project>
                     })
                 }
 
-        configureBuildTask(project.tasks.named('npmRunBuild'))
         configureBuildTask(project.tasks.named("npm_run_${project.npmRun.buildDev}"))
         if (BuildUtils.useServerNode(project) && project.path !== BuildUtils.getServerProject(project).path) {
             project.tasks.named('npmSetup').configure


### PR DESCRIPTION
#### Rationale
Issue [53067](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53067) At some point, Gradle started to not like it when tasks shared output directories and it will not cache the task output when this happens, resulting in much more running of tasks than is strictly necessary. The wrapper tasks `npmRunBuild` and `npmRunBuildProd` are really more for convenience than anything, and do not need to declare explicit inputs or outputs since the output is produced by the wrapped tasks that come from the NPM plugin.

#### Related Pull Requests
- https://github.com/LabKey/server/pull/1118

#### Changes
- Remove input and output configuration for wrapping tasks.
