### PR TITLE
Fix `PurgeNpmAlphaVersion` to not require properties used by base class

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ If you are making changes to the plugins, please see the [internal docs](https:/
 on how to do that, including how to develop and test locally and the versioning information.
 
 ## Release Notes
+### TBD
+*Released* TBD
+(Earliest compatible LabKey version: 25.10)
+- Fix `PurgeNpmAlphaVersions` task
 
 ### 7.2.0
 *Released*: 11 December 2025

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ If you are making changes to the plugins, please see the [internal docs](https:/
 on how to do that, including how to develop and test locally and the versioning information.
 
 ## Release Notes
-### TBD
-*Released* TBD
+### 7.2.1
+*Released* 23 December 2025
 (Earliest compatible LabKey version: 25.10)
 - Fix `PurgeNpmAlphaVersions` task
 

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
 }
 
 group = 'org.labkey.build'
-project.version = "7.3.0-SNAPSHOT"
+project.version = "7.3.0-fixNpmPurge-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
 }
 
 group = 'org.labkey.build'
-project.version = "7.3.0-fixNpmPurge-SNAPSHOT"
+project.version = "7.3.0-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/src/main/groovy/org/labkey/gradle/task/PurgeNpmVersions.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/PurgeNpmVersions.groovy
@@ -11,6 +11,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import org.labkey.gradle.util.TaskUtils
 
@@ -22,9 +23,11 @@ abstract class PurgeNpmVersions extends DefaultTask
     private static final String VERSION_LIST_PROP = "versionList"
 
     @Input
+    @Optional
     final abstract Property<String> packageName = project.objects.property(String).convention((project.hasProperty(PACKAGE_NAME_PROP) ? (String) project.property(PACKAGE_NAME_PROP) : null))
 
     @Input
+    @Optional
     final abstract Property<String> versionList = project.objects.property(String).convention((project.hasProperty(VERSION_LIST_PROP) ? (String) project.property(VERSION_LIST_PROP) : null))
 
     @Input


### PR DESCRIPTION
#### Rationale
The addition of the `PurgeNpmVersion` task as a base class for `PurgeNpmAlphaVersions` inadvertently made the former require properties used by the latter. Marking those properties as optional since we have internal logic to verify they are provided.

#### Related Pull Requests
- #238 
- https://github.com/LabKey/server/pull/1245

#### Changes
- Mark `packageName` and 'versionList` as optional input properties
