### PR TITLE
Update to Gradle 9.6.0 and make minor adjustments for deprecated features

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ on how to do that, including how to develop and test locally and the versioning 
 
 ## Release Notes
 
-### TBD
-*Released*: TBD
+### 9.1.0
+*Released*: 23 June 2026
 (Earliest compatible LabKey version: 26.6.0)
 - Update `ModuleFinder.isModuleContainer` to use `hasProperty` instead of `findProperty` for better future compatibility
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ on how to do that, including how to develop and test locally and the versioning 
 
 ## Release Notes
 
+### TBD
+*Released*: TBD
+(Earliest compatible LabKey version: 26.6.0)
+- Update `ModuleFinder.isModuleContainer` to use `hasProperty` instead of `findProperty` for better future compatibility
+
 ### 9.0.0
 *Released*: 20 May 2026
 (Earliest compatible LabKey version: 26.6.0)

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
 }
 
 group = 'org.labkey.build'
-project.version = "9.1.0-gradle960-SNAPSHOT"
+project.version = "9.2.0-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
 }
 
 group = 'org.labkey.build'
-project.version = "9.1.0-SNAPSHOT"
+project.version = "9.1.0-gradle960-SNAPSHOT"
 
 gradlePlugin {
     plugins {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/src/main/groovy/org/labkey/gradle/util/ModuleFinder.groovy
+++ b/src/main/groovy/org/labkey/gradle/util/ModuleFinder.groovy
@@ -81,7 +81,7 @@ class ModuleFinder extends SimpleFileVisitor<Path>
 
     static boolean isModuleContainer(Project p)
     {
-        return (p.findProperty("moduleContainer") && p.path.equalsIgnoreCase((String) p.property("moduleContainer")))
+        return (p.hasProperty("moduleContainer") && p.path.equalsIgnoreCase((String) p.property("moduleContainer")))
     }
 
     static boolean isPotentialModule(Project p)


### PR DESCRIPTION
#### Rationale
[Gradle 9.6.0 ](https://docs.gradle.org/9.6.0/release-notes.html)is the latest and it comes with a [deprecation of certain patterns for getting properties](https://docs.gradle.org/9.6.0/release-notes.html#build-authoring-improvements)

#### Related Pull Requests
- https://github.com/LabKey/server/pull/1424

#### Changes
- Update `ModuleFinder.isModuleContainer` to use `hasProperty` instead of `findProperty` for better future compatibility
