### PR TITLE
Issue 851: Allow for multiple versions of jackson libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ If you are making changes to the plugins, please see the [internal docs](https:/
 on how to do that, including how to develop and test locally and the versioning information.
 
 ## Release Notes
+### TBD
+*Released* TBD
+(Earliest compatible LabKey version: 25.10)
+- [GitHub Issue 851](https://github.com/LabKey/internal-issues/issues/851) We need to allow for twoversions of jackson as transitive dependencies of different libraries
+
 ### 7.3.0
 *Released* 8 January 2026
 (Earliest compatible LabKey version: 25.10)

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ If you are making changes to the plugins, please see the [internal docs](https:/
 on how to do that, including how to develop and test locally and the versioning information.
 
 ## Release Notes
-### TBD
-*Released* TBD
+### 7.3.1
+*Released* 11 February 2026
 (Earliest compatible LabKey version: 25.10)
-- [GitHub Issue 851](https://github.com/LabKey/internal-issues/issues/851) We need to allow for twoversions of jackson as transitive dependencies of different libraries
+- [GitHub Issue 851](https://github.com/LabKey/internal-issues/issues/851) We need to allow for two versions of jackson as transitive dependencies of different libraries
 
 ### 7.3.0
 *Released* 8 January 2026

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
 }
 
 group = 'org.labkey.build'
-project.version = "7.4.0-multiJackson-SNAPSHOT"
+project.version = "7.4.0-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
 }
 
 group = 'org.labkey.build'
-project.version = "7.4.0-SNAPSHOT"
+project.version = "7.4.0-multiJackson-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/src/main/groovy/org/labkey/gradle/task/CheckForVersionConflicts.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/CheckForVersionConflicts.groovy
@@ -90,7 +90,7 @@ class CheckForVersionConflicts  extends DefaultTask
                 String nameWithClassifier = matcher.group(BuildUtils.ARTIFACT_NAME_INDEX)
                 if (matcher.group(BuildUtils.ARTIFACT_CLASSIFIER_INDEX) != null)
                     nameWithClassifier += matcher.group(BuildUtils.ARTIFACT_CLASSIFIER_INDEX)
-                if (nameVersionMap.containsKey(nameWithClassifier) && !MULTIPLE_VERSIONS_ALLOWED.contains(nameWithClassifier))
+                if (nameVersionMap.containsKey(nameWithClassifier))
                 {
                     if (MULTIPLE_VERSIONS_ALLOWED.contains(nameWithClassifier))
                     {

--- a/src/main/groovy/org/labkey/gradle/task/CheckForVersionConflicts.groovy
+++ b/src/main/groovy/org/labkey/gradle/task/CheckForVersionConflicts.groovy
@@ -31,6 +31,9 @@ import java.util.regex.Matcher
  */
 class CheckForVersionConflicts  extends DefaultTask
 {
+    @Input
+    Set<String> MULTIPLE_VERSIONS_ALLOWED = Set.of("jackson-core", "jackson-databind")
+
     enum ConflictAction  {
         delete,
         fail,
@@ -87,10 +90,17 @@ class CheckForVersionConflicts  extends DefaultTask
                 String nameWithClassifier = matcher.group(BuildUtils.ARTIFACT_NAME_INDEX)
                 if (matcher.group(BuildUtils.ARTIFACT_CLASSIFIER_INDEX) != null)
                     nameWithClassifier += matcher.group(BuildUtils.ARTIFACT_CLASSIFIER_INDEX)
-                if (nameVersionMap.containsKey(nameWithClassifier))
+                if (nameVersionMap.containsKey(nameWithClassifier) && !MULTIPLE_VERSIONS_ALLOWED.contains(nameWithClassifier))
                 {
-                    haveMultiples = true
-                    conflictMessages += "Multiple existing ${matcher.group(BuildUtils.ARTIFACT_NAME_INDEX)} ${extension} files."
+                    if (MULTIPLE_VERSIONS_ALLOWED.contains(nameWithClassifier))
+                    {
+                        this.logger.info("Multiple exsiting versions of ${matcher.group(BuildUtils.ARTIFACT_NAME_INDEX)} ${extension} found, but deemed acceptable.")
+                    }
+                    else
+                    {
+                        haveMultiples = true
+                        conflictMessages += "Multiple existing ${matcher.group(BuildUtils.ARTIFACT_NAME_INDEX)} ${extension} files."
+                    }
                 }
                 else if (matcher.group(BuildUtils.ARTIFACT_VERSION_INDEX) != null)
                 {
@@ -120,8 +130,12 @@ class CheckForVersionConflicts  extends DefaultTask
                     String existingVersion = nameVersionMap.get(name).v1
                     if (existingVersion != version)
                     {
-                        existingFilesInConflict.add(nameVersionMap.get(name).v2)
-                        conflictMessages += "Conflicting version of ${matcher.group(BuildUtils.ARTIFACT_NAME_INDEX)} ${extension} file (${existingVersion} in directory vs. ${version} from build)."
+                        if (MULTIPLE_VERSIONS_ALLOWED.contains(name))
+                            this.logger.info("Multiple versions of ${matcher.group(BuildUtils.ARTIFACT_NAME_INDEX)} ${extension} file found, but deemed acceptable (${existingVersion} and ${version})")
+                        else {
+                            existingFilesInConflict.add(nameVersionMap.get(name).v2)
+                            conflictMessages += "Conflicting version of ${matcher.group(BuildUtils.ARTIFACT_NAME_INDEX)} ${extension} file (${existingVersion} in directory vs. ${version} from build)."
+                        }
                     }
                 }
             }


### PR DESCRIPTION
#### Rationale
Issue [851](https://github.com/LabKey/internal-issues/issues/851): We need to allow for two versions of jackson as transitive dependencies of different libraries

#### Changes
- Add some exclusion logic in `CheckForVersionConflicts` to allow multiple versions 
